### PR TITLE
[114]: Added logic to reset searchresults and selections on searches

### DIFF
--- a/src/tabs/crawler/CrawlerTab.tsx
+++ b/src/tabs/crawler/CrawlerTab.tsx
@@ -49,9 +49,22 @@ export function CrawlerTab() {
     { value: "database" as const, label: t("crawler.databaseMode") },
   ];
 
+  const resetSearchSlate = ({
+    clearCompanySelection = false,
+  }: { clearCompanySelection?: boolean } = {}) => {
+    setSelectedReports([]);
+    setManualReports(null);
+    setDatabaseReports(null);
+
+    if (clearCompanySelection) {
+      setSelectedCompanies([]);
+    }
+  };
+
   const handleManualSearchClick = async () => {
     if (!companyNameInput || !reportYearInput) return;
 
+    resetSearchSlate();
     setIsLoading(true);
     const companyNames = companyNameInput
       .split(/\r?\n/)
@@ -91,6 +104,7 @@ export function CrawlerTab() {
       const response = await saveToWaitingRoom(selectedReports);
       if (response) {
         setWaitingRoomResponse(response);
+        resetSearchSlate({ clearCompanySelection: true });
       }
     } catch (error) {
       const errorMessage =
@@ -112,6 +126,7 @@ export function CrawlerTab() {
     if (!selectedReports || !selectedReports.length) return;
 
     writeCrawledReportsToCsv(selectedReports);
+    resetSearchSlate({ clearCompanySelection: true });
   };
 
   const handleSearchInputChange = (
@@ -129,11 +144,13 @@ export function CrawlerTab() {
   const handleDatabaseSearchClick = async () => {
     if (!selectedCompanies.length || !reportYearInput) return;
 
+    const companyNames = selectedCompanies;
+    resetSearchSlate();
     setIsLoading(true);
 
     try {
       const transformedData = await searchCompanyReports({
-        companyNames: selectedCompanies,
+        companyNames,
         reportYear: reportYearInput,
       });
 


### PR DESCRIPTION
This pull request introduces improvements to the `CrawlerTab` component, focusing on better state management and user experience during search and export operations. The main change is the addition of a `resetSearchSlate` function, which centralizes and streamlines the clearing of search-related state, and is now invoked at key points in the workflow.

State management enhancements:

* Added the `resetSearchSlate` function to clear report selections, manual and database reports, and optionally company selections; this function is now used throughout the component to ensure consistent state resets. 

User experience improvements:

* After saving reports to the waiting room or exporting to CSV, `resetSearchSlate` is called with `clearCompanySelection: true` to fully reset the selection state, preventing leftover selections from affecting subsequent actions.

Closes #114 