### PR TITLE
[FIX] url display jobstatus

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -515,6 +515,7 @@
       "tabTechnical": "Technical details",
       "reportLink": "Report",
       "reportLabel": "Report",
+      "cachedPdfUrl": "Stored PDF URL",
       "wikidataLink": "Wikidata",
       "tryAgain": "Try again",
       "reject": "Reject",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -515,6 +515,7 @@
       "tabTechnical": "Tekniska detaljer",
       "reportLink": "Rapport",
       "reportLabel": "Rapport",
+      "cachedPdfUrl": "Lagrad PDF-URL",
       "wikidataLink": "Wikidata",
       "tryAgain": "Försök igen",
       "reject": "Avvisa",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -69,6 +69,8 @@ export const JobDataSchema = z
     status: z.string().optional(),
     needsApproval: z.boolean().optional(),
     comment: z.string().optional(),
+    /** Original report URL when `data.url` points at a cached copy (e.g. S3). Set by pipeline-api when cachePdf is used. */
+    sourceUrl: z.string().optional(),
   })
   .passthrough();
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 
-// Base schemas
 export const CountsSchema = z.object({
   active: z.number(),
   completed: z.number(),
@@ -69,7 +68,6 @@ export const JobDataSchema = z
     status: z.string().optional(),
     needsApproval: z.boolean().optional(),
     comment: z.string().optional(),
-    /** Original report URL when `data.url` points at a cached copy (e.g. S3). Set by pipeline-api when cachePdf is used. */
     sourceUrl: z.string().optional(),
   })
   .passthrough();

--- a/src/tabs/jobbstatus/components/job-details/DialogTabs.tsx
+++ b/src/tabs/jobbstatus/components/job-details/DialogTabs.tsx
@@ -11,9 +11,21 @@ interface DialogTabsProps {
   job: QueueJob;
 }
 
