### PR TITLE
[63] Hides search window when no results are present

### DIFF
--- a/src/tabs/crawler/CrawlerTab.tsx
+++ b/src/tabs/crawler/CrawlerTab.tsx
@@ -102,10 +102,12 @@ export function CrawlerTab() {
           </div>
         </div>
       ) : (
-        <ResultsList
-          setCompanyReports={setCompanyReports}
-          companyReports={companyReports}
-        />
+        companyReports && (
+          <ResultsList
+            setCompanyReports={setCompanyReports}
+            companyReports={companyReports}
+          />
+        )
       )}
     </div>
   );


### PR DESCRIPTION
This pull request makes a small change to the `CrawlerTab` component to ensure that the `ResultsList` is only rendered when `companyReports` is defined.

Closes #63 