### PR TITLE
[Feat]: Added functionality to show thumbnails and previews for PDFS

### DIFF
--- a/src/tabs/crawler/CrawlerTab.tsx
+++ b/src/tabs/crawler/CrawlerTab.tsx
@@ -108,8 +108,6 @@ export function CrawlerTab() {
     ]);
   };
 
-  console.log("Selected Reports:", selectedReports);
-
   return (
     <div className="flex flex-col gap-6">
       <motion.div

--- a/src/tabs/crawler/components/SearchResultItem.tsx
+++ b/src/tabs/crawler/components/SearchResultItem.tsx
@@ -8,6 +8,9 @@ import {
 } from "lucide-react";
 import { CompanyReport } from "../lib/crawler-types";
 import { useI18n } from "@/contexts/I18nContext";
+import { generateReportPreviews } from "../lib/crawler-utils";
+import { LoadingSpinner } from "@/ui/loading-spinner";
+import ReactDOM from "react-dom";
 
 interface SearchResultItemProps {
   companyReport: CompanyReport;
@@ -23,7 +26,43 @@ const SearchResultItem = ({
 }: SearchResultItemProps) => {
   const { t } = useI18n();
   const { companyName, results } = companyReport;
+  const [resultsWithPreview, setResultsWithPreview] = useState<any[]>([]);
   const [isDialogOpen, setIsDialogOpen] = useState<boolean>(false);
+  const [previewOpenIndex, setPreviewOpenIndex] = useState<number | null>(null);
+  const [imgStatus, setImgStatus] = useState<
+    { loading: boolean; error: boolean }[]
+  >([]);
+
+  useEffect(() => {
+    if (previewOpenIndex === null) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setPreviewOpenIndex(null);
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [previewOpenIndex]);
+
+  const handlePreviewOpen = (index: number) => {
+    setPreviewOpenIndex(index);
+  };
+
+  const handlePreviewClose = () => {
+    setPreviewOpenIndex(null);
+  };
+
+  useEffect(() => {
+    if (results && results.length > 0) {
+      setResultsWithPreview(generateReportPreviews(results as Report[]));
+    }
+  }, [results]);
+
+  useEffect(() => {
+    if (resultsWithPreview.length > 0) {
+      setImgStatus(
+        Array(resultsWithPreview.length).fill({ loading: true, error: false }),
+      );
+    }
+  }, [resultsWithPreview.length]);
 
   const handleReportSelect = (url: string) => {
     if (selectedReport === url) {
@@ -62,24 +101,74 @@ const SearchResultItem = ({
         </div>
         <div className="bg-gray-04/80 backdrop-blur-sm rounded-[20px] overflow-hidden hover:shadow-md transition-shadow">
           {isDialogOpen &&
-            results.map((result, index) => (
+            resultsWithPreview.map((result, index) => (
               <div
                 key={`${result.url}-${index}`}
                 className="w-full px-4 py-3 border-b border-gray-03 flex items-center justify-between"
               >
-                <span className="text-sm text-gray-02 flex gap-2">
-                  {index + 1}.
-                  <a
-                    href={result.url as string}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="flex items-center text-gray-02 hover:text-blue-04"
-                  >
-                    {result?.url?.substring(0, 100) + "..."}
-
-                    <ExternalLink className="w-4 h-4 ml-2" />
-                  </a>
-                </span>
+                <div
+                  className="relative flex items-center gap-4"
+                  style={{ minWidth: 50, minHeight: 50 }}
+                >
+                  <div className="relative" style={{ width: 50, height: 50 }}>
+                    <img
+                      src={result.previewUrl}
+                      height={50}
+                      width={50}
+                      className="rounded shadow cursor-pointer"
+                      onClick={() => handlePreviewOpen(index)}
+                      alt="Preview"
+                      style={{
+                        visibility:
+                          imgStatus[index]?.loading || imgStatus[index]?.error
+                            ? "hidden"
+                            : "visible",
+                        transition: "visibility 0.2s",
+                        width: 50,
+                        height: 50,
+                        objectFit: "cover",
+                      }}
+                      onLoad={() => {
+                        setImgStatus((prev) => {
+                          const arr = [...prev];
+                          arr[index] = { loading: false, error: false };
+                          return arr;
+                        });
+                      }}
+                      onError={() => {
+                        setImgStatus((prev) => {
+                          const arr = [...prev];
+                          arr[index] = { loading: false, error: true };
+                          return arr;
+                        });
+                      }}
+                    />
+                    {imgStatus[index]?.loading && (
+                      <div className="absolute inset-0 flex items-center justify-center">
+                        <LoadingSpinner size={6} />
+                      </div>
+                    )}
+                    {imgStatus[index]?.error && (
+                      <div className="absolute inset-0 flex items-center justify-center">
+                        <span className="text-xs text-red-04">
+                          Image failed to load
+                        </span>
+                      </div>
+                    )}
+                  </div>
+                  <span className="text-sm text-gray-02 flex gap-2">
+                    {index + 1}.
+                    <a
+                      href={result.url as string}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="flex items-center text-gray-02 hover:text-blue-04"
+                    >
+                      {result?.url?.substring(0, 100) + "..."}
+                      <ExternalLink className="w-4 h-4 ml-2" />
+                    </a>
+                  </span>
+                </div>
                 <button
                   onClick={() => handleReportSelect(result.url as string)}
                 >
@@ -87,6 +176,34 @@ const SearchResultItem = ({
                     className={`${selectedReport === result.url ? "text-green-03" : "text-gray-02"} w-6 h-6`}
                   />
                 </button>
+                {/* Portal for preview image */}
+                {previewOpenIndex === index &&
+                  ReactDOM.createPortal(
+                    <div
+                      style={{
+                        position: "fixed",
+                        left: 0,
+                        top: 0,
+                        width: "100vw",
+                        height: "100vh",
+                        zIndex: 10000,
+                        background: "rgba(0,0,0,0.2)",
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                      }}
+                      onClick={handlePreviewClose}
+                    >
+                      <img
+                        src={result.previewUrl}
+                        className="max-h-[90vh] max-w-[90vw] rounded shadow-lg border border-gray-200 bg-white"
+                        alt="Full Preview"
+                        style={{ objectFit: "contain" }}
+                        onClick={(e) => e.stopPropagation()}
+                      />
+                    </div>,
+                    document.body,
+                  )}
               </div>
             ))}
         </div>

--- a/src/tabs/crawler/lib/crawler-api.ts
+++ b/src/tabs/crawler/lib/crawler-api.ts
@@ -6,7 +6,7 @@ type SearchQuery = {
   reportYear: string;
 };
 
-function reportsUrl(path: string): string {
+export function reportsUrl(path: string): string {
   const base = getGarboApiBaseUrl();
   const segment = path.replace(/^\//, "").replace(/\/+$/, "");
   const url = segment ? `${base}/${segment}` : base;

--- a/src/tabs/crawler/lib/crawler-utils.ts
+++ b/src/tabs/crawler/lib/crawler-utils.ts
@@ -1,11 +1,29 @@
 import type { CompanyReport, LockedReport } from "./crawler-types";
 import { updateCompanyReports } from "./crawler-api";
+import { reportsUrl } from "./crawler-api";
+
+export interface ReportWithPreview extends Report {
+  previewUrl: string;
+}
 
 interface SearchCompanyReportsParams {
   companyNames: string[];
   reportYear: string;
 }
 
+export const generateReportPreviews = (
+  results: Report[],
+): ReportWithPreview[] => {
+  return results.map((result) => {
+    const previewUrl = result.url ? generateReportPreview(result.url) : "";
+    return { ...result, previewUrl };
+  });
+};
+
+/**
+ * Fetches company reports for given names and year.
+ * Returns an array of CompanyReport objects.
+ */
 export const searchCompanyReports = async ({
   companyNames,
   reportYear,
@@ -14,25 +32,29 @@ export const searchCompanyReports = async ({
     return [];
   }
 
-  const searchQueries = companyNames.map((name) => ({
-    name,
-    reportYear,
-  }));
+  const searchQueries: { name: string; reportYear: string }[] =
+    companyNames.map((name) => ({
+      name,
+      reportYear,
+    }));
 
-  const data = await Promise.all(
+  const data: CompanyReport[][] = await Promise.all(
     searchQueries.map((query) => updateCompanyReports(query)),
   );
 
-  return data.flatMap((response) =>
-    response.results.map((item: CompanyReport) => ({
-      companyName: item.companyName || "Unknown",
-      reportYear: item.reportYear || "Unknown",
-      results: item.results ?? [],
-    })),
-  );
+  return data.flat().map((item) => ({
+    companyName: item.companyName || "Unknown",
+    reportYear: item.reportYear || "Unknown",
+    results: item.results ?? [],
+  }));
 };
 
-export const writeCrawledReportsToCsv = (companyReports: LockedReport[]) => {
+/**
+ * Writes crawled reports to CSV file and triggers download.
+ */
+export const writeCrawledReportsToCsv = (
+  companyReports: LockedReport[],
+): void => {
   const escapeCsvValue = (value: string) => {
     const escaped = value.replace(/"/g, '""');
     return `"${escaped}"`;
@@ -56,4 +78,17 @@ export const writeCrawledReportsToCsv = (companyReports: LockedReport[]) => {
   document.body.appendChild(link);
   link.click();
   document.body.removeChild(link);
+};
+
+/**
+ * Returns the direct preview image URL for a report.
+ */
+export const generateReportPreview = (reportUrl: string): string => {
+  if (!reportUrl) return "";
+
+  const url =
+    reportsUrl("reports/preview?pdfUrl=") + encodeURIComponent(reportUrl);
+
+  // Use relative path for FE/BE compatibility
+  return url;
 };


### PR DESCRIPTION
This pull request introduces a new feature for generating and displaying preview images for company reports in the crawler tab. The main changes involve creating utilities to generate preview URLs, updating the UI to show preview thumbnails with loading/error states, and allowing users to view larger previews in a modal. Additionally, some utility functions were refactored and exported for broader use. Calls new BE endpoints introduced in the PR below.

Awaiting and dependent on BE PR -> https://github.com/Klimatbyran/garbo/pull/1129