+function primaryReportHref(job: QueueJob): string | undefined {
+  const url = job.data?.url?.trim();
+  const sourceRaw = job.data?.sourceUrl;
+  const source =
+    typeof sourceRaw === "string" ? sourceRaw.trim() : sourceRaw != null ? String(sourceRaw).trim() : "";
+  if (source && /^https?:\/\//i.test(source)) return source;
+  if (url) return url;
+  if (source) return source;
+  return undefined;
+}
+
 export function DialogTabs({ activeTab, setActiveTab, job }: DialogTabsProps) {
   const { t } = useI18n();
   const wikidataInfo = getWikidataInfo(job);
+  const reportHref = primaryReportHref(job);
 
   return (
     <div className="flex flex-wrap items-center gap-2 mb-6">
@@ -29,10 +41,10 @@ export function DialogTabs({ activeTab, setActiveTab, job }: DialogTabsProps) {
           </TabsTrigger>
         </TabsList>
       </Tabs>
-      {job.data.url && (
+      {reportHref && /^https?:\/\//i.test(reportHref) && (
         <Button variant="ghost" size="sm" asChild className="rounded-full">
           <a
-            href={job.data.url}
+            href={reportHref}
             target="_blank"
             rel="noopener noreferrer"
             className="flex items-center"

--- a/src/tabs/jobbstatus/components/job-details/JobDetailsDialog.tsx
+++ b/src/tabs/jobbstatus/components/job-details/JobDetailsDialog.tsx
@@ -331,7 +331,7 @@ export function JobDetailsDialog({
           <DialogTabs
             activeTab={activeTab}
             setActiveTab={setActiveTab}
-            job={job}
+            job={effectiveJob ?? job}
           />
 
           <div className="space-y-6 my-6">
@@ -382,7 +382,7 @@ export function JobDetailsDialog({
         <DialogTabs
           activeTab={activeTab}
           setActiveTab={setActiveTab}
-          job={job}
+          job={effectiveJob ?? job}
         />
 
         <div className="space-y-6 my-6">

--- a/src/tabs/jobbstatus/components/job-details/JobSpecificDataView.tsx
+++ b/src/tabs/jobbstatus/components/job-details/JobSpecificDataView.tsx
@@ -209,7 +209,6 @@ export function JobSpecificDataView({ data, job }: JobSpecificDataViewProps) {
     return urlString.trim() || undefined;
   }, [effectiveJob, job, processedData]);
 
-  /** Original publisher URL when the job was enqueued with PDF caching (`data.url` is the cached copy). */
   const sourceReportUrl: string | undefined = React.useMemo(() => {
     const raw =
       effectiveJob?.data?.sourceUrl ??

--- a/src/tabs/jobbstatus/components/job-details/JobSpecificDataView.tsx
+++ b/src/tabs/jobbstatus/components/job-details/JobSpecificDataView.tsx
@@ -29,6 +29,35 @@ interface JobSpecificDataViewProps {
   job?: QueueJob;
 }
 
+function isHttpReportUrl(s: string) {
+  return /^https?:\/\//i.test(s.trim());
+}
+
+function JobReportUrlRow({ title, url }: { title: string; url: string }) {
+  const { t } = useI18n();
+  return (
+    <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+      <div className="min-w-0">
+        <h4 className="text-base font-medium text-gray-01">{title}</h4>
+        <p className="text-sm text-gray-02 break-all">{url}</p>
+      </div>
+      {isHttpReportUrl(url) ? (
+        <Button variant="ghost" size="sm" asChild className="shrink-0 self-start sm:self-center">
+          <a
+            href={url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center text-blue-03 hover:text-blue-04"
+          >
+            <ExternalLink className="w-4 h-4 mr-2" />
+            {t("editor.periodEditor.openReport")}
+          </a>
+        </Button>
+      ) : null}
+    </div>
+  );
+}
+
 export function JobSpecificDataView({ data, job }: JobSpecificDataViewProps) {
   const { t } = useI18n();
   const [detailed, setDetailed] = React.useState<any | null>(null);
@@ -167,8 +196,6 @@ export function JobSpecificDataView({ data, job }: JobSpecificDataViewProps) {
     return trimmed.length > 0 ? trimmed : undefined;
   }, [effectiveJob, processedData, wikidataApprovalData]);
 
-  const isHttpUrl = (s: string) => /^https?:\/\//i.test(s.trim());
-
   // Pipeline job URL (often S3 public URL when PDF caching was used)
   const storedPdfUrl: string | undefined = React.useMemo(() => {
     const url =
@@ -264,77 +291,22 @@ export function JobSpecificDataView({ data, job }: JobSpecificDataViewProps) {
                 <FileText className="w-5 h-5 text-blue-03" />
               </div>
               <div className="min-w-0 flex-1 space-y-4">
-                {showBothUrls && sourceReportUrl && (
-                  <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-                    <div className="min-w-0">
-                      <h4 className="text-base font-medium text-gray-01">
-                        {t("registry.sourceUrl")}
-                      </h4>
-                      <p className="text-sm text-gray-02 break-all">{sourceReportUrl}</p>
-                    </div>
-                    {isHttpUrl(sourceReportUrl) ? (
-                      <Button variant="ghost" size="sm" asChild className="shrink-0 self-start sm:self-center">
-                        <a
-                          href={sourceReportUrl}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="flex items-center text-blue-03 hover:text-blue-04"
-                        >
-                          <ExternalLink className="w-4 h-4 mr-2" />
-                          {t("editor.periodEditor.openReport")}
-                        </a>
-                      </Button>
-                    ) : null}
-                  </div>
-                )}
-                {storedPdfUrl && (
-                  <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-                    <div className="min-w-0">
-                      <h4 className="text-base font-medium text-gray-01">
-                        {showBothUrls
-                          ? t("jobstatus.jobdetails.cachedPdfUrl")
-                          : t("jobstatus.jobdetails.reportLabel")}
-                      </h4>
-                      <p className="text-sm text-gray-02 break-all">{storedPdfUrl}</p>
-                    </div>
-                    {isHttpUrl(storedPdfUrl) ? (
-                      <Button variant="ghost" size="sm" asChild className="shrink-0 self-start sm:self-center">
-                        <a
-                          href={storedPdfUrl}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="flex items-center text-blue-03 hover:text-blue-04"
-                        >
-                          <ExternalLink className="w-4 h-4 mr-2" />
-                          {t("editor.periodEditor.openReport")}
-                        </a>
-                      </Button>
-                    ) : null}
-                  </div>
-                )}
-                {!storedPdfUrl && sourceReportUrl && (
-                  <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-                    <div className="min-w-0">
-                      <h4 className="text-base font-medium text-gray-01">
-                        {t("jobstatus.jobdetails.reportLabel")}
-                      </h4>
-                      <p className="text-sm text-gray-02 break-all">{sourceReportUrl}</p>
-                    </div>
-                    {isHttpUrl(sourceReportUrl) ? (
-                      <Button variant="ghost" size="sm" asChild className="shrink-0 self-start sm:self-center">
-                        <a
-                          href={sourceReportUrl}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="flex items-center text-blue-03 hover:text-blue-04"
-                        >
-                          <ExternalLink className="w-4 h-4 mr-2" />
-                          {t("editor.periodEditor.openReport")}
-                        </a>
-                      </Button>
-                    ) : null}
-                  </div>
-                )}
+                {showBothUrls && sourceReportUrl ? (
+                  <JobReportUrlRow title={t("registry.sourceUrl")} url={sourceReportUrl} />
+                ) : null}
+                {storedPdfUrl ? (
+                  <JobReportUrlRow
+                    title={
+                      showBothUrls
+                        ? t("jobstatus.jobdetails.cachedPdfUrl")
+                        : t("jobstatus.jobdetails.reportLabel")
+                    }
+                    url={storedPdfUrl}
+                  />
+                ) : null}
+                {!storedPdfUrl && sourceReportUrl ? (
+                  <JobReportUrlRow title={t("jobstatus.jobdetails.reportLabel")} url={sourceReportUrl} />
+                ) : null}
               </div>
             </div>
           </div>

--- a/src/tabs/jobbstatus/components/job-details/JobSpecificDataView.tsx
+++ b/src/tabs/jobbstatus/components/job-details/JobSpecificDataView.tsx
@@ -96,7 +96,14 @@ export function JobSpecificDataView({ data, job }: JobSpecificDataViewProps) {
   const returnValueData = parseReturnValueData(effectiveJob);
 
   // List of technical fields to hide from the user-friendly view
-  const technicalFields = ["autoApprove", "threadId", "messageId", "url"];
+  const technicalFields = [
+    "autoApprove",
+    "threadId",
+    "messageId",
+    "url",
+    "sourceUrl",
+    "pdfCache",
+  ];
 
   function ValueList({ items }: { items: any[] }) {
     return (
@@ -160,18 +167,36 @@ export function JobSpecificDataView({ data, job }: JobSpecificDataViewProps) {
     return trimmed.length > 0 ? trimmed : undefined;
   }, [effectiveJob, processedData, wikidataApprovalData]);
 
-  // Get URL from multiple possible sources
-  const jobUrl: string | undefined = React.useMemo(() => {
-    const url = 
-      effectiveJob?.data?.url || 
-      job?.data?.url || 
+  const isHttpUrl = (s: string) => /^https?:\/\//i.test(s.trim());
+
+  // Pipeline job URL (often S3 public URL when PDF caching was used)
+  const storedPdfUrl: string | undefined = React.useMemo(() => {
+    const url =
+      effectiveJob?.data?.url ||
+      job?.data?.url ||
       processedData?.url ||
       (effectiveJob as any)?.url ||
       (job as any)?.url;
     if (!url) return undefined;
-    const urlString = typeof url === 'string' ? url : String(url);
+    const urlString = typeof url === "string" ? url : String(url);
     return urlString.trim() || undefined;
   }, [effectiveJob, job, processedData]);
+
+  /** Original publisher URL when the job was enqueued with PDF caching (`data.url` is the cached copy). */
+  const sourceReportUrl: string | undefined = React.useMemo(() => {
+    const raw =
+      effectiveJob?.data?.sourceUrl ??
+      job?.data?.sourceUrl ??
+      (processedData as { sourceUrl?: unknown })?.sourceUrl;
+    if (raw == null) return undefined;
+    const s = typeof raw === "string" ? raw : String(raw);
+    const t = s.trim();
+    return t.length ? t : undefined;
+  }, [effectiveJob, job, processedData]);
+
+  const showBothUrls =
+    Boolean(storedPdfUrl && sourceReportUrl) &&
+    storedPdfUrl !== sourceReportUrl;
 
   // Get company name from multiple possible sources
   const companyName: string | undefined = React.useMemo(() => {
@@ -230,36 +255,87 @@ export function JobSpecificDataView({ data, job }: JobSpecificDataViewProps) {
 
   return (
     <div className="space-y-3 text-sm">
-      {/* Show URL if available */}
-      {jobUrl && (
+      {/* Report / PDF URLs (source vs cached S3 when both exist) */}
+      {(storedPdfUrl || sourceReportUrl) && (
         <div className="mb-4">
           <div className="bg-gray-03/20 rounded-lg p-4">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center space-x-3">
-                <div className="p-2 rounded-full bg-blue-03/20">
-                  <FileText className="w-5 h-5 text-blue-03" />
-                </div>
-                <div>
-                  <h4 className="text-base font-medium text-gray-01">{t("jobstatus.jobdetails.reportLabel")}</h4>
-                  <p className="text-sm text-gray-02 truncate max-w-md">{jobUrl}</p>
-                </div>
+            <div className="flex items-start gap-3">
+              <div className="p-2 rounded-full bg-blue-03/20 shrink-0">
+                <FileText className="w-5 h-5 text-blue-03" />
               </div>
-              <Button
-                variant="ghost"
-                size="sm"
-                asChild
-                className="flex-shrink-0"
-              >
-                <a
-                  href={jobUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex items-center text-blue-03 hover:text-blue-04"
-                >
-                  <ExternalLink className="w-4 h-4 mr-2" />
-                  Öppna
-                </a>
-              </Button>
+              <div className="min-w-0 flex-1 space-y-4">
+                {showBothUrls && sourceReportUrl && (
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                    <div className="min-w-0">
+                      <h4 className="text-base font-medium text-gray-01">
+                        {t("registry.sourceUrl")}
+                      </h4>
+                      <p className="text-sm text-gray-02 break-all">{sourceReportUrl}</p>
+                    </div>
+                    {isHttpUrl(sourceReportUrl) ? (
+                      <Button variant="ghost" size="sm" asChild className="shrink-0 self-start sm:self-center">
+                        <a
+                          href={sourceReportUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="flex items-center text-blue-03 hover:text-blue-04"
+                        >
+                          <ExternalLink className="w-4 h-4 mr-2" />
+                          {t("editor.periodEditor.openReport")}
+                        </a>
+                      </Button>
+                    ) : null}
+                  </div>
+                )}
+                {storedPdfUrl && (
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                    <div className="min-w-0">
+                      <h4 className="text-base font-medium text-gray-01">
+                        {showBothUrls
+                          ? t("jobstatus.jobdetails.cachedPdfUrl")
+                          : t("jobstatus.jobdetails.reportLabel")}
+                      </h4>
+                      <p className="text-sm text-gray-02 break-all">{storedPdfUrl}</p>
+                    </div>
+                    {isHttpUrl(storedPdfUrl) ? (
+                      <Button variant="ghost" size="sm" asChild className="shrink-0 self-start sm:self-center">
+                        <a
+                          href={storedPdfUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="flex items-center text-blue-03 hover:text-blue-04"
+                        >
+                          <ExternalLink className="w-4 h-4 mr-2" />
+                          {t("editor.periodEditor.openReport")}
+                        </a>
+                      </Button>
+                    ) : null}
+                  </div>
+                )}
+                {!storedPdfUrl && sourceReportUrl && (
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                    <div className="min-w-0">
+                      <h4 className="text-base font-medium text-gray-01">
+                        {t("jobstatus.jobdetails.reportLabel")}
+                      </h4>
+                      <p className="text-sm text-gray-02 break-all">{sourceReportUrl}</p>
+                    </div>
+                    {isHttpUrl(sourceReportUrl) ? (
+                      <Button variant="ghost" size="sm" asChild className="shrink-0 self-start sm:self-center">
+                        <a
+                          href={sourceReportUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="flex items-center text-blue-03 hover:text-blue-04"
+                        >
+                          <ExternalLink className="w-4 h-4 mr-2" />
+                          {t("editor.periodEditor.openReport")}
+                        </a>
+                      </Button>
+                    ) : null}
+                  </div>
+                )}
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
### ✨ What’s Changed?

Update report job details to show both the sourceurl and the s3url when available

### 🔎 Context

When looking at pending reports before comapny name is know, seeing the original url can sometime help to know which report/company is running without opening the pdf.

### ✅ Validation / Test Plan (if applicable)

<!-- How did you verify this works? Include commands + key scenarios. -->

- [x] Manual verification (describe below)
- [ ] Automated tests added/updated (or N/A)

### 📸 Screenshots / Screen recordings (if applicable)

<!-- Especially for editor/UI changes. Include before/after when useful. -->

### 💥 Impact (check all that apply)

- [ ] **Docs updated** (README/docs)
- [ ] **Routes/query params updated** (deep-links / URL state)
- [ ] **Breaking change**
- [ ] **Backfill/migration needed**
- [ ] **Data/validation behavior changed** (rules, units, rounding, derived calcs, defaults)
- [x] **Visual or setup change only** (styling, ui, gh templates, etc)

### 📋 Checklist

- [x] PR title starts with an issue reference (e.g. `[#123] ...`) or uses a prefix like `[fix]` / `[feat]` / `[chore]`
- [x] Labels set (and milestone if relevant)
- [x] I’ve verified the change locally (repro steps included above when non-trivial)
- [ ] Any new env vars/config are documented (and safe defaults exist)
- [ ] Follow-ups created as issues (or N/A)

### 🛠 Related Issue

Closes #[issue-number] <!-- or: Related to #[issue-number] -->
