### PR TITLE
[Change]: Modified company input to be on separate lines

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -447,7 +447,7 @@
     "databaseSearch": "Search in database",
     "databaseSearchGuard": "Select at least one company and a year from the existing database.",
     "databaseControlsDescription": "The search will return the reports for each selected company from the selected year that is in the database.",
-    "searchPlaceholder": "Search for companies (separate with commas)",
+    "searchPlaceholder": "Search for companies (one company per line)",
     "reportYear": "Report year",
     "reportYearPlaceholder": "E.g. 2025",
     "search": "Search",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -447,7 +447,7 @@
     "databaseSearch": "Sök i befintlig databas",
     "databaseSearchGuard": "Välj minst ett företag och ett år från företag i den befintliga databasen.",
     "databaseControlsDescription": "Sökningen returnerar rapporter för varje valt företag från det valda året som finns i databasen.",
-    "searchPlaceholder": "Sök efter företag (separera med kommatecken)",
+    "searchPlaceholder": "Sök efter företag (ett företag per rad)",
     "reportYear": "Rapportår",
     "reportYearPlaceholder": "T.ex. 2025",
     "search": "Sök",

--- a/src/tabs/crawler/CrawlerTab.tsx
+++ b/src/tabs/crawler/CrawlerTab.tsx
@@ -41,7 +41,7 @@ export function CrawlerTab() {
 
     setIsLoading(true);
     const companyNames = companyNameInput
-      .split(",")
+      .split(/\r?\n/)
       .map((name) => name.trim())
       .filter(Boolean);
 


### PR DESCRIPTION
The main change is that users should now enter one company per line instead of separating company names with commas. This affects both the input parsing logic and the placeholder text in English and Swedish.
