### PR TITLE
Show extractLEI job in swimlanes live view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9481,9 +9481,9 @@
       }
     },
     "node_modules/mermaid": {
-      "version": "10.9.5",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-10.9.5.tgz",
-      "integrity": "sha512-eRlKEjzak4z1rcXeCd1OAlyawhrptClQDo8OuI8n6bSVqJ9oMfd5Lrf3Q+TdJHewi/9AIOc3UmEo8Fz+kNzzuQ==",
+      "version": "10.9.6",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-10.9.6.tgz",
+      "integrity": "sha512-XRjjRaI4aPCAMpVaOhxIwLYdx3U4Cb6mN0M268ggFAfFRqsvyFW8zxWbEZazN/mPkqsVWThb0oa1UawWK+XMNg==",
       "license": "MIT",
       "dependencies": {
         "@braintree/sanitize-url": "^6.0.1",
@@ -9504,7 +9504,7 @@
         "non-layered-tidy-tree-layout": "^2.0.2",
         "stylis": "^4.1.3",
         "ts-dedent": "^2.2.0",
-        "uuid": "^9.0.0",
+        "uuid": "^9.0.0 || ^10 || ^11.1.0 || ^12 || ^13 || ^14.0.0",
         "web-worker": "^1.2.0"
       }
     },

--- a/src/lib/workflow-config.ts
+++ b/src/lib/workflow-config.ts
@@ -38,6 +38,7 @@ export const QUEUE_DISPLAY_NAMES: Record<string, string> = {
   extractDescriptions: "Extrahera beskrivningar",
 
   // AI Data Extraction
+  extractLEI: "LEI Extraktion",
   guessWikidata: "Wikidata",
   diffReportingPeriods: "Diff rapportperioder",
   extractEmissions: "Extrahera utsläpp",
@@ -107,6 +108,7 @@ export const PIPELINE_STEPS: PipelineStep[] = [
       "followUpFiscalYear",
       "followUpCompanyTags",
       "followUpIndustryGics",
+      "extractLEI",
       "diffIndustry",
       "diffGoals",
       "diffInitiatives",


### PR DESCRIPTION
## Summary
- Added `extractLEI` to `QUEUE_DISPLAY_NAMES` with display name "LEI Extraktion"
- Added `extractLEI` to the `data-extraction` pipeline step in `PIPELINE_STEPS`

The job was previously only visible in the archive view. It belongs in `data-extraction` (not preprocessing) since nothing in the pipeline depends on it — it's a standalone run-only worker like the other follow-up workers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)