### PR TITLE
[Change]: Added configuration to point goffer towards unearth

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -28,8 +28,8 @@
 # In the network tab you'll see which path is used: /garbo-local, /garbo-stage, or /garbo.
 # =============================================================================
 # VITE_GARBO_LOCAL_URL=http://localhost:3000
-# VITE_GARBO_STAGE_URL=https://stage-api.klimatkollen.se
-# VITE_GARBO_PROD_URL=https://api.klimatkollen.se
+# VITE_GARBO_STAGE_URL=https://stage-api.unearthdata.ai
+# VITE_GARBO_PROD_URL=https://api.unearthdata.ai
 
 # =============================================================================
 # Other

--- a/README.md
+++ b/README.md
@@ -71,7 +71,29 @@ yarn dev
 
 The development server will start on `http://localhost:5173` (or the next available port).
 
+On startup, the terminal logs which backends the Vite proxy targets, for example:
+
+```
+[vite] pipeline target: stage -> https://stage-pipeline-api.klimatkollen.se
+[vite] garbo target: stage -> https://stage-api.unearthdata.ai ...
+```
+
 4. Open your browser and navigate to the URL shown in the terminal (typically `http://localhost:5173`)
+
+### Backend APIs
+
+The app talks to two backends:
+
+| Backend | Used for | Default host (stage) |
+|---------|----------|----------------------|
+| **Garbo** | Auth, crawler, registry, api-access, queue archive, errors tab | `stage-api.unearthdata.ai` |
+| **Pipeline** | Live job status, upload, batches, reruns | `stage-pipeline-api.klimatkollen.se` |
+
+In **local dev**, the browser calls same-origin proxy paths (`/garbo-stage/api/...`, `/pipeline-stage/api/...`); Vite forwards them to the hosts above. Configure targets in `.env.development` (see `.env.development.example`).
+
+In **staging/production**, nginx in the container proxies `/garbo-api` and `/api` using `GARBO_API_URL` and `BACKEND_API_URL` from the k8s manifests. Garbo endpoints point at unearthdata; pipeline stays on klimatkollen.
+
+For path names, env vars, and Jobbstatus live vs archive, see [API and proxy setup](./docs/API_AND_PROXY_SETUP.md).
 
 ## Development
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 # Pipeline backend (default: staging)
 BACKEND_API_URL=${BACKEND_API_URL:-https://stage-pipeline-api.klimatkollen.se}
 # Garbo backend (default: staging API base including /api)
-GARBO_API_URL=${GARBO_API_URL:-https://stage-api.klimatkollen.se/api}
+GARBO_API_URL=${GARBO_API_URL:-https://stage-api.unearthdata.ai/api}
 # API key for non auth endpoints in garbo (e.g. /garbo-api/companies)
 GARBO_ALL_ACCESS_API_KEY=${GARBO_ALL_ACCESS_API_KEY:-}
 

--- a/docs/API_AND_PROXY_SETUP.md
+++ b/docs/API_AND_PROXY_SETUP.md
@@ -97,7 +97,7 @@ VITE_GARBO_TARGET=local
 
 ### URL overrides (optional)
 
-By default, local/stage/prod URLs are fixed (e.g. stage-api.klimatkollen.se for garbo stage). To point at a different host:
+By default, local/stage/prod URLs are fixed. Garbo stage/prod default to unearthdata; pipeline stays on klimatkollen. To point at a different host:
 
 - Pipeline: `VITE_PIPELINE_API_URL`, `VITE_PIPELINE_STAGE_URL`, `VITE_PIPELINE_PROD_URL`
 - Garbo: `VITE_GARBO_LOCAL_URL`, `VITE_GARBO_STAGE_URL`, `VITE_GARBO_PROD_URL`
@@ -128,8 +128,8 @@ When you change `.env`, **restart the dev server** so the proxy and app config p
 Garbo uses two kinds of URLs (per garbo team):
 
 - **API base** (stage-api / api) – used for all backend calls (reports, companies, auth).  
-  Stage: `https://stage-api.klimatkollen.se`  
-  Prod: `https://api.klimatkollen.se`
+  Stage: `https://stage-api.unearthdata.ai`  
+  Prod: `https://api.unearthdata.ai`
 - **Frontend origin** (stage / klimatkollen) – used when the app needs to link to the Klimatkollen **web app** (e.g. “back to site” links, not API calls).  
   Stage: `https://stage.klimatkollen.se`  
   Prod: `https://klimatkollen.se`

--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -23,7 +23,7 @@ spec:
               value: "https://stage-pipeline-api.klimatkollen.se"
             # Garbo API - auth, companies, tag-options (override in overlays for prod)
             - name: GARBO_API_URL
-              value: "https://stage-api.klimatkollen.se/api"
+              value: "https://stage-api.unearthdata.ai/api"
             # Garbo all-access API key - for non auth endpoints in garbo (e.g. /garbo-api/companies)
             - name: GARBO_ALL_ACCESS_API_KEY
               valueFrom:

--- a/k8s/overlays/production/deployment-patch.yaml
+++ b/k8s/overlays/production/deployment-patch.yaml
@@ -11,4 +11,4 @@ spec:
             - name: BACKEND_API_URL
               value: "https://pipeline-api.klimatkollen.se"
             - name: GARBO_API_URL
-              value: "https://api.klimatkollen.se/api"
+              value: "https://api.unearthdata.ai/api"

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -61,11 +61,11 @@ server {
     }
     location /garbo-stage-api/ {
         # Keep the incoming /api/... path intact (avoid /api/api/...).
-        proxy_pass https://stage-api.klimatkollen.se/;
+        proxy_pass https://stage-api.unearthdata.ai/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
-        proxy_set_header Host stage-api.klimatkollen.se;
+        proxy_set_header Host stage-api.unearthdata.ai;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
@@ -81,11 +81,11 @@ server {
     }
     location /garbo-prod-api/ {
         # Keep the incoming /api/... path intact (avoid /api/api/...).
-        proxy_pass https://api.klimatkollen.se/;
+        proxy_pass https://api.unearthdata.ai/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
-        proxy_set_header Host api.klimatkollen.se;
+        proxy_set_header Host api.unearthdata.ai;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2336,9 +2336,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12985,16 +12985,16 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/uvu": {

--- a/src/config/api-env.ts
+++ b/src/config/api-env.ts
@@ -13,8 +13,8 @@ export const GARBO_STAGE_ORIGIN = "https://stage.klimatkollen.se";
 export const GARBO_PROD_ORIGIN = "https://klimatkollen.se";
 
 // API base origin (backend the FE calls). Used here for prod URLs; vite.config imports for dev proxy.
-export const GARBO_STAGE_API = "https://stage-api.klimatkollen.se";
-export const GARBO_PROD_API = "https://api.klimatkollen.se";
+export const GARBO_STAGE_API = "https://stage-api.unearthdata.ai";
+export const GARBO_PROD_API = "https://api.unearthdata.ai";
 
 function jointMode(): ApiTarget {
   const v = import.meta.env.VITE_API_MODE as string | undefined;


### PR DESCRIPTION
### ✨ What’s Changed?

This pull request updates the application to use new Garbo API endpoints under the `unearthdata.ai` domain instead of the previous `klimatkollen.se` domain. These changes affect environment variables, configuration files, deployment manifests, and Nginx proxy settings to ensure all environments (development, staging, and production) consistently reference the new API URLs.

**API Endpoint Updates:**

* `.env.development.example`, `src/config/api-env.ts`: Updated `VITE_GARBO_STAGE_URL`, `VITE_GARBO_PROD_URL`, `GARBO_STAGE_API`, and `GARBO_PROD_API` to use the new `unearthdata.ai` domain for both staging and production. 
* `docker-entrypoint.sh`, `k8s/base/deployment.yaml`, `k8s/overlays/production/deployment-patch.yaml`: Changed default and environment variable values for `GARBO_API_URL` to point to the new staging and production endpoints at `unearthdata.ai`. 

**Nginx Proxy Configuration:**

* Updated proxy pass and host headers for `/garbo-stage-api/` and `/garbo-prod-api/` locations to forward requests to the new Garbo API endpoints on `unearthdata.ai`.

### ✅ Validation / Test Plan (if applicable)

- [x] Manual verification (describe below)
- [ ] Automated tests added/updated (or N/A)

### 💥 Impact (check all that apply)

- [ ] **Docs updated** (README/docs)
- [x] **Routes/query params updated** (deep-links / URL state)
- [x] **Breaking change**
- [ ] **Backfill/migration needed**
- [ ] **Data/validation behavior changed** (rules, units, rounding, derived calcs, defaults)
- [ ] **Visual or setup change only** (styling, ui, gh templates, etc)

### 📋 Checklist

- [x] PR title starts with an issue reference (e.g. `[#123] ...`) or uses a prefix like `[fix]` / `[feat]` / `[chore]`
- [x] Labels set (and milestone if relevant)
- [x] I’ve verified the change locally (repro steps included above when non-trivial)
- [x] Any new env vars/config are documented (and safe defaults exist)
- [ ] Follow-ups created as issues (or N/A)