### PR TITLE
[Feat] Update crawler filters and new registry add function

### DIFF
--- a/docs/ROUTING_URL_STATE.md
+++ b/docs/ROUTING_URL_STATE.md
@@ -82,6 +82,7 @@ These examples are meant to be copied by humans and AI tools.
 - `/jobbstatus`
 - `/workflow`
 - `/debug`
+- `/access` — API key management (auth-gated; tab is hidden in the nav until logged in)
 
 ### Jobbstatus (Live vs Archive)
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,7 +32,7 @@ function App() {
           <Route path="/crawler" element={<CrawlerTab />} />
           <Route path="/registry" element={<RegistryTab />} />
           <Route path="/upload" element={<UploadTab />} />
-          <Route path="/api-access" element={<ApiAccessTab />} />
+          <Route path="/access" element={<ApiAccessTab />} />
           <Route path="/jobbstatus" element={<JobbstatusTab />} />
           <Route path="/workflow" element={<WorkflowTab />} />
           <Route path="/debug" element={<DebugTab />} />

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -957,7 +957,6 @@
     "sortIdHint": "Row order uses the internal id as a stand-in until a created-at field exists on reports.",
     "addEntry": "Add Entry",
     "addEntryAdding": "Adding...",
-    "addEntryUploading": "Uploading to S3…",
     "addEntryTitle": "Add Registry Entry",
     "addEntryDescription": "Manually register a report URL. Source URL is pre-filled from the report URL and can be adjusted.",
     "addEntrySuccess": "Registry entry added.",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -880,7 +880,12 @@
     "unknownCompany": "Unknown",
     "unknownId": "Unknown",
     "manuallyAddReport": "Manually add report URL",
-    "country": "Country of origin"
+    "country": "Country of origin",
+    "filterByTags": "Filter by tags",
+    "allTags": "All tags",
+    "tagsSelected": "{{count}} tag(s) selected",
+    "noTags": "No tags available",
+    "clearTagFilter": "Clear filter"
   },
   "registry": {
     "title": "Registry",
@@ -949,7 +954,16 @@
     "sortReportYearAsc": "Report year (oldest first)",
     "sortRegistryIdDesc": "Registry row (newest first, approximate)",
     "sortRegistryIdAsc": "Registry row (oldest first, approximate)",
-    "sortIdHint": "Row order uses the internal id as a stand-in until a created-at field exists on reports."
+    "sortIdHint": "Row order uses the internal id as a stand-in until a created-at field exists on reports.",
+    "addEntry": "Add Entry",
+    "addEntryAdding": "Adding...",
+    "addEntryUploading": "Uploading to S3…",
+    "addEntryTitle": "Add Registry Entry",
+    "addEntryDescription": "Manually register a report URL. Source URL is pre-filled from the report URL and can be adjusted.",
+    "addEntrySuccess": "Registry entry added.",
+    "addEntryError": "Could not add registry entry: {{message}}",
+    "companyNameRequired": "Company name is required",
+    "reportYearRequired": "Report year is required"
   },
   "climate": {
     "loading": "Loading climate plans...",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -957,7 +957,6 @@
     "sortIdHint": "Ordningen använder internt id som approximation tills rapporter får ett skapat-datum-fält.",
     "addEntry": "Lägg till post",
     "addEntryAdding": "Lägger till...",
-    "addEntryUploading": "Laddar upp till S3…",
     "addEntryTitle": "Lägg till registerpost",
     "addEntryDescription": "Registrera en rapport-URL manuellt. Käll-URL fylls i från rapport-URL och kan justeras.",
     "addEntrySuccess": "Registerpost tillagd.",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -880,7 +880,12 @@
     "unknownCompany": "Okänt",
     "unknownId": "Okänt",
     "manuallyAddReport": "Lägg till rapport URL manuellt",
-    "country": "Ursprungsland"
+    "country": "Ursprungsland",
+    "filterByTags": "Filtrera på taggar",
+    "allTags": "Alla taggar",
+    "tagsSelected": "{{count}} tagg(ar) valda",
+    "noTags": "Inga taggar tillgängliga",
+    "clearTagFilter": "Rensa filter"
   },
   "registry": {
     "title": "Register",
@@ -949,7 +954,16 @@
     "sortReportYearAsc": "Rapportår (äldst först)",
     "sortRegistryIdDesc": "Registrerad (nyast först, ungefär)",
     "sortRegistryIdAsc": "Registrerad (äldst först, ungefär)",
-    "sortIdHint": "Ordningen använder internt id som approximation tills rapporter får ett skapat-datum-fält."
+    "sortIdHint": "Ordningen använder internt id som approximation tills rapporter får ett skapat-datum-fält.",
+    "addEntry": "Lägg till post",
+    "addEntryAdding": "Lägger till...",
+    "addEntryUploading": "Laddar upp till S3…",
+    "addEntryTitle": "Lägg till registerpost",
+    "addEntryDescription": "Registrera en rapport-URL manuellt. Käll-URL fylls i från rapport-URL och kan justeras.",
+    "addEntrySuccess": "Registerpost tillagd.",
+    "addEntryError": "Kunde inte lägga till registerpost: {{message}}",
+    "companyNameRequired": "Företagsnamn krävs",
+    "reportYearRequired": "Rapportår krävs"
   },
   "climate": {
     "loading": "Laddar klimatplaner...",

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -9,9 +9,11 @@ import {
   type TopLevelTabSegment,
   topLevelTabFromPathname,
 } from "@/lib/top-level-routes";
+import { useAuth } from "@/hooks/useAuth";
 
 export function MainLayout() {
   const { t } = useI18n();
+  const { isAuthenticated } = useAuth();
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -35,7 +37,9 @@ export function MainLayout() {
               <TabsTrigger value="crawler">{t("nav.crawler")}</TabsTrigger>
               <TabsTrigger value="registry">{t("nav.registry")}</TabsTrigger>
               <TabsTrigger value="upload">{t("nav.upload")}</TabsTrigger>
-              <TabsTrigger value="api-access">{t("nav.apiAccess")}</TabsTrigger>
+              {isAuthenticated && (
+                <TabsTrigger value="access">{t("nav.apiAccess")}</TabsTrigger>
+              )}
               <TabsTrigger value="jobbstatus">{t("nav.jobStatus")}</TabsTrigger>
               <TabsTrigger value="workflow">{t("nav.workflow")}</TabsTrigger>
               <TabsTrigger value="debug">{t("nav.debug")}</TabsTrigger>

--- a/src/lib/top-level-routes.ts
+++ b/src/lib/top-level-routes.ts
@@ -6,7 +6,7 @@ export const TOP_LEVEL_TAB_SEGMENTS = [
   "crawler",
   "registry",
   "upload",
-  "api-access",
+  "access",
   "jobbstatus",
   "workflow",
   "debug",

--- a/src/tabs/crawler/CrawlerTab.tsx
+++ b/src/tabs/crawler/CrawlerTab.tsx
@@ -44,6 +44,8 @@ export function CrawlerTab() {
   const [countryInput, setCountryInput] = useState<string>("");
   const [filterEnabled, setFilterEnabled] = useState<boolean>(false);
   const [filterYear, setFilterYear] = useState<number | null>(null);
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const [tagOptions, setTagOptions] = useState<string[]>([]);
   const [selectedReports, setSelectedReports] = useState<SelectedReport[]>([]);
   const [selectedCompanies, setSelectedCompanies] = useState<
     CompanySelection[]
@@ -335,6 +337,9 @@ export function CrawlerTab() {
                 searchYear={reportYearInput}
                 handleAddToRegistryClick={handleAddToRegistryClick}
                 onRunSelectedReports={() => setIsRunReportsOpen(true)}
+                tagOptions={tagOptions}
+                selectedTags={selectedTags}
+                onTagsChange={setSelectedTags}
               />
               {(!reportYearInput || !selectedCompanies.length) && (
                 <p className="text-sm text-gray-02 mt-4">
@@ -397,6 +402,8 @@ export function CrawlerTab() {
           onSelectionChange={setSelectedCompanies}
           filterYear={filterYear}
           filterEnabled={filterEnabled}
+          selectedTags={selectedTags}
+          onTagOptionsLoaded={setTagOptions}
         />
       )}
     </div>

--- a/src/tabs/crawler/components/CompaniesNamesList.tsx
+++ b/src/tabs/crawler/components/CompaniesNamesList.tsx
@@ -22,6 +22,8 @@ interface CompaniesNamesListProps {
   selectedCompanies: CompanySelection[];
   filterYear?: number | null;
   filterEnabled?: boolean;
+  selectedTags: string[];
+  onTagOptionsLoaded: (tags: string[]) => void;
 }
 
 const CompaniesNamesList = ({
@@ -30,6 +32,8 @@ const CompaniesNamesList = ({
   onSelectionChange,
   filterYear,
   filterEnabled,
+  selectedTags,
+  onTagOptionsLoaded,
 }: CompaniesNamesListProps) => {
   const { t } = useI18n();
   const [companiesList, setcompaniesList] = useState<CompanyDetails[] | null>(
@@ -40,10 +44,15 @@ const CompaniesNamesList = ({
     const fetchData = async () => {
       setIsLoading(true);
       const data = await fetchCompanyNamesList();
-
       if (data) {
         setcompaniesList(data);
         setIsLoading(false);
+
+        const tagSet = new Set<string>();
+        for (const company of data as CompanyDetails[]) {
+          for (const tag of company.tags ?? []) tagSet.add(tag);
+        }
+        onTagOptionsLoaded(Array.from(tagSet).sort());
       }
     };
     fetchData();
@@ -60,38 +69,56 @@ const CompaniesNamesList = ({
     [onSelectionChange],
   );
 
-  const handleSelectAllCompanies = () => {
-    if (selectedCompanies.length === companiesList?.length) {
-      onSelectionChange([]);
-    } else {
-      const allSelections =
-        companiesList?.map((company) => ({
-          name: company.name,
-          wikidataId: company.wikidataId,
-        })) || [];
-      onSelectionChange(allSelections);
-    }
-  };
-
-  const companiesListWithSortedPeriods = useMemo(() => {
+  const companiesListFiltered = useMemo(() => {
     let filtered = companiesList;
+
     if (filterEnabled && filterYear && !isNaN(filterYear)) {
       filtered =
-        companiesList?.filter((company) => {
-          // Exclude companies that have a reporting period ending in filterYear
-          return !company.reportingPeriods.some((rp) => {
-            const endYear = new Date(rp.endDate).getFullYear();
-            return endYear === filterYear;
-          });
-        }) || null;
+        filtered?.filter(
+          (company) =>
+            !company.reportingPeriods.some(
+              (rp) => new Date(rp.endDate).getFullYear() === filterYear,
+            ),
+        ) ?? null;
     }
+
+    if (selectedTags.length > 0) {
+      filtered =
+        filtered?.filter((company) =>
+          selectedTags.some((tag) => company.tags?.includes(tag)),
+        ) ?? null;
+    }
+
     return filtered?.map((company) => ({
       ...company,
       reportingPeriods: [...company.reportingPeriods].sort((a, b) =>
         b.endDate.localeCompare(a.endDate),
       ),
     }));
-  }, [companiesList, filterYear, filterEnabled]);
+  }, [companiesList, filterYear, filterEnabled, selectedTags]);
+
+  const handleSelectAllCompanies = () => {
+    const visibleNames = new Set(
+      companiesListFiltered?.map((c) => c.name) ?? [],
+    );
+    const allVisible =
+      visibleNames.size > 0 &&
+      companiesListFiltered?.every((c) =>
+        selectedCompanies.some((s) => s.name === c.name),
+      );
+
+    if (allVisible) {
+      onSelectionChange((prev) =>
+        prev.filter((s) => !visibleNames.has(s.name)),
+      );
+    } else {
+      const toAdd =
+        companiesListFiltered
+          ?.filter((c) => !selectedCompanies.some((s) => s.name === c.name))
+          .map((c) => ({ name: c.name, wikidataId: c.wikidataId })) ?? [];
+      onSelectionChange((prev) => [...prev, ...toAdd]);
+    }
+  };
 
   return (
     <>
@@ -111,8 +138,8 @@ const CompaniesNamesList = ({
                     </span>
                     <span className="font-medium text-gray-02">
                       {t("crawler.foundCompanies", {
-                        count: companiesListWithSortedPeriods?.length ?? 0,
-                      })}{" "}
+                        count: companiesListFiltered?.length ?? 0,
+                      })}
                     </span>
                   </th>
                   <th className="px-4 py-3 text-left text-xs font-semibold text-gray-02 uppercase tracking-wider">
@@ -121,10 +148,7 @@ const CompaniesNamesList = ({
                   <th className="pl-4 py-3 flex flex-col text-xs tracking-wider">
                     <span className="font-semibold flex gap-2 text-gray-02 uppercase">
                       {t("crawler.select")}{" "}
-                      <button
-                        className="flex"
-                        onClick={handleSelectAllCompanies}
-                      >
+                      <button className="flex" onClick={handleSelectAllCompanies}>
                         <span className="flex gap-2">
                           ({t("crawler.clickSelectAll")})
                         </span>
@@ -133,24 +157,23 @@ const CompaniesNamesList = ({
                     <span className="font-medium text-gray-02">
                       {t("crawler.selectedCompanies", {
                         count: selectedCompanies.length,
-                      })}{" "}
+                      })}
                     </span>
                   </th>
                 </tr>
               </DataTableHead>
 
               <DataTableBody>
-                {companiesListWithSortedPeriods &&
-                  companiesListWithSortedPeriods.map((company, index) => (
-                    <CompaniesNamesResultItem
-                      key={index}
-                      companyDetails={company}
-                      isSelected={selectedCompanies.some(
-                        (s) => s.name === company.name,
-                      )}
-                      onToggle={handleToggleCompany}
-                    />
-                  ))}
+                {companiesListFiltered?.map((company, index) => (
+                  <CompaniesNamesResultItem
+                    key={index}
+                    companyDetails={company}
+                    isSelected={selectedCompanies.some(
+                      (s) => s.name === company.name,
+                    )}
+                    onToggle={handleToggleCompany}
+                  />
+                ))}
               </DataTableBody>
             </DataTable>
           </DataTableShell>

--- a/src/tabs/crawler/components/DatabaseSearchControls.tsx
+++ b/src/tabs/crawler/components/DatabaseSearchControls.tsx
@@ -2,6 +2,7 @@ import ControlsBase from "./ControlsBase";
 import type { SelectedReport } from "../lib/crawler-types";
 import { useState } from "react";
 import { useI18n } from "@/contexts/I18nContext";
+import { MultiSelectDropdown } from "@/ui/multi-select-dropdown";
 
 interface DatabaseSearchControlsProps {
   onReportYearChange: (
@@ -18,6 +19,9 @@ interface DatabaseSearchControlsProps {
   searchYear: string;
   handleAddToRegistryClick?: () => void;
   onRunSelectedReports?: () => void;
+  tagOptions: string[];
+  selectedTags: string[];
+  onTagsChange: (tags: string[]) => void;
 }
 
 const DatabaseSearchControls = ({
@@ -32,6 +36,9 @@ const DatabaseSearchControls = ({
   searchYear,
   handleAddToRegistryClick,
   onRunSelectedReports,
+  tagOptions,
+  selectedTags,
+  onTagsChange,
 }: DatabaseSearchControlsProps) => {
   const { t } = useI18n();
 
@@ -40,7 +47,7 @@ const DatabaseSearchControls = ({
     <>
       <div className="flex flex-col gap-2">
         <p className="text-gray-02">{t("crawler.filterDescription")}</p>
-        <div className="flex gap-4 mb-8">
+        <div className="flex flex-wrap gap-4 mb-4">
           <input
             type="text"
             value={filterInput}
@@ -74,6 +81,33 @@ const DatabaseSearchControls = ({
               : t("crawler.filterEnable")}
           </button>
         </div>
+        {tagOptions.length > 0 && (
+          <div className="flex items-center gap-3 mb-8">
+            <span className="text-sm text-gray-02 shrink-0">
+              {t("crawler.filterByTags")}
+            </span>
+            <MultiSelectDropdown
+              options={tagOptions}
+              selectedIds={selectedTags}
+              onChange={onTagsChange}
+              triggerLabel={
+                selectedTags.length > 0
+                  ? t("crawler.tagsSelected", { count: selectedTags.length })
+                  : t("crawler.allTags")
+              }
+              emptyLabel={t("crawler.noTags")}
+              triggerClassName="min-w-[180px]"
+            />
+            {selectedTags.length > 0 && (
+              <button
+                className="text-xs text-gray-02 hover:text-gray-01 underline"
+                onClick={() => onTagsChange([])}
+              >
+                {t("crawler.clearTagFilter")}
+              </button>
+            )}
+          </div>
+        )}
       </div>
       <h3 className="text-gray-02">
         {t("crawler.databaseControlsDescription")}

--- a/src/tabs/crawler/lib/crawler-types.ts
+++ b/src/tabs/crawler/lib/crawler-types.ts
@@ -24,6 +24,7 @@ export interface CompanyReport {
 export interface CompanyDetails {
   name: string;
   wikidataId?: string;
+  tags?: string[];
   reportingPeriods: ReportingPeriod[];
 }
 

--- a/src/tabs/registry/RegistryTab.tsx
+++ b/src/tabs/registry/RegistryTab.tsx
@@ -19,11 +19,14 @@ import {
 import { useGarboCompanyTagsMap } from "./hooks/useGarboCompanyTagsMap";
 import { useRegistryDisplayedView } from "./hooks/useRegistryDisplayedView";
 import {
+  addRegistryEntry,
   deleteReportFromRegistry,
   editRegistryEntry,
   fetchRegistryList,
 } from "./lib/registry-api";
 import RegistryFiltersAndSort from "./components/RegistryFiltersAndSort";
+import RegistryAddModal from "./components/RegistryAddModal";
+import type { RegistryNewEntry } from "./lib/registry-types";
 
 export function RegistryTab() {
   const { t } = useI18n();
@@ -36,6 +39,8 @@ export function RegistryTab() {
   const [isDeletingSelected, setIsDeletingSelected] = useState<boolean>(false);
   const [editingReportIds, setEditingReportIds] = useState<string[]>([]);
   const [isRunReportsOpen, setIsRunReportsOpen] = useState<boolean>(false);
+  const [isAddEntryOpen, setIsAddEntryOpen] = useState<boolean>(false);
+  const [isAddingEntry, setIsAddingEntry] = useState<boolean>(false);
   const [filters, setFilters] = useState(defaultRegistryViewFilters);
   const patchFilters = useCallback((patch: Partial<RegistryViewFilters>) => {
     setFilters((f) => mergeRegistryViewFilters(f, patch));
@@ -159,6 +164,18 @@ export function RegistryTab() {
     void runForUrls(urls, { onSuccess: () => setIsRunReportsOpen(false) });
   }, [runForUrls, selectedReports]);
 
+  const handleAddEntry = async (entry: RegistryNewEntry) => {
+    setIsAddingEntry(true);
+    try {
+      const newEntry = await addRegistryEntry(entry);
+      setRegistry((current) => [newEntry, ...current]);
+    } catch (error) {
+      console.error("Failed to add registry entry", error);
+    } finally {
+      setIsAddingEntry(false);
+    }
+  };
+
   const handleEditEntry = async (entry: RegistryEntryUpdate) => {
     const reportId = entry.id;
 
@@ -207,6 +224,7 @@ export function RegistryTab() {
           }}
           onRefresh={handleRefresh}
           isRefreshing={isLoading}
+          onAddEntry={() => setIsAddEntryOpen(true)}
           onRunReports={() => setIsRunReportsOpen(true)}
           isRunReportsDisabled={!selectedReports.length}
           onExport={handleExport}
@@ -217,6 +235,13 @@ export function RegistryTab() {
           }
           selectedCount={selectedReports.length}
           isDeletingSelected={isDeletingSelected}
+        />
+
+        <RegistryAddModal
+          open={isAddEntryOpen}
+          onOpenChange={setIsAddEntryOpen}
+          onAdd={handleAddEntry}
+          isAdding={isAddingEntry}
         />
 
         <RegistryFiltersAndSort

--- a/src/tabs/registry/RegistryTab.tsx
+++ b/src/tabs/registry/RegistryTab.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { motion } from "framer-motion";
 import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
 import { useI18n } from "@/contexts/I18nContext";
 import { Callout } from "@/ui/callout";
 import { ApiAuthError } from "@/lib/garbo-auth-fetch";
@@ -169,8 +170,11 @@ export function RegistryTab() {
     try {
       const newEntry = await addRegistryEntry(entry);
       setRegistry((current) => [newEntry, ...current]);
+      toast.success(t("registry.addEntrySuccess"));
     } catch (error) {
-      console.error("Failed to add registry entry", error);
+      const message = error instanceof Error ? error.message : String(error);
+      toast.error(t("registry.addEntryError", { message }));
+      throw error;
     } finally {
       setIsAddingEntry(false);
     }

--- a/src/tabs/registry/components/RegistryAddModal.tsx
+++ b/src/tabs/registry/components/RegistryAddModal.tsx
@@ -10,29 +10,16 @@ import {
   DialogTitle,
 } from "@/ui/dialog";
 import type { RegistryNewEntry } from "../lib/registry-types";
+import {
+  isValidHttpUrl,
+  isValidOptionalHttpUrl,
+} from "../lib/registry-utils";
 
 interface RegistryAddModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onAdd: (entry: RegistryNewEntry) => Promise<void>;
   isAdding: boolean;
-}
-
-function isValidHttpUrl(raw: string): boolean {
-  const t = raw.trim();
-  if (!t) return false;
-  try {
-    const u = new URL(t);
-    return u.protocol === "http:" || u.protocol === "https:";
-  } catch {
-    return false;
-  }
-}
-
-function isValidOptionalHttpUrl(raw: string): boolean {
-  const t = raw.trim();
-  if (!t) return true;
-  return isValidHttpUrl(raw);
 }
 
 const RegistryAddModal = ({
@@ -139,6 +126,7 @@ const RegistryAddModal = ({
   };
 
   const handleOpenChange = (open: boolean) => {
+    if (isAdding) return;
     if (!open) resetForm();
     onOpenChange(open);
   };
@@ -255,7 +243,7 @@ const RegistryAddModal = ({
               !!sourceUrlError
             }
           >
-            {isAdding ? t("registry.addEntryUploading") : t("registry.addEntry")}
+            {isAdding ? t("registry.addEntryAdding") : t("registry.addEntry")}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/tabs/registry/components/RegistryAddModal.tsx
+++ b/src/tabs/registry/components/RegistryAddModal.tsx
@@ -1,0 +1,266 @@
+import { useState } from "react";
+import { useI18n } from "@/contexts/I18nContext";
+import { Button } from "@/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/ui/dialog";
+import type { RegistryNewEntry } from "../lib/registry-types";
+
+interface RegistryAddModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onAdd: (entry: RegistryNewEntry) => Promise<void>;
+  isAdding: boolean;
+}
+
+function isValidHttpUrl(raw: string): boolean {
+  const t = raw.trim();
+  if (!t) return false;
+  try {
+    const u = new URL(t);
+    return u.protocol === "http:" || u.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function isValidOptionalHttpUrl(raw: string): boolean {
+  const t = raw.trim();
+  if (!t) return true;
+  return isValidHttpUrl(raw);
+}
+
+const RegistryAddModal = ({
+  open,
+  onOpenChange,
+  onAdd,
+  isAdding,
+}: RegistryAddModalProps) => {
+  const { t } = useI18n();
+  const [companyName, setCompanyName] = useState("");
+  const [wikidataId, setWikidataId] = useState("");
+  const [reportYear, setReportYear] = useState("");
+  const [url, setUrl] = useState("");
+  const [sourceUrl, setSourceUrl] = useState("");
+  const [sourceUrlTouched, setSourceUrlTouched] = useState(false);
+
+  const [companyNameError, setCompanyNameError] = useState<string | null>(null);
+  const [yearError, setYearError] = useState<string | null>(null);
+  const [urlError, setUrlError] = useState<string | null>(null);
+  const [sourceUrlError, setSourceUrlError] = useState<string | null>(null);
+
+  const resetForm = () => {
+    setCompanyName("");
+    setWikidataId("");
+    setReportYear("");
+    setUrl("");
+    setSourceUrl("");
+    setSourceUrlTouched(false);
+    setCompanyNameError(null);
+    setYearError(null);
+    setUrlError(null);
+    setSourceUrlError(null);
+  };
+
+  const handleUrlChange = (value: string) => {
+    setUrl(value);
+    setUrlError(null);
+    if (!sourceUrlTouched) {
+      setSourceUrl(value);
+    }
+  };
+
+  const handleSourceUrlChange = (value: string) => {
+    setSourceUrl(value);
+    setSourceUrlTouched(true);
+    setSourceUrlError(null);
+  };
+
+  const handleAdd = async () => {
+    const trimmedName = companyName.trim();
+    const trimmedWikidata = wikidataId.trim();
+    const trimmedYear = reportYear.trim();
+    const trimmedUrl = url.trim();
+    const trimmedSource = sourceUrl.trim();
+
+    let hasError = false;
+
+    if (!trimmedName) {
+      setCompanyNameError(t("registry.companyNameRequired"));
+      hasError = true;
+    } else {
+      setCompanyNameError(null);
+    }
+
+    if (!trimmedYear) {
+      setYearError(t("registry.reportYearRequired"));
+      hasError = true;
+    } else {
+      const yearNum = Number(trimmedYear);
+      if (!/^\d{4}$/.test(trimmedYear) || yearNum < 1900 || yearNum > 2100) {
+        setYearError(t("registry.invalidYear"));
+        hasError = true;
+      } else {
+        setYearError(null);
+      }
+    }
+
+    if (!isValidHttpUrl(trimmedUrl)) {
+      setUrlError(t("registry.invalidUrl"));
+      hasError = true;
+    } else {
+      setUrlError(null);
+    }
+
+    if (!isValidOptionalHttpUrl(trimmedSource)) {
+      setSourceUrlError(t("registry.invalidUrl"));
+      hasError = true;
+    } else {
+      setSourceUrlError(null);
+    }
+
+    if (hasError) return;
+
+    await onAdd({
+      companyName: trimmedName,
+      wikidataId: trimmedWikidata || undefined,
+      reportYear: trimmedYear,
+      url: trimmedUrl,
+      sourceUrl: trimmedSource || undefined,
+    });
+
+    resetForm();
+    onOpenChange(false);
+  };
+
+  const handleOpenChange = (open: boolean) => {
+    if (!open) resetForm();
+    onOpenChange(open);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{t("registry.addEntryTitle")}</DialogTitle>
+          <DialogDescription>{t("registry.addEntryDescription")}</DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-3">
+          <label className="text-sm text-gray-02">
+            {t("registry.companyName")}
+            <span className="text-red-400 ml-0.5">*</span>
+            <input
+              value={companyName}
+              onChange={(e) => {
+                setCompanyName(e.target.value);
+                setCompanyNameError(null);
+              }}
+              className={`mt-1 w-full bg-gray-03/20 border rounded-lg px-3 py-2 text-gray-01 ${
+                companyNameError ? "border-red-500" : "border-gray-03"
+              }`}
+            />
+            {companyNameError && (
+              <span className="mt-1 block text-xs text-red-500">
+                {companyNameError}
+              </span>
+            )}
+          </label>
+
+          <label className="text-sm text-gray-02">
+            {t("registry.wikidataId")}
+            <input
+              value={wikidataId}
+              onChange={(e) => setWikidataId(e.target.value)}
+              className="mt-1 w-full bg-gray-03/20 border border-gray-03 rounded-lg px-3 py-2 text-gray-01"
+              placeholder="Q12345"
+            />
+          </label>
+
+          <label className="text-sm text-gray-02">
+            {t("registry.reportYear")}
+            <span className="text-red-400 ml-0.5">*</span>
+            <input
+              value={reportYear}
+              onChange={(e) => {
+                setReportYear(e.target.value);
+                setYearError(null);
+              }}
+              className={`mt-1 w-full bg-gray-03/20 border rounded-lg px-3 py-2 text-gray-01 ${
+                yearError ? "border-red-500" : "border-gray-03"
+              }`}
+              placeholder="2024"
+            />
+            {yearError && (
+              <span className="mt-1 block text-xs text-red-500">{yearError}</span>
+            )}
+          </label>
+
+          <label className="text-sm text-gray-02">
+            {t("registry.reportUrl")}
+            <span className="text-red-400 ml-0.5">*</span>
+            <input
+              value={url}
+              onChange={(e) => handleUrlChange(e.target.value)}
+              className={`mt-1 w-full bg-gray-03/20 border rounded-lg px-3 py-2 text-gray-01 ${
+                urlError ? "border-red-500" : "border-gray-03"
+              }`}
+              placeholder="https://…"
+            />
+            {urlError && (
+              <span className="mt-1 block text-xs text-red-500">{urlError}</span>
+            )}
+          </label>
+
+          <label className="text-sm text-gray-02">
+            {t("registry.sourceUrl")}
+            <input
+              value={sourceUrl}
+              onChange={(e) => handleSourceUrlChange(e.target.value)}
+              className={`mt-1 w-full bg-gray-03/20 border rounded-lg px-3 py-2 text-gray-01 ${
+                sourceUrlError ? "border-red-500" : "border-gray-03"
+              }`}
+              placeholder="https://…"
+            />
+            {sourceUrlError && (
+              <span className="mt-1 block text-xs text-red-500">
+                {sourceUrlError}
+              </span>
+            )}
+          </label>
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => handleOpenChange(false)}
+            disabled={isAdding}
+          >
+            {t("registry.cancel")}
+          </Button>
+          <Button
+            size="sm"
+            onClick={() => void handleAdd()}
+            disabled={
+              isAdding ||
+              !!companyNameError ||
+              !!yearError ||
+              !!urlError ||
+              !!sourceUrlError
+            }
+          >
+            {isAdding ? t("registry.addEntryUploading") : t("registry.addEntry")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default RegistryAddModal;

--- a/src/tabs/registry/components/RegistryControls.tsx
+++ b/src/tabs/registry/components/RegistryControls.tsx
@@ -1,4 +1,4 @@
-import { BookDownIcon, RefreshCw } from "lucide-react";
+import { BookDownIcon, PlusCircle, RefreshCw } from "lucide-react";
 import { Button } from "@/ui/button";
 import { useI18n } from "@/contexts/I18nContext";
 
@@ -7,6 +7,7 @@ interface RegistryControlsProps {
   onQueryChange: (value: string) => void;
   onRefresh: () => void;
   isRefreshing: boolean;
+  onAddEntry: () => void;
   onRunReports: () => void;
   isRunReportsDisabled: boolean;
   onExport: () => void;
@@ -22,6 +23,7 @@ const RegistryControls = ({
   onQueryChange,
   onRefresh,
   isRefreshing,
+  onAddEntry,
   onRunReports,
   isRunReportsDisabled,
   onExport,
@@ -52,6 +54,14 @@ const RegistryControls = ({
         >
           {t("common.refresh")}
           <RefreshCw className="w-4 h-4 ml-2" />
+        </Button>
+        <Button
+          size="sm"
+          variant="secondary"
+          onClick={onAddEntry}
+        >
+          {t("registry.addEntry")}
+          <PlusCircle className="w-4 h-4 ml-2" />
         </Button>
         <Button
           size="sm"

--- a/src/tabs/registry/components/RegistryEditModal.tsx
+++ b/src/tabs/registry/components/RegistryEditModal.tsx
@@ -10,6 +10,7 @@ import {
   DialogTitle,
 } from "@/ui/dialog";
 import type { RegistryEntry, RegistryEntryUpdate } from "../lib/registry-types";
+import { isValidOptionalHttpUrl } from "../lib/registry-utils";
 
 interface RegistryEditModalProps {
   entry: RegistryEntry;
@@ -17,17 +18,6 @@ interface RegistryEditModalProps {
   onOpenChange: (open: boolean) => void;
   onEdit: (entry: RegistryEntryUpdate) => Promise<void>;
   isEditing: boolean;
-}
-
-function isValidOptionalHttpUrl(raw: string): boolean {
-  const t = raw.trim();
-  if (!t) return true;
-  try {
-    const u = new URL(t);
-    return u.protocol === "http:" || u.protocol === "https:";
-  } catch {
-    return false;
-  }
 }
 
 const RegistryEditModal = ({

--- a/src/tabs/registry/lib/registry-api.ts
+++ b/src/tabs/registry/lib/registry-api.ts
@@ -1,6 +1,11 @@
-import { getGarboApiBaseUrl } from "@/config/api-env";
+import { getGarboApiBaseUrl, getPipelineUrl } from "@/config/api-env";
+import { authenticatedFetch } from "@/lib/api-helpers";
 import { garboAuthFetch, throwIfAuthError } from "@/lib/garbo-auth-fetch";
-import type { RegistryEntry, RegistryEntryUpdate } from "./registry-types";
+import type {
+  RegistryEntry,
+  RegistryEntryUpdate,
+  RegistryNewEntry,
+} from "./registry-types";
 import { filterRegistryEntries } from "./registry-utils";
 
 function registryUrl(path: string): string {
@@ -80,6 +85,82 @@ export const deleteReportFromRegistry = async (reportIds: string[]) => {
     }
   } catch (error) {
     const msg = `Failed to delete reports with IDs ${reportIds.join(", ")}`;
+    console.error(msg, error);
+    throw error instanceof Error ? error : new Error(msg);
+  }
+};
+
+type PdfCacheResult = {
+  publicUrl: string;
+  key: string;
+  bucket: string;
+  sha256: string;
+};
+
+async function cachePdfToS3(
+  sourceUrl: string,
+): Promise<PdfCacheResult | null> {
+  try {
+    const response = await authenticatedFetch(
+      getPipelineUrl("cache-pdf"),
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url: sourceUrl }),
+      },
+    );
+    if (!response.ok) return null;
+    return (await response.json()) as PdfCacheResult;
+  } catch {
+    return null;
+  }
+}
+
+export const addRegistryEntry = async (
+  entry: RegistryNewEntry,
+): Promise<RegistryEntry> => {
+  const cache = await cachePdfToS3(entry.url);
+
+  const payload: RegistryNewEntry = {
+    ...entry,
+    ...(cache && {
+      s3Url: cache.publicUrl,
+      s3Key: cache.key,
+      s3Bucket: cache.bucket,
+      sha256: cache.sha256,
+    }),
+  };
+
+  const url = registryUrl("internal-companies/reports/save-reports");
+  try {
+    const response = await garboAuthFetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify([payload]),
+    });
+
+    let body: { successes?: RegistryEntry[]; message?: string } | null = null;
+    try {
+      body = await response.json();
+    } catch {
+      body = null;
+    }
+
+    if (!response.ok) {
+      const errorMsg =
+        body?.message ??
+        `Failed to add registry entry: ${response.status} ${response.statusText}`;
+      throw new Error(errorMsg);
+    }
+
+    const saved = body?.successes?.[0];
+    if (!saved) throw new Error("No entry returned from server");
+    return saved;
+  } catch (error) {
+    const msg = `Failed to add registry entry for URL ${entry.url}`;
     console.error(msg, error);
     throw error instanceof Error ? error : new Error(msg);
   }

--- a/src/tabs/registry/lib/registry-types.ts
+++ b/src/tabs/registry/lib/registry-types.ts
@@ -24,6 +24,18 @@ export interface RegistryEntryUpdate {
   sha256?: string | null;
 }
 
+export interface RegistryNewEntry {
+  companyName: string;
+  wikidataId?: string;
+  reportYear: string;
+  url: string;
+  sourceUrl?: string;
+  s3Url?: string;
+  s3Key?: string;
+  s3Bucket?: string;
+  sha256?: string;
+}
+
 export interface RegistryStats {
   total: number;
 }

--- a/src/tabs/registry/lib/registry-utils.ts
+++ b/src/tabs/registry/lib/registry-utils.ts
@@ -1,5 +1,21 @@
 import type { RegistryEntry, RegistryStats } from "./registry-types";
 
+export function isValidHttpUrl(raw: string): boolean {
+  const trimmed = raw.trim();
+  if (!trimmed) return false;
+  try {
+    const u = new URL(trimmed);
+    return u.protocol === "http:" || u.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+export function isValidOptionalHttpUrl(raw: string): boolean {
+  if (!raw.trim()) return true;
+  return isValidHttpUrl(raw);
+}
+
 export function filterRegistryEntries(
   entries: RegistryEntry[],
   query: string,


### PR DESCRIPTION
### ✨ What’s Changed?

- add tags as a filter on the crawler database list view
- add a new "Add Report" button and modal to registry to add new reports without needing to go through crawler if you already have the url but don't want to upload yet

### 🔎 Context

Since it costs to run docling, there are cases when we want to add/collect the reports into the reports table but we don't need the crawler if we already have a url. Adding the report will automatically cache the pdf to s3 bucket so only need to add the web url

### ✅ Validation / Test Plan (if applicable)

<!-- How did you verify this works? Include commands + key scenarios. -->

- [x] Manual verification (describe below)
- [ ] Automated tests added/updated (or N/A)

### 📸 Screenshots / Screen recordings (if applicable)

<!-- Especially for editor/UI changes. Include before/after when useful. -->

### 💥 Impact (check all that apply)

- [x] **Docs updated** (README/docs)
- [x] **Routes/query params updated** (deep-links / URL state)
- [ ] **Breaking change**
- [ ] **Backfill/migration needed**
- [ ] **Data/validation behavior changed** (rules, units, rounding, derived calcs, defaults)
- [ ] **Visual or setup change only** (styling, ui, gh templates, etc)

### 📋 Checklist

- [x] PR title starts with an issue reference (e.g. `[#123] ...`) or uses a prefix like `[fix]` / `[feat]` / `[chore]`
- [x] Labels set (and milestone if relevant)
- [x] I’ve verified the change locally (repro steps included above when non-trivial)
- [ ] Any new env vars/config are documented (and safe defaults exist)
- [x] Follow-ups created as issues (or N/A)

### 🛠 Related Issue

Closes #[issue-number] <!-- or: Related to #[issue-number] -->
