### PR TITLE
[143] Add search to multi company view

### DIFF
--- a/src/tabs/editor/components/MultiCompanyFilters.tsx
+++ b/src/tabs/editor/components/MultiCompanyFilters.tsx
@@ -1,12 +1,16 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { useI18n } from "@/contexts/I18nContext";
 import { Button } from "@/ui/button";
 import { MultiSelectDropdown } from "@/ui/multi-select-dropdown";
 import { SingleSelectDropdown } from "@/ui/single-select-dropdown";
+import { inputClassName } from "../lib/company-edit-utils";
 import { buildTagLabelBySlug } from "../lib/editor-tag-and-payload-utils";
 import { NO_TAGS_FILTER_OPTION, type TagOption } from "../lib/types";
+import { SearchAndFiltersCard } from "@/ui/search-and-filters-card";
 
 export function MultiCompanyFilters({
+  searchQuery,
+  onSearchQueryChange,
   years,
   selectedYear,
   onYearChange,
@@ -16,6 +20,8 @@ export function MultiCompanyFilters({
   onRefresh,
   refreshDisabled,
 }: {
+  searchQuery: string;
+  onSearchQueryChange: (query: string) => void;
   years: string[];
   selectedYear: string;
   onYearChange: (year: string) => void;
@@ -27,39 +33,72 @@ export function MultiCompanyFilters({
 }) {
   const { t } = useI18n();
   const tagLabelBySlug = useMemo(() => buildTagLabelBySlug(tagOptions), [tagOptions]);
+  const [filtersOpen, setFiltersOpen] = useState(true);
 
   return (
-    <div className="flex flex-wrap items-center gap-3">
-      <span className="text-sm text-gray-02">{t("editor.companies.filters")}</span>
-      <SingleSelectDropdown
-        options={["", ...years]}
-        value={selectedYear}
-        onChange={onYearChange}
-        placeholder={t("editor.companies.allYears")}
-        getOptionLabel={(optionValue) => (optionValue ? optionValue : t("editor.companies.allYears"))}
-        triggerClassName="min-w-[120px]"
-      />
-      <MultiSelectDropdown
-        options={[NO_TAGS_FILTER_OPTION, ...tagOptions.map((o) => o.slug)]}
-        selectedIds={selectedTags}
-        onChange={onTagsChange}
-        triggerLabel={t("editor.companies.tag")}
-        getOptionLabel={(optionValue) => {
-          if (optionValue === NO_TAGS_FILTER_OPTION) return t("editor.companies.noTags");
-          return tagLabelBySlug[optionValue] ?? optionValue;
-        }}
-        emptyLabel={t("editor.companies.allTags")}
-        triggerClassName="min-w-[140px]"
-      />
-      <Button
-        variant="secondary"
-        size="sm"
-        onClick={onRefresh}
-        disabled={refreshDisabled}
-      >
-        {t("common.refresh")}
-      </Button>
-    </div>
+    <SearchAndFiltersCard
+      title={t("editor.singleCompanyView.searchAndFilters")}
+      open={filtersOpen}
+      onOpenChange={setFiltersOpen}
+    >
+      <div>
+        <label className="block text-xs font-medium text-gray-02 mb-1">
+          {t("editor.singleCompanyView.searchByNameOrId")}
+        </label>
+        <input
+          type="text"
+          value={searchQuery}
+          onChange={(e) => onSearchQueryChange(e.target.value)}
+          placeholder={t("editor.singleCompanyView.searchPlaceholder")}
+          className={inputClassName}
+        />
+      </div>
+
+      <div className="flex flex-wrap gap-4 items-end">
+        <div>
+          <label className="block text-xs font-medium text-gray-02 mb-1">
+            {t("editor.companies.tag")}
+          </label>
+          <MultiSelectDropdown
+            options={[NO_TAGS_FILTER_OPTION, ...tagOptions.map((o) => o.slug)]}
+            selectedIds={selectedTags}
+            onChange={onTagsChange}
+            triggerLabel={t("editor.companies.tags")}
+            getOptionLabel={(optionValue) => {
+              if (optionValue === NO_TAGS_FILTER_OPTION) return t("editor.companies.noTags");
+              return tagLabelBySlug[optionValue] ?? optionValue;
+            }}
+            emptyLabel={t("editor.companies.allTags")}
+            triggerClassName="min-w-[140px]"
+          />
+        </div>
+
+        <div>
+          <label className="block text-xs font-medium text-gray-02 mb-1">
+            {t("editor.companies.year")}
+          </label>
+          <SingleSelectDropdown
+            options={["", ...years]}
+            value={selectedYear}
+            onChange={onYearChange}
+            placeholder={t("editor.companies.allYears")}
+            getOptionLabel={(optionValue) =>
+              optionValue ? optionValue : t("editor.companies.allYears")
+            }
+            triggerClassName="min-w-[120px]"
+          />
+        </div>
+
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={onRefresh}
+          disabled={refreshDisabled}
+        >
+          {t("common.refresh")}
+        </Button>
+      </div>
+    </SearchAndFiltersCard>
   );
 }
 

--- a/src/tabs/editor/components/MultiCompanyView.tsx
+++ b/src/tabs/editor/components/MultiCompanyView.tsx
@@ -20,12 +20,21 @@ import {
   parseTagSlugs,
 } from "../lib/editor-tag-and-payload-utils";
 
+function companyMatchesSearch(company: GarboCompanyListItem, query: string): boolean {
+  const q = query.trim().toLowerCase();
+  if (!q) return true;
+  const name = (company.name ?? "").toLowerCase();
+  const id = (company.wikidataId ?? "").toLowerCase();
+  return name.includes(q) || id.includes(q);
+}
+
 export function MultiCompanyView() {
   const { t } = useI18n();
   const [companies, setCompanies] = useState<GarboCompanyListItem[]>([]);
   const [tagOptions, setTagOptions] = useState<TagOption[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
   const [selectedYear, setSelectedYear] = useState<string>("");
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [actionLoading, setActionLoading] = useState(false);
@@ -71,6 +80,9 @@ export function MultiCompanyView() {
 
   const filteredCompanies = useMemo(() => {
     let filteredList = companies;
+    if (searchQuery.trim()) {
+      filteredList = filteredList.filter((company) => companyMatchesSearch(company, searchQuery));
+    }
     if (selectedTags.length) {
       // API returns company.tags as string[] of slugs; filter shows companies that have any selected tag
       filteredList = filteredList.filter((company) =>
@@ -84,7 +96,7 @@ export function MultiCompanyView() {
       );
     }
     return filteredList;
-  }, [companies, selectedYear, selectedTags]);
+  }, [companies, searchQuery, selectedYear, selectedTags]);
 
   const toggleCompanySelection = useCallback((wikidataId: string) => {
     setSelectedWikidataIds((prev) => {
@@ -242,6 +254,8 @@ export function MultiCompanyView() {
   return (
     <div className="space-y-4">
       <MultiCompanyFilters
+        searchQuery={searchQuery}
+        onSearchQueryChange={setSearchQuery}
         years={years}
         selectedYear={selectedYear}
         onYearChange={setSelectedYear}

--- a/src/tabs/editor/components/SingleCompanyView.tsx
+++ b/src/tabs/editor/components/SingleCompanyView.tsx
@@ -3,10 +3,7 @@ import {
   AlertCircle,
   ArrowLeft,
   CheckCircle2,
-  ChevronDown,
-  ChevronRight,
   Minus,
-  Search,
 } from "lucide-react";
 import { useI18n } from "@/contexts/I18nContext";
 import { Button } from "@/ui/button";
@@ -26,6 +23,7 @@ import { CompanyEditDetail } from "./CompanyEditDetail";
 import { DataTable, DataTableBody, DataTableHead, DataTableShell } from "@/ui/data-table";
 import { NO_TAGS_FILTER_OPTION } from "../lib/types";
 import { buildTagLabelBySlug, companyMatchesTagFilter } from "../lib/editor-tag-and-payload-utils";
+import { SearchAndFiltersCard } from "@/ui/search-and-filters-card";
 
 function getPeriodYear(period: { startDate?: string; endDate?: string }): string | null {
   const y = period.endDate?.slice(0, 4) ?? period.startDate?.slice(0, 4);
@@ -234,128 +232,116 @@ export function SingleCompanyView() {
 
   return (
     <div className="space-y-4">
-      <div className="bg-gray-04/80 backdrop-blur-sm rounded-lg border border-gray-03 p-4 flex flex-col gap-4">
-        <details
-          open={filtersOpen}
-          onToggle={(e) => setFiltersOpen((e.target as HTMLDetailsElement).open)}
-          className="group"
-        >
-          <summary className="flex items-center gap-2 px-0 py-1 cursor-pointer list-none text-gray-01 font-medium hover:text-gray-02 select-none">
-            {filtersOpen ? (
-              <ChevronDown className="w-4 h-4 text-gray-02" />
-            ) : (
-              <ChevronRight className="w-4 h-4 text-gray-02" />
+      <SearchAndFiltersCard
+        title={t("editor.singleCompanyView.searchAndFilters")}
+        open={filtersOpen}
+        onOpenChange={setFiltersOpen}
+        after={
+          <>
+            {error && !loadingList && (
+              <div className="rounded-lg border border-gray-03 bg-gray-05/80 p-4">
+                <p className="text-gray-01 font-medium">
+                  {t("editor.singleCompanyView.loadError")}
+                </p>
+                <p className="text-sm text-gray-02 mt-1">{error}</p>
+              </div>
             )}
-            <Search className="w-4 h-4 text-gray-02" />
-            {t("editor.singleCompanyView.searchAndFilters")}
-          </summary>
-          <div className="pt-4 space-y-4 border-t border-gray-03/50 mt-2">
+
+            {loadingList && (
+              <div className="flex justify-center py-12">
+                <LoadingSpinner label={t("editor.companies.loading")} />
+              </div>
+            )}
+
+            {!loadingList && filteredCompanies.length === 0 && (
+              <div className="py-8 text-center text-gray-02 text-sm">
+                {t("editor.singleCompanyView.noCompaniesMatch")}
+              </div>
+            )}
+          </>
+        }
+      >
+        <div>
+          <label className="block text-xs font-medium text-gray-02 mb-1">
+            {t("editor.singleCompanyView.searchByNameOrId")}
+          </label>
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder={t("editor.singleCompanyView.searchPlaceholder")}
+            className="w-full max-w-md px-3 py-2 rounded-lg border border-gray-03 bg-gray-05 text-gray-01 placeholder:text-gray-03 focus:outline-none focus:ring-2 focus:ring-blue-03"
+          />
+        </div>
+        <div className="flex flex-wrap gap-4">
+          <div>
+            <label className="block text-xs font-medium text-gray-02 mb-1">
+              {t("editor.companies.tag")}
+            </label>
+            <MultiSelectDropdown
+              options={[NO_TAGS_FILTER_OPTION, ...tagOptions.map((o) => o.slug)]}
+              selectedIds={filterTags}
+              onChange={setFilterTags}
+              triggerLabel={t("editor.companies.tags")}
+              getOptionLabel={(slug) =>
+                slug === NO_TAGS_FILTER_OPTION
+                  ? t("editor.companies.noTags")
+                  : (tagLabelBySlug[slug] ?? slug)
+              }
+              emptyLabel={t("editor.companies.allTags")}
+              triggerClassName="min-w-[140px]"
+            />
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-gray-02 mb-1">
+              {t("editor.companies.year")}
+            </label>
+            <MultiSelectDropdown
+              options={years}
+              selectedIds={filterYears}
+              onChange={setFilterYears}
+              triggerLabel={t("editor.companies.year")}
+              emptyLabel={t("editor.companies.allYears")}
+              triggerClassName="min-w-[120px]"
+            />
+          </div>
+          {sectors.length > 0 && (
             <div>
               <label className="block text-xs font-medium text-gray-02 mb-1">
-                {t("editor.singleCompanyView.searchByNameOrId")}
+                {t("editor.singleCompanyView.sector")}
               </label>
-              <input
-                type="text"
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                placeholder={t("editor.singleCompanyView.searchPlaceholder")}
-                className="w-full max-w-md px-3 py-2 rounded-lg border border-gray-03 bg-gray-05 text-gray-01 placeholder:text-gray-03 focus:outline-none focus:ring-2 focus:ring-blue-03"
+              <SingleSelectDropdown
+                options={["", ...sectors]}
+                value={filterSector}
+                onChange={setFilterSector}
+                placeholder={t("editor.singleCompanyView.allSectors")}
+                getOptionLabel={(v) => (v ? v : t("editor.singleCompanyView.allSectors"))}
+                triggerClassName="min-w-[140px]"
               />
             </div>
-            <div className="flex flex-wrap gap-4">
-              <div>
-                <label className="block text-xs font-medium text-gray-02 mb-1">
-                  {t("editor.companies.tag")}
-                </label>
-                <MultiSelectDropdown
-                  options={[NO_TAGS_FILTER_OPTION, ...tagOptions.map((o) => o.slug)]}
-                  selectedIds={filterTags}
-                  onChange={setFilterTags}
-                  triggerLabel={t("editor.companies.tags")}
-                  getOptionLabel={(slug) =>
-                    slug === NO_TAGS_FILTER_OPTION
-                      ? t("editor.companies.noTags")
-                      : (tagLabelBySlug[slug] ?? slug)
-                  }
-                  emptyLabel={t("editor.companies.allTags")}
-                  triggerClassName="min-w-[140px]"
-                />
-              </div>
-              <div>
-                <label className="block text-xs font-medium text-gray-02 mb-1">
-                  {t("editor.companies.year")}
-                </label>
-                <MultiSelectDropdown
-                  options={years}
-                  selectedIds={filterYears}
-                  onChange={setFilterYears}
-                  triggerLabel={t("editor.companies.year")}
-                  emptyLabel={t("editor.companies.allYears")}
-                  triggerClassName="min-w-[120px]"
-                />
-              </div>
-              {sectors.length > 0 && (
-                <div>
-                  <label className="block text-xs font-medium text-gray-02 mb-1">
-                    {t("editor.singleCompanyView.sector")}
-                  </label>
-                  <SingleSelectDropdown
-                    options={["", ...sectors]}
-                    value={filterSector}
-                    onChange={setFilterSector}
-                    placeholder={t("editor.singleCompanyView.allSectors")}
-                    getOptionLabel={(v) =>
-                      v ? v : t("editor.singleCompanyView.allSectors")
-                    }
-                    triggerClassName="min-w-[140px]"
-                  />
-                </div>
-              )}
-              <div className="flex flex-wrap items-end gap-4">
-                <label className="flex items-center gap-2 cursor-pointer text-gray-01 text-sm">
-                  <input
-                    type="checkbox"
-                    checked={filterHasUnverifiedEmissions}
-                    onChange={(e) => setFilterHasUnverifiedEmissions(e.target.checked)}
-                    className="rounded border-gray-03"
-                  />
-                  {t("editor.singleCompanyView.filterHasUnverifiedEmissions")}
-                </label>
-                <label className="flex items-center gap-2 cursor-pointer text-gray-01 text-sm">
-                  <input
-                    type="checkbox"
-                    checked={filterHasUnverifiedData}
-                    onChange={(e) => setFilterHasUnverifiedData(e.target.checked)}
-                    className="rounded border-gray-03"
-                  />
-                  {t("editor.singleCompanyView.filterHasUnverifiedData")}
-                </label>
-              </div>
-            </div>
+          )}
+          <div className="flex flex-wrap items-end gap-4">
+            <label className="flex items-center gap-2 cursor-pointer text-gray-01 text-sm">
+              <input
+                type="checkbox"
+                checked={filterHasUnverifiedEmissions}
+                onChange={(e) => setFilterHasUnverifiedEmissions(e.target.checked)}
+                className="rounded border-gray-03"
+              />
+              {t("editor.singleCompanyView.filterHasUnverifiedEmissions")}
+            </label>
+            <label className="flex items-center gap-2 cursor-pointer text-gray-01 text-sm">
+              <input
+                type="checkbox"
+                checked={filterHasUnverifiedData}
+                onChange={(e) => setFilterHasUnverifiedData(e.target.checked)}
+                className="rounded border-gray-03"
+              />
+              {t("editor.singleCompanyView.filterHasUnverifiedData")}
+            </label>
           </div>
-        </details>
-
-        {error && !loadingList && (
-          <div className="rounded-lg border border-gray-03 bg-gray-05/80 p-4">
-            <p className="text-gray-01 font-medium">
-              {t("editor.singleCompanyView.loadError")}
-            </p>
-            <p className="text-sm text-gray-02 mt-1">{error}</p>
-          </div>
-        )}
-
-        {loadingList && (
-          <div className="flex justify-center py-12">
-            <LoadingSpinner label={t("editor.companies.loading")} />
-          </div>
-        )}
-
-        {!loadingList && filteredCompanies.length === 0 && (
-          <div className="py-8 text-center text-gray-02 text-sm">
-            {t("editor.singleCompanyView.noCompaniesMatch")}
-          </div>
-        )}
-      </div>
+        </div>
+      </SearchAndFiltersCard>
 
       {!loadingList && filteredCompanies.length > 0 && (
         <DataTableShell>

--- a/src/tabs/jobbstatus/components/FilterBar.tsx
+++ b/src/tabs/jobbstatus/components/FilterBar.tsx
@@ -17,6 +17,7 @@ import {
 } from "lucide-react";
 import { useI18n } from "@/contexts/I18nContext";
 import { Button } from "@/ui/button";
+import { SearchAndFiltersCard } from "@/ui/search-and-filters-card";
 import type {
   FilterType,
   RunScope,
@@ -80,6 +81,7 @@ export function FilterBar({
   isRefreshing = false,
 }: FilterBarProps) {
   const { t } = useI18n();
+  const [filtersOpen, setFiltersOpen] = useState(true);
   const hasActiveFiltersOrSearch =
     activeFilters.size > 0 ||
     selectedBatchIds.length > 0 ||
@@ -116,7 +118,12 @@ export function FilterBar({
   }, [showMoreFilters]);
 
   return (
-    <div className="bg-gray-04/50 rounded-lg p-4 border border-gray-03">
+    <SearchAndFiltersCard
+      title={t("jobstatus.filter")}
+      icon={<Filter className="w-4 h-4 text-gray-02" />}
+      open={filtersOpen}
+      onOpenChange={setFiltersOpen}
+    >
       <div className="flex flex-col gap-4">
         {/* Company search and Omfattning (scope) */}
         <div className="flex flex-col sm:flex-row sm:items-center gap-3">
@@ -323,6 +330,6 @@ export function FilterBar({
 
         <FilterBarRerunSection onRerunByWorker={onRerunByWorker} />
       </div>
-    </div>
+    </SearchAndFiltersCard>
   );
 }

--- a/src/ui/search-and-filters-card.tsx
+++ b/src/ui/search-and-filters-card.tsx
@@ -1,0 +1,43 @@
+import type { ReactNode } from "react";
+import { ChevronDown, ChevronRight, Search } from "lucide-react";
+
+export function SearchAndFiltersCard({
+  title,
+  icon,
+  open,
+  onOpenChange,
+  children,
+  after,
+}: {
+  title: ReactNode;
+  icon?: ReactNode;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  children: ReactNode;
+  after?: ReactNode;
+}) {
+  return (
+    <div className="bg-gray-04/50 rounded-lg p-4 border border-gray-03 flex flex-col gap-4">
+      <details
+        open={open}
+        onToggle={(e) => onOpenChange((e.target as HTMLDetailsElement).open)}
+        className="group"
+      >
+        <summary className="flex items-center gap-2 px-0 py-1 cursor-pointer list-none text-gray-01 font-medium hover:text-gray-02 select-none">
+          {open ? (
+            <ChevronDown className="w-4 h-4 text-gray-02" />
+          ) : (
+            <ChevronRight className="w-4 h-4 text-gray-02" />
+          )}
+          {icon ?? <Search className="w-4 h-4 text-gray-02" />}
+          {title}
+        </summary>
+
+        <div className="pt-4 space-y-4 border-t border-gray-03/50 mt-2">{children}</div>
+      </details>
+
+      {after}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- Added **company search** to the Editor **Multi-company** view (filter by name or Wikidata ID).
- Unified Editor filter styling by extracting a shared, collapsible wrapper (`SearchAndFiltersCard`) and using it in both **Single-company** and **Multi-company** views.
- Updated Job Status filter bar to use the same **collapsible filter container** for consistent UI behavior across tabs.