### PR TITLE
[Change]: Swapped endpoints to point towards stage

### DIFF
--- a/src/tabs/crawler/lib/crawler-api.ts
+++ b/src/tabs/crawler/lib/crawler-api.ts
@@ -5,7 +5,7 @@ type SearchQuery = {
 
 export const fetchCompanyReports = async (searchQuery: SearchQuery) => {
   try {
-    const response = await fetch("http://localhost:3000/api/reports", {
+    const response = await fetch("https://stage.klimatkollen.se/api/reports/", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -28,7 +28,9 @@ export const fetchCompanyReports = async (searchQuery: SearchQuery) => {
 
 export const fetchCompanyNamesList = async () => {
   try {
-    const response = await fetch("http://localhost:3000/api/companies/names");
+    const response = await fetch(
+      "http://stage.klimatkollen.se/api/companies/names",
+    );
     if (response.ok) {
       const data = await response.json();
       return data;


### PR DESCRIPTION
This pull request updates the API endpoints used in the `crawler-api.ts` file to point to the staging server instead of the local development server. This ensures that the application fetches data from the correct environment for testing and staging purposes.
