### PR TITLE
[Fix] Update API paths/names and registry bug

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -44,13 +44,10 @@
 # API keys (proxy injection; vite dev + nginx in staging/production)
 # k8s Secret "env" may still use legacy key names — see k8s/base/deployment.yaml
 #
-# UNEARTH_ALL_ACCESS_API_KEY     — /unearth-api/ (primary deployment target)
-# UNEARTH_STAGE_ALL_ACCESS_API_KEY — /unearth-stage-api/ (errors tab, fixed stage)
-# UNEARTH_PROD_ALL_ACCESS_API_KEY  — /unearth-prod-api/ (errors tab, fixed prod)
-# GARBO_ALL_ACCESS_API_KEY       — /garbo-api/queue-archive/ (Garbo monolith)
-#
-# Legacy names (still read by vite if UNEARTH_* unset):
-# GARBO_STAGE_ALL_ACCESS_API_KEY, GARBO_PROD_ALL_ACCESS_API_KEY
+# GARBO_ALL_ACCESS_API_KEY     — /unearth-api/ (primary target: stage or prod per deployment)
+# GARBO_STAGE_ALL_ACCESS_API_KEY — /unearth-stage-api/ and /garbo-api/queue-archive/ (stage monolith)
+# GARBO_PROD_ALL_ACCESS_API_KEY  — /unearth-prod-api/ (errors tab, fixed prod)
+# Both stage and prod secrets are required in every deployment (errors tab compares both envs).
 # =============================================================================
-# UNEARTH_STAGE_ALL_ACCESS_API_KEY=garb_yourlookup.yoursecret
-# UNEARTH_PROD_ALL_ACCESS_API_KEY=garb_yourlookup.yoursecret
+# GARBO_STAGE_ALL_ACCESS_API_KEY=garb_yourlookup.yoursecret
+# GARBO_PROD_ALL_ACCESS_API_KEY=garb_yourlookup.yoursecret

--- a/.env.development.example
+++ b/.env.development.example
@@ -1,35 +1,39 @@
 # Development API config. Copy to .env.development or .env.development.local.
-# See src/config/api-env.ts for behaviour.
+# See src/config/api-env.ts and docs/API_AND_PROXY_SETUP.md.
 
 # =============================================================================
-# Joint override (sets both pipeline and garbo when not overridden)
+# Joint override (sets both pipeline and Unearth/Garbo when not overridden)
 # =============================================================================
 # VITE_API_MODE=stage
 # VITE_API_MODE=local
 # VITE_API_MODE=prod
 
 # =============================================================================
-# Per-backend overrides (override joint for that backend only)
+# Per-backend overrides
 # =============================================================================
 # VITE_PIPELINE_TARGET=local
-# VITE_GARBO_TARGET=stage
+# VITE_UNEARTH_TARGET=stage
+# VITE_GARBO_TARGET=stage   # legacy alias for VITE_UNEARTH_TARGET
 
 # =============================================================================
-# Pipeline (job status, upload): in network tab you see /pipeline-local, /pipeline-stage, or /pipeline.
-# local = pipeline on this machine (e.g. localhost:3001); stage/prod = remote APIs.
+# Pipeline (job status, upload): /pipeline-local, /pipeline-stage, or /pipeline
 # =============================================================================
 # VITE_PIPELINE_API_URL=http://localhost:3001
 # VITE_PIPELINE_STAGE_URL=https://stage-pipeline-api.klimatkollen.se
 # VITE_PIPELINE_PROD_URL=https://pipeline-api.klimatkollen.se
 
 # =============================================================================
-# Garbo (auth, crawler, Jobbstatus Archive /queue-archive): same proxy targets.
-# local = garbo on this machine (e.g. localhost:3000); stage/prod = remote APIs.
-# In the network tab you'll see which path is used: /garbo-local, /garbo-stage, or /garbo.
+# Unearth HTTP API (auth, crawler, registry): /unearth-local, /unearth-stage, /unearth
 # =============================================================================
-# VITE_GARBO_LOCAL_URL=http://localhost:3000
-# VITE_GARBO_STAGE_URL=https://stage-api.unearthdata.ai
-# VITE_GARBO_PROD_URL=https://api.unearthdata.ai
+# VITE_UNEARTH_LOCAL_URL=http://localhost:3000
+# VITE_UNEARTH_STAGE_URL=https://stage-api.unearthdata.ai
+# VITE_UNEARTH_PROD_URL=https://api.unearthdata.ai
+
+# =============================================================================
+# Garbo monolith (queue-archive only): /garbo-local, /garbo-stage, /garbo + /queue-archive
+# =============================================================================
+# VITE_GARBO_STAGE_URL=https://stage-api.klimatkollen.se
+# VITE_GARBO_PROD_URL=https://api.klimatkollen.se
 
 # =============================================================================
 # Other
@@ -37,17 +41,16 @@
 # VITE_SCREENSHOTS_API_URL=http://localhost:3000
 
 # =============================================================================
-# Garbo all-access API keys (proxy injection)
-# In production/staging: nginx injects these as X-API-Key on proxied garbo requests.
-# All three are stored as keys in the k8s Secret named "env" in the validate namespace.
+# API keys (proxy injection; vite dev + nginx in staging/production)
+# k8s Secret "env" may still use legacy key names — see k8s/base/deployment.yaml
 #
-# GARBO_ALL_ACCESS_API_KEY     — for /garbo-api/ (primary target: stage or prod per deployment)
-# GARBO_STAGE_ALL_ACCESS_API_KEY — for /garbo-stage-api/ (always stage-api.klimatkollen.se)
-# GARBO_PROD_ALL_ACCESS_API_KEY  — for /garbo-prod-api/  (always api.klimatkollen.se)
-# Both stage and prod secrets are required in every deployment (errors tab compares both envs).
+# UNEARTH_ALL_ACCESS_API_KEY     — /unearth-api/ (primary deployment target)
+# UNEARTH_STAGE_ALL_ACCESS_API_KEY — /unearth-stage-api/ (errors tab, fixed stage)
+# UNEARTH_PROD_ALL_ACCESS_API_KEY  — /unearth-prod-api/ (errors tab, fixed prod)
+# GARBO_ALL_ACCESS_API_KEY       — /garbo-api/queue-archive/ (Garbo monolith)
 #
-# In local dev: set the keys below — the vite proxy injects them the same way nginx does.
-# Generate each key via the API Access tab in validate while logged in to the matching env.
+# Legacy names (still read by vite if UNEARTH_* unset):
+# GARBO_STAGE_ALL_ACCESS_API_KEY, GARBO_PROD_ALL_ACCESS_API_KEY
 # =============================================================================
-# GARBO_STAGE_ALL_ACCESS_API_KEY=garb_yourlookup.yoursecret
-# GARBO_PROD_ALL_ACCESS_API_KEY=garb_yourlookup.yoursecret
+# UNEARTH_STAGE_ALL_ACCESS_API_KEY=garb_yourlookup.yoursecret
+# UNEARTH_PROD_ALL_ACCESS_API_KEY=garb_yourlookup.yoursecret

--- a/README.md
+++ b/README.md
@@ -75,23 +75,25 @@ On startup, the terminal logs which backends the Vite proxy targets, for example
 
 ```
 [vite] pipeline target: stage -> https://stage-pipeline-api.klimatkollen.se
-[vite] garbo target: stage -> https://stage-api.unearthdata.ai ...
+[vite] unearth target: stage -> https://stage-api.unearthdata.ai ...
+[vite] garbo (queue-archive) target: stage -> https://stage-api.klimatkollen.se ...
 ```
 
 4. Open your browser and navigate to the URL shown in the terminal (typically `http://localhost:5173`)
 
 ### Backend APIs
 
-The app talks to two backends:
+The app talks to three backends:
 
 | Backend | Used for | Default host (stage) |
 |---------|----------|----------------------|
-| **Garbo** | Auth, crawler, registry, api-access, queue archive, errors tab | `stage-api.unearthdata.ai` |
-| **Pipeline** | Live job status, upload, batches, reruns | `stage-pipeline-api.klimatkollen.se` |
+| **Unearth API** | Auth, crawler, registry, api-access, errors tab | `stage-api.unearthdata.ai` |
+| **Garbo monolith** | Queue archive (Jobbstatus Archive, batch pickers) | `stage-api.klimatkollen.se` |
+| **Pipeline** | Live job status, upload, reruns | `stage-pipeline-api.klimatkollen.se` |
 
-In **local dev**, the browser calls same-origin proxy paths (`/garbo-stage/api/...`, `/pipeline-stage/api/...`); Vite forwards them to the hosts above. Configure targets in `.env.development` (see `.env.development.example`).
+In **local dev**, Unearth uses `/unearth-stage/api/...` and Garbo archive uses `/garbo-stage/api/queue-archive/...`.
 
-In **staging/production**, nginx in the container proxies `/garbo-api` and `/api` using `GARBO_API_URL` and `BACKEND_API_URL` from the k8s manifests. Garbo endpoints point at unearthdata; pipeline stays on klimatkollen.
+In **staging/production**, nginx proxies `/unearth-api/` → `UNEARTH_API_URL` and `/garbo-api/queue-archive/` → `GARBO_API_URL`. Pipeline uses `BACKEND_API_URL`.
 
 For path names, env vars, and Jobbstatus live vs archive, see [API and proxy setup](./docs/API_AND_PROXY_SETUP.md).
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -7,11 +7,10 @@ BACKEND_API_URL=${BACKEND_API_URL:-https://stage-pipeline-api.klimatkollen.se}
 UNEARTH_API_URL=${UNEARTH_API_URL:-https://stage-api.unearthdata.ai/api}
 # Garbo monolith — queue-archive only (default: staging klimatkollen)
 GARBO_API_URL=${GARBO_API_URL:-https://stage-api.klimatkollen.se/api}
-# API keys (k8s secret keys may still be named GARBO_* — see deployment.yaml)
-UNEARTH_ALL_ACCESS_API_KEY=${UNEARTH_ALL_ACCESS_API_KEY:-}
+# API keys for proxied requests (injected as X-API-Key)
 GARBO_ALL_ACCESS_API_KEY=${GARBO_ALL_ACCESS_API_KEY:-}
-UNEARTH_STAGE_ALL_ACCESS_API_KEY=${UNEARTH_STAGE_ALL_ACCESS_API_KEY:-${GARBO_STAGE_ALL_ACCESS_API_KEY:-}}
-UNEARTH_PROD_ALL_ACCESS_API_KEY=${UNEARTH_PROD_ALL_ACCESS_API_KEY:-${GARBO_PROD_ALL_ACCESS_API_KEY:-}}
+GARBO_STAGE_ALL_ACCESS_API_KEY=${GARBO_STAGE_ALL_ACCESS_API_KEY:-}
+GARBO_PROD_ALL_ACCESS_API_KEY=${GARBO_PROD_ALL_ACCESS_API_KEY:-}
 
 # Extract hostnames for Host header (required when using variable in proxy_pass)
 BACKEND_HOST=$(echo "$BACKEND_API_URL" | sed -E 's|^https?://||' | sed -E 's|/.*$||')
@@ -24,11 +23,10 @@ export UNEARTH_API_URL
 export UNEARTH_HOST
 export GARBO_API_URL
 export GARBO_HOST
-export UNEARTH_ALL_ACCESS_API_KEY
 export GARBO_ALL_ACCESS_API_KEY
-export UNEARTH_STAGE_ALL_ACCESS_API_KEY
-export UNEARTH_PROD_ALL_ACCESS_API_KEY
+export GARBO_STAGE_ALL_ACCESS_API_KEY
+export GARBO_PROD_ALL_ACCESS_API_KEY
 
-envsubst '${BACKEND_API_URL} ${BACKEND_HOST} ${UNEARTH_API_URL} ${UNEARTH_HOST} ${GARBO_API_URL} ${GARBO_HOST} ${UNEARTH_ALL_ACCESS_API_KEY} ${GARBO_ALL_ACCESS_API_KEY} ${UNEARTH_STAGE_ALL_ACCESS_API_KEY} ${UNEARTH_PROD_ALL_ACCESS_API_KEY}' < /etc/nginx/templates/nginx.conf.template > /etc/nginx/conf.d/default.conf
+envsubst '${BACKEND_API_URL} ${BACKEND_HOST} ${UNEARTH_API_URL} ${UNEARTH_HOST} ${GARBO_API_URL} ${GARBO_HOST} ${GARBO_ALL_ACCESS_API_KEY} ${GARBO_STAGE_ALL_ACCESS_API_KEY} ${GARBO_PROD_ALL_ACCESS_API_KEY}' < /etc/nginx/templates/nginx.conf.template > /etc/nginx/conf.d/default.conf
 
 exec nginx -g 'daemon off;'

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,28 +3,32 @@ set -e
 
 # Pipeline backend (default: staging)
 BACKEND_API_URL=${BACKEND_API_URL:-https://stage-pipeline-api.klimatkollen.se}
-# Garbo backend (default: staging API base including /api)
-GARBO_API_URL=${GARBO_API_URL:-https://stage-api.unearthdata.ai/api}
-# API key for non auth endpoints in garbo (e.g. /garbo-api/companies)
+# Unearth HTTP API (default: staging, includes /api suffix)
+UNEARTH_API_URL=${UNEARTH_API_URL:-https://stage-api.unearthdata.ai/api}
+# Garbo monolith — queue-archive only (default: staging klimatkollen)
+GARBO_API_URL=${GARBO_API_URL:-https://stage-api.klimatkollen.se/api}
+# API keys (k8s secret keys may still be named GARBO_* — see deployment.yaml)
+UNEARTH_ALL_ACCESS_API_KEY=${UNEARTH_ALL_ACCESS_API_KEY:-}
 GARBO_ALL_ACCESS_API_KEY=${GARBO_ALL_ACCESS_API_KEY:-}
-# API keys for the fixed-host errors tab proxies (always stage + prod regardless of deployment)
-GARBO_STAGE_ALL_ACCESS_API_KEY=${GARBO_STAGE_ALL_ACCESS_API_KEY:-}
-GARBO_PROD_ALL_ACCESS_API_KEY=${GARBO_PROD_ALL_ACCESS_API_KEY:-}
+UNEARTH_STAGE_ALL_ACCESS_API_KEY=${UNEARTH_STAGE_ALL_ACCESS_API_KEY:-${GARBO_STAGE_ALL_ACCESS_API_KEY:-}}
+UNEARTH_PROD_ALL_ACCESS_API_KEY=${UNEARTH_PROD_ALL_ACCESS_API_KEY:-${GARBO_PROD_ALL_ACCESS_API_KEY:-}}
 
 # Extract hostnames for Host header (required when using variable in proxy_pass)
 BACKEND_HOST=$(echo "$BACKEND_API_URL" | sed -E 's|^https?://||' | sed -E 's|/.*$||')
+UNEARTH_HOST=$(echo "$UNEARTH_API_URL" | sed -E 's|^https?://||' | sed -E 's|/.*$||')
 GARBO_HOST=$(echo "$GARBO_API_URL" | sed -E 's|^https?://||' | sed -E 's|/.*$||')
 
 export BACKEND_API_URL
 export BACKEND_HOST
+export UNEARTH_API_URL
+export UNEARTH_HOST
 export GARBO_API_URL
 export GARBO_HOST
+export UNEARTH_ALL_ACCESS_API_KEY
 export GARBO_ALL_ACCESS_API_KEY
-export GARBO_STAGE_ALL_ACCESS_API_KEY
-export GARBO_PROD_ALL_ACCESS_API_KEY
+export UNEARTH_STAGE_ALL_ACCESS_API_KEY
+export UNEARTH_PROD_ALL_ACCESS_API_KEY
 
-# Substitute environment variables in nginx config template
-envsubst '${BACKEND_API_URL} ${BACKEND_HOST} ${GARBO_API_URL} ${GARBO_HOST} ${GARBO_ALL_ACCESS_API_KEY} ${GARBO_STAGE_ALL_ACCESS_API_KEY} ${GARBO_PROD_ALL_ACCESS_API_KEY}' < /etc/nginx/templates/nginx.conf.template > /etc/nginx/conf.d/default.conf
+envsubst '${BACKEND_API_URL} ${BACKEND_HOST} ${UNEARTH_API_URL} ${UNEARTH_HOST} ${GARBO_API_URL} ${GARBO_HOST} ${UNEARTH_ALL_ACCESS_API_KEY} ${GARBO_ALL_ACCESS_API_KEY} ${UNEARTH_STAGE_ALL_ACCESS_API_KEY} ${UNEARTH_PROD_ALL_ACCESS_API_KEY}' < /etc/nginx/templates/nginx.conf.template > /etc/nginx/conf.d/default.conf
 
-# Start nginx
 exec nginx -g 'daemon off;'

--- a/docs/API_AND_PROXY_SETUP.md
+++ b/docs/API_AND_PROXY_SETUP.md
@@ -1,148 +1,100 @@
 # API and proxy setup
 
-This doc describes how the app talks to the **pipeline** and **garbo** backends in development and production, and how to switch between local, stage, and prod.
+How Validate talks to **pipeline**, **Unearth API**, and **Garbo monolith** in development and production.
 
 ## Overview
 
-- **Pipeline** – live job status (Redis), upload, pipeline batch listing, queues (validate/pipeline API).
-- **Garbo** – auth, crawler reports, companies, and **queue archive** (Postgres `ReportRun` / `ReportRunJob` history for Jobbstatus).
-- **Error browser** – always calls both garbo stage and garbo prod for comparison; no “target” setting.
+| Backend | Host (stage) | Browser path (deployed) |
+|---------|----------------|-------------------------|
+| **Pipeline API** | `stage-pipeline-api.klimatkollen.se` | `/api/…` |
+| **Unearth API** | `stage-api.unearthdata.ai` | `/unearth-api/…` |
+| **Garbo monolith** | `stage-api.klimatkollen.se` | `/garbo-api/queue-archive/…` only |
 
-In **development**, the Vite dev server proxies request paths to the right backend. The path you see in the **network tab** is the backend you’re hitting (e.g. `/pipeline-stage`, `/garbo-local`).
+- **Errors tab** – always compares Unearth stage and prod via `/unearth-stage-api/` and `/unearth-prod-api/` (ignores target).
 
-In **production**, the app uses full API URLs (garbo) or `/api` (pipeline); there is no Vite proxy.
+In **development**, Vite proxies same-origin paths (see network tab table below).
 
 ---
 
-## What you see in the network tab
+## Network tab paths (dev)
 
 | Path | Backend |
 |------|--------|
-| `/pipeline-local` | Pipeline on this machine (e.g. localhost:3001) |
-| `/pipeline-stage` | Stage pipeline API |
-| `/pipeline` | Prod pipeline API |
-| `/garbo-local` | Garbo on this machine (e.g. localhost:3000) |
-| `/garbo-stage` | Stage garbo API |
-| `/garbo` | Prod garbo API |
+| `/pipeline-local` | Pipeline on this machine |
+| `/pipeline-stage` | Stage pipeline |
+| `/pipeline` | Prod pipeline |
+| `/unearth-local` | Local API (Unearth; often localhost:3000) |
+| `/unearth-stage` | Stage Unearth |
+| `/unearth` | Prod Unearth |
+| `/garbo-local/api/queue-archive` | Local Garbo monolith |
+| `/garbo-stage/api/queue-archive` | Stage Garbo monolith |
+| `/garbo/api/queue-archive` | Prod Garbo monolith |
 
-So you can tell at a glance which pipeline and which garbo you’re using without opening `.env`.
+Deployed builds use `/unearth-api` and `/garbo-api/queue-archive` instead.
 
 ---
 
-## The three cases
+## Usage cases
 
-### 1. Error browser – always stage and prod
+### 1. Errors tab
 
-The Errors tab always fetches from **both** garbo stage and garbo prod (for comparison). It does not use the “garbo target” setting. Paths: `/garbo-stage/...` and `/garbo/...` (prod).
+Fetches **both** Unearth stage and prod. Paths: `/unearth-stage/…` (dev) or `/unearth-stage-api/…` (deployed), and `/unearth/…` or `/unearth-prod-api/…`.
 
-### 2. Garbo single target – auth, crawler, etc.
+### 2. Unearth target – auth, crawler, registry
 
-Auth, crawler (reports/list, etc.) and any other “single” garbo usage hit **one** garbo backend, chosen by your target. Default is **stage**. Overridable by env (see below). Path in network tab: `/garbo-local`, `/garbo-stage`, or `/garbo`.
+One Unearth backend from `VITE_UNEARTH_TARGET` (legacy: `VITE_GARBO_TARGET`). Helpers: `getUnearthApiBaseUrl()`, `getUnearthTarget()`.
 
-### 3. Pipeline single target – job status, upload, etc.
+### 3. Garbo monolith – queue archive
 
-Live swimlane data (companies, active jobs, reruns, approvals) uses **one** pipeline backend. Default is **stage**. Overridable by env. Path in network tab: `/pipeline-local`, `/pipeline-stage`, or `/pipeline`.
+Jobbstatus Archive, batch pickers, `POST /queue-archive/batches`. Helper: `getGarboQueueArchiveUrl()` → `/garbo-api/queue-archive/…` (deployed) or `/garbo-stage/api/queue-archive/…` (dev).
 
-### Jobbstatus: Live vs Archive (Garbo Postgres)
+Requires JWT from Unearth login (`garboAuthFetch`); monolith must share `JWT_SECRET` with Unearth.
 
-The **Jobbstatus** top-level tab has two in-app subtabs:
+### 4. Pipeline target – live job status
 
-| Subtab | Data source | Role |
-|--------|----------------|------|
-| **Live (Redis)** | Pipeline API | Real-time queues: swimlane, filters, rerun-by-worker, job details from Redis, approvals. Same target as section 3. |
-| **Archive** | Garbo API (`/queue-archive/…`) | Read-only history persisted when workers archive runs to Postgres. Uses the **same Garbo target** as auth/crawler (section 2). Requires a logged-in JWT (`garboAuthFetch`). |
+`getPipelineApiBaseUrl()` → `/pipeline-stage`, etc.
 
-**Archive HTTP paths** (under the chosen garbo proxy prefix, e.g. `/garbo-stage/queue-archive/…` in dev):
+---
 
-- `GET /queue-archive/batches` – batch dropdown (Garbo `Batch.id` + `batchName`).
-- `POST /queue-archive/batches` – body `{ "batchName": string }`; upserts by name and returns `{ batch: { id, batchName } }` so Validate can send **`id`** as pipeline `batchId`.
-- `GET /queue-archive/runs` – paginated list; optional query params: `q`, `page`, `pageSize`, **`batchDbId`** (exact Garbo `Batch.id`), **`batchName`** (exact legacy pipeline string still stored on some jobs).
-- `GET /queue-archive/runs/:threadId` – one run with jobs.
+## Jobbstatus Archive endpoints
 
-The app builds these URLs with **`getGarboQueueArchiveUrl()`** in `src/config/api-env.ts` (Garbo API base + `/queue-archive` + path).
+- `GET /queue-archive/batches`
+- `POST /queue-archive/batches` – `{ "batchName": string }`
+- `GET /queue-archive/runs`
+- `GET /queue-archive/runs/:threadId`
 
-**Batches:** New work from Validate uses **`Batch.id`** (cuid) as pipeline `job.data.batchId`. Garbo still accepts a legacy **`batchName`** string on that field for older Redis jobs. Upload / Registry / Jobbstatus batch pickers load rows from **`GET /queue-archive/batches`** (same Garbo target as auth).
-
-**Operational note:** Reruns and any mutating pipeline actions stay on **Live**; Archive does not drive the pipeline.
-
-**Jobbstatus URL:** the Live vs Archive subtab is reflected as `?source=live` (default, often omitted) or `?source=archive`. See [routing / URL state](./ROUTING_URL_STATE.md#jobbstatus-live-vs-archive).
+See [routing / URL state](./ROUTING_URL_STATE.md#jobbstatus-live-vs-archive).
 
 ---
 
 ## Environment variables
 
-Copy `.env.development.example` to `.env.development` or `.env.development.local` and uncomment or set what you need.
+See `.env.development.example`.
 
-### Joint override (sets both pipeline and garbo)
+| Variable | Purpose |
+|----------|---------|
+| `VITE_API_MODE` | Joint default for pipeline + Unearth/Garbo |
+| `VITE_UNEARTH_TARGET` | Unearth + Garbo archive target (`local` \| `stage` \| `prod`) |
+| `VITE_PIPELINE_TARGET` | Pipeline only |
+| `VITE_UNEARTH_STAGE_URL` | Override Unearth stage host |
+| `VITE_GARBO_STAGE_URL` | Override Garbo monolith stage host |
+| `UNEARTH_API_URL` | nginx → Unearth (includes `/api` suffix) |
+| `GARBO_API_URL` | nginx → Garbo monolith (includes `/api` suffix) |
+| `UNEARTH_ALL_ACCESS_API_KEY` | `/unearth-api/` |
+| `GARBO_ALL_ACCESS_API_KEY` | `/garbo-api/queue-archive/` |
 
-If you don’t set per-backend overrides, both pipeline and garbo use this:
-
-- `VITE_API_MODE=stage` (default)
-- `VITE_API_MODE=local`
-- `VITE_API_MODE=prod`
-
-### Per-backend overrides
-
-Override pipeline or garbo independently:
-
-- `VITE_PIPELINE_TARGET=local` | `stage` | `prod` – pipeline only
-- `VITE_GARBO_TARGET=local` | `stage` | `prod` – garbo only
-
-Example: pipeline to stage, garbo to local:
-
-```bash
-VITE_PIPELINE_TARGET=stage
-VITE_GARBO_TARGET=local
-```
-
-### URL overrides (optional)
-
-By default, local/stage/prod URLs are fixed. Garbo stage/prod default to unearthdata; pipeline stays on klimatkollen. To point at a different host:
-
-- Pipeline: `VITE_PIPELINE_API_URL`, `VITE_PIPELINE_STAGE_URL`, `VITE_PIPELINE_PROD_URL`
-- Garbo: `VITE_GARBO_LOCAL_URL`, `VITE_GARBO_STAGE_URL`, `VITE_GARBO_PROD_URL`
-- Screenshots: `VITE_SCREENSHOTS_API_URL`
+k8s Secret keys may still be named `GARBO_*` (see `k8s/base/deployment.yaml`).
 
 ---
 
-## How to use
+## Klimatkollen frontend origin
 
-1. **Set your targets** in `.env.development` or `.env.development.local` (e.g. `VITE_API_MODE=stage` or per-backend overrides).
-2. **Start the dev server**: `npm run dev`.
-3. **Check the terminal** – you’ll see which pipeline and garbo targets are active and their URLs.
-4. **Check the browser console** (DevTools) – on load you’ll see e.g. `[validate] garbo target: stage | pipeline target: stage`.
-5. **Check the network tab** – pipeline requests will show `/pipeline-local`, `/pipeline-stage`, or `/pipeline`; garbo requests will show `/garbo-local`, `/garbo-stage`, or `/garbo`.
-
-When you change `.env`, **restart the dev server** so the proxy and app config pick up the new values. Env is read when the dev server starts.
-
-**If garbo still hits stage when you set local:**  
-1. Use the exact variable **`VITE_GARBO_TARGET=local`** (not `GARBO_TARGET`; the `VITE_` prefix is required for the app to see it).  
-2. Put it in **`.env.development`** or **`.env.development.local`** in the project root (copy from `.env.development.example` if needed).  
-3. Restart the dev server (`npm run dev`).  
-4. In the browser console on load you should see `[validate] garbo target: local | pipeline target: ...`. In the network tab, garbo requests should go to `http://localhost:5173/garbo-local/...`.
-
----
-
-## Garbo: API base vs frontend origin
-
-Garbo uses two kinds of URLs (per garbo team):
-
-- **API base** (stage-api / api) – used for all backend calls (reports, companies, auth).  
-  Stage: `https://stage-api.unearthdata.ai`  
-  Prod: `https://api.unearthdata.ai`
-- **Frontend origin** (stage / klimatkollen) – used when the app needs to link to the Klimatkollen **web app** (e.g. “back to site” links, not API calls).  
-  Stage: `https://stage.klimatkollen.se`  
-  Prod: `https://klimatkollen.se`
-
-The app uses the API base for requests and the origin constants (`GARBO_STAGE_ORIGIN`, `GARBO_PROD_ORIGIN`) only where it needs to point users at the frontend app.
-
-In **production**, the app uses relative paths for both backends: `/api` (pipeline) and `/garbo-api` (Garbo). Nginx in the container proxies these to the backends (per `BACKEND_API_URL` and `GARBO_API_URL` in k8s), so the browser only talks to the same origin and CORS is not required. Stage vs prod is determined by the deployment overlay (staging vs production) setting those env vars. If you ever call Garbo from a different origin (e.g. Errors tab comparing stage and prod), CORS may be required and should be handled by the Garbo backend.
+`GARBO_STAGE_ORIGIN` / `GARBO_PROD_ORIGIN` – web app links only, not API hosts.
 
 ---
 
 ## Reference
 
-- **Config and helpers**: `src/config/api-env.ts` – `getPipelineTarget()`, `getGarboTarget()`, `getPipelineApiBaseUrl()`, `getPipelineUrl()`, `getGarboApiBaseUrl()`, `getGarboQueueArchiveUrl()`, `getStageGarboUrl()`, `getProdGarboUrl()`.
-- **Jobbstatus Archive UI**: `src/tabs/jobbstatus/components/JobbstatusArchivePanel.tsx`, `JobbstatusArchiveDetailDialog.tsx`, `JobbstatusArchiveRunCard.tsx`, `JobbstatusArchiveQueueAttemptsDialog.tsx`, `ArchiveQueueStepPill.tsx`; hook `useArchiveRunsList.ts`; lib `archive-types.ts`, `archive-filter-styles.ts`, `format-archive-datetime.ts`, `format-redis-retention-approx-duration.ts`, `archive-run-jobs.ts`.
-- **Proxy definition**: `vite.config.ts` – proxy targets and path rewrites.
-- **Example env**: `.env.development.example` – all supported variables and short comments.
+- `src/config/api-env.ts` – `getUnearthApiBaseUrl()`, `getGarboApiBaseUrl()`, `getGarboQueueArchiveUrl()`, `getStageUnearthUrl()`, `getProdUnearthUrl()`
+- `vite.config.ts` – dev proxies
+- `nginx.conf.template` – deployed proxies

--- a/docs/API_AND_PROXY_SETUP.md
+++ b/docs/API_AND_PROXY_SETUP.md
@@ -80,10 +80,9 @@ See `.env.development.example`.
 | `VITE_GARBO_STAGE_URL` | Override Garbo monolith stage host |
 | `UNEARTH_API_URL` | nginx → Unearth (includes `/api` suffix) |
 | `GARBO_API_URL` | nginx → Garbo monolith (includes `/api` suffix) |
-| `UNEARTH_ALL_ACCESS_API_KEY` | `/unearth-api/` |
-| `GARBO_ALL_ACCESS_API_KEY` | `/garbo-api/queue-archive/` |
-
-k8s Secret keys may still be named `GARBO_*` (see `k8s/base/deployment.yaml`).
+| `GARBO_ALL_ACCESS_API_KEY` | `/unearth-api/` (primary deployment target) |
+| `GARBO_STAGE_ALL_ACCESS_API_KEY` | `/unearth-stage-api/`, `/garbo-api/queue-archive/` |
+| `GARBO_PROD_ALL_ACCESS_API_KEY` | `/unearth-prod-api/` |
 
 ---
 

--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -21,22 +21,31 @@ spec:
             # Pipeline API (override in overlays for prod)
             - name: BACKEND_API_URL
               value: "https://stage-pipeline-api.klimatkollen.se"
-            # Garbo API - auth, companies, tag-options (override in overlays for prod)
-            - name: GARBO_API_URL
+            # Unearth HTTP API (override in overlays for prod)
+            - name: UNEARTH_API_URL
               value: "https://stage-api.unearthdata.ai/api"
-            # Garbo all-access API key - for non auth endpoints in garbo (e.g. /garbo-api/companies)
-            - name: GARBO_ALL_ACCESS_API_KEY
+            # Garbo monolith — queue-archive only
+            - name: GARBO_API_URL
+              value: "https://stage-api.klimatkollen.se/api"
+            # Unearth all-access key for /unearth-api/ (secret key name is legacy)
+            - name: UNEARTH_ALL_ACCESS_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: env
                   key: GARBO_ALL_ACCESS_API_KEY
-            # Keys for the fixed-host errors tab proxies (always stage + prod regardless of deployment)
-            - name: GARBO_STAGE_ALL_ACCESS_API_KEY
+            # Garbo monolith key for /garbo-api/queue-archive/
+            - name: GARBO_ALL_ACCESS_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: env
                   key: GARBO_STAGE_ALL_ACCESS_API_KEY
-            - name: GARBO_PROD_ALL_ACCESS_API_KEY
+            # Fixed-host errors tab (Unearth stage + prod)
+            - name: UNEARTH_STAGE_ALL_ACCESS_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: env
+                  key: GARBO_STAGE_ALL_ACCESS_API_KEY
+            - name: UNEARTH_PROD_ALL_ACCESS_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: env

--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -27,25 +27,19 @@ spec:
             # Garbo monolith — queue-archive only
             - name: GARBO_API_URL
               value: "https://stage-api.klimatkollen.se/api"
-            # Unearth all-access key for /unearth-api/ (secret key name is legacy)
-            - name: UNEARTH_ALL_ACCESS_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: env
-                  key: GARBO_ALL_ACCESS_API_KEY
-            # Garbo monolith key for /garbo-api/queue-archive/
+            # Garbo all-access API key - for /unearth-api/ (primary target: stage or prod per deployment)
             - name: GARBO_ALL_ACCESS_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: env
-                  key: GARBO_STAGE_ALL_ACCESS_API_KEY
-            # Fixed-host errors tab (Unearth stage + prod)
-            - name: UNEARTH_STAGE_ALL_ACCESS_API_KEY
+                  key: GARBO_ALL_ACCESS_API_KEY
+            # Keys for the fixed-host errors tab proxies (always stage + prod regardless of deployment)
+            - name: GARBO_STAGE_ALL_ACCESS_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: env
                   key: GARBO_STAGE_ALL_ACCESS_API_KEY
-            - name: UNEARTH_PROD_ALL_ACCESS_API_KEY
+            - name: GARBO_PROD_ALL_ACCESS_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: env

--- a/k8s/overlays/production/deployment-patch.yaml
+++ b/k8s/overlays/production/deployment-patch.yaml
@@ -14,13 +14,3 @@ spec:
               value: "https://api.unearthdata.ai/api"
             - name: GARBO_API_URL
               value: "https://api.klimatkollen.se/api"
-            - name: UNEARTH_ALL_ACCESS_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: env
-                  key: GARBO_ALL_ACCESS_API_KEY
-            - name: GARBO_ALL_ACCESS_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: env
-                  key: GARBO_PROD_ALL_ACCESS_API_KEY

--- a/k8s/overlays/production/deployment-patch.yaml
+++ b/k8s/overlays/production/deployment-patch.yaml
@@ -10,5 +10,17 @@ spec:
           env:
             - name: BACKEND_API_URL
               value: "https://pipeline-api.klimatkollen.se"
-            - name: GARBO_API_URL
+            - name: UNEARTH_API_URL
               value: "https://api.unearthdata.ai/api"
+            - name: GARBO_API_URL
+              value: "https://api.klimatkollen.se/api"
+            - name: UNEARTH_ALL_ACCESS_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: env
+                  key: GARBO_ALL_ACCESS_API_KEY
+            - name: GARBO_ALL_ACCESS_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: env
+                  key: GARBO_PROD_ALL_ACCESS_API_KEY

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -66,7 +66,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-API-Key ${UNEARTH_ALL_ACCESS_API_KEY};
+        proxy_set_header X-API-Key ${GARBO_ALL_ACCESS_API_KEY};
         proxy_cache_bypass $http_upgrade;
 
         proxy_connect_timeout 30s;
@@ -87,7 +87,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-API-Key ${UNEARTH_STAGE_ALL_ACCESS_API_KEY};
+        proxy_set_header X-API-Key ${GARBO_STAGE_ALL_ACCESS_API_KEY};
         proxy_cache_bypass $http_upgrade;
 
         proxy_connect_timeout 30s;
@@ -107,7 +107,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-API-Key ${UNEARTH_PROD_ALL_ACCESS_API_KEY};
+        proxy_set_header X-API-Key ${GARBO_PROD_ALL_ACCESS_API_KEY};
         proxy_cache_bypass $http_upgrade;
 
         proxy_connect_timeout 30s;

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -30,15 +30,13 @@ server {
         proxy_read_timeout 30s;
     }
 
-    # Safety: ensure /garbo-api (no trailing slash) doesn't fall through to the SPA.
-    # Client code should normally call /garbo-api/<endpoint>, which hits location /garbo-api/.
     location = /garbo-api {
         return 308 /garbo-api/;
     }
 
-    # Garbo API proxy - /garbo-api -> Garbo backend (auth, companies, tag-options, etc.)
-    location /garbo-api/ {
-        proxy_pass ${GARBO_API_URL}/;
+    # Garbo monolith: queue-archive only
+    location /garbo-api/queue-archive/ {
+        proxy_pass ${GARBO_API_URL}/queue-archive/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
@@ -54,13 +52,33 @@ server {
         proxy_read_timeout 30s;
     }
 
-    # Errors tab: proxy BOTH stage and prod garbo via same-origin paths to avoid CORS.
-    # These are intentionally fixed to the canonical hosts (not env-controlled).
-    location = /garbo-stage-api {
-        return 308 /garbo-stage-api/;
+    location = /unearth-api {
+        return 308 /unearth-api/;
     }
-    location /garbo-stage-api/ {
-        # Keep the incoming /api/... path intact (avoid /api/api/...).
+
+    # Unearth HTTP API: auth, companies, registry, tag-options, etc.
+    location /unearth-api/ {
+        proxy_pass ${UNEARTH_API_URL}/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host ${UNEARTH_HOST};
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-API-Key ${UNEARTH_ALL_ACCESS_API_KEY};
+        proxy_cache_bypass $http_upgrade;
+
+        proxy_connect_timeout 30s;
+        proxy_send_timeout 30s;
+        proxy_read_timeout 30s;
+    }
+
+    # Errors tab: fixed Unearth stage + prod (not env-controlled)
+    location = /unearth-stage-api {
+        return 308 /unearth-stage-api/;
+    }
+    location /unearth-stage-api/ {
         proxy_pass https://stage-api.unearthdata.ai/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
@@ -69,7 +87,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-API-Key ${GARBO_STAGE_ALL_ACCESS_API_KEY};
+        proxy_set_header X-API-Key ${UNEARTH_STAGE_ALL_ACCESS_API_KEY};
         proxy_cache_bypass $http_upgrade;
 
         proxy_connect_timeout 30s;
@@ -77,11 +95,10 @@ server {
         proxy_read_timeout 30s;
     }
 
-    location = /garbo-prod-api {
-        return 308 /garbo-prod-api/;
+    location = /unearth-prod-api {
+        return 308 /unearth-prod-api/;
     }
-    location /garbo-prod-api/ {
-        # Keep the incoming /api/... path intact (avoid /api/api/...).
+    location /unearth-prod-api/ {
         proxy_pass https://api.unearthdata.ai/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
@@ -90,7 +107,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-API-Key ${GARBO_PROD_ALL_ACCESS_API_KEY};
+        proxy_set_header X-API-Key ${UNEARTH_PROD_ALL_ACCESS_API_KEY};
         proxy_cache_bypass $http_upgrade;
 
         proxy_connect_timeout 30s;
@@ -104,7 +121,6 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
-        # Set Host header to backend hostname (required when using variable in proxy_pass)
         proxy_set_header Host ${BACKEND_HOST};
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -120,14 +136,12 @@ server {
     location / {
         try_files $uri $uri/ /index.html;
         
-        # Cache static assets
         location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
             expires 1y;
             add_header Cache-Control "public, immutable";
         }
     }
 
-    # Health check endpoint
     location /health {
         access_log off;
         return 200 "healthy\n";

--- a/src/config/api-env.ts
+++ b/src/config/api-env.ts
@@ -1,20 +1,24 @@
 /**
- * API config: pipeline + garbo, with env overrides.
+ * API config: pipeline, Unearth HTTP API, and Garbo monolith (queue-archive).
  *
- * Dev: Vite proxy. Pipeline: /pipeline-local, /pipeline-stage, /pipeline. Garbo: /garbo-local, /garbo-stage, /garbo.
- * Prod: relative paths. Pipeline: /api. Garbo: /garbo-api. Both are proxied by nginx in the deployment (BACKEND_API_URL, GARBO_API_URL).
- * Env: VITE_API_MODE (joint), VITE_PIPELINE_TARGET, VITE_GARBO_TARGET. Default: stage.
+ * Dev proxies: /pipeline-*, /unearth-*, /garbo-* (see docs/API_AND_PROXY_SETUP.md).
+ * Deployed: /api (pipeline), /unearth-api (Unearth), /garbo-api (Garbo monolith queue-archive only).
+ * Env: VITE_API_MODE, VITE_PIPELINE_TARGET, VITE_UNEARTH_TARGET (legacy: VITE_GARBO_TARGET).
  */
 
 export type ApiTarget = "local" | "stage" | "prod";
 
-// Frontend app origin (where the FE is served). Use for redirects, "back to site" links, etc.
+/** Klimatkollen web app (not an API host). Used for “back to site” links. */
 export const GARBO_STAGE_ORIGIN = "https://stage.klimatkollen.se";
 export const GARBO_PROD_ORIGIN = "https://klimatkollen.se";
 
-// API base origin (backend the FE calls). Used here for prod URLs; vite.config imports for dev proxy.
-export const GARBO_STAGE_API = "https://stage-api.unearthdata.ai";
-export const GARBO_PROD_API = "https://api.unearthdata.ai";
+/** Unearth HTTP API hosts (auth, companies, registry, …). */
+export const UNEARTH_STAGE_API = "https://stage-api.unearthdata.ai";
+export const UNEARTH_PROD_API = "https://api.unearthdata.ai";
+
+/** Garbo monolith hosts (workers, Postgres queue-archive). */
+export const GARBO_STAGE_API = "https://stage-api.klimatkollen.se";
+export const GARBO_PROD_API = "https://api.klimatkollen.se";
 
 function jointMode(): ApiTarget {
   const v = import.meta.env.VITE_API_MODE as string | undefined;
@@ -34,9 +38,23 @@ export function getPipelineTarget(): ApiTarget {
   return jointMode();
 }
 
-// --- Pipeline (single target: job status, upload, etc.) ---
+/** Unearth API target (auth, crawler, registry, …). */
+export function getUnearthTarget(): ApiTarget {
+  const v =
+    (import.meta.env.VITE_UNEARTH_TARGET as string | undefined) ??
+    (import.meta.env.VITE_GARBO_TARGET as string | undefined);
+  if (v === "local" || v === "stage" || v === "prod") return v;
+  return jointMode();
+}
 
-/** Pipeline API base URL. Dev: /pipeline-local (this machine), /pipeline-stage, or /pipeline (prod). Prod: /api. No trailing slash. */
+/** Garbo monolith target (queue-archive). Same selector as {@link getUnearthTarget}. */
+export function getGarboTarget(): ApiTarget {
+  return getUnearthTarget();
+}
+
+// --- Pipeline ---
+
+/** Pipeline API base URL. Dev: /pipeline-local, /pipeline-stage, or /pipeline. Prod: /api. */
 export function getPipelineApiBaseUrl(): string {
   const target = getPipelineTarget();
   if (import.meta.env.DEV) {
@@ -47,32 +65,30 @@ export function getPipelineApiBaseUrl(): string {
   return "/api";
 }
 
-/** Pipeline URL for a path (e.g. /processes/batches). No trailing slash on result. */
 export function getPipelineUrl(path: string): string {
   const p = (path.startsWith("/") ? path : `/${path}`).replace(/\/+$/, "");
   return getPipelineApiBaseUrl() + p;
 }
 
-/**
- * Garbo internal queue archive API (Postgres `ReportRun` / jobs) for Validate Jobbstatus.
- * Example: `/queue-archive/runs` appended after {@link getGarboApiBaseUrl} (auth required).
- */
-export function getGarboQueueArchiveUrl(path: string): string {
-  const base = getGarboApiBaseUrl().replace(/\/+$/, "");
-  const p = (path.startsWith("/") ? path : `/${path}`).replace(/\/+$/, "");
-  return `${base}/queue-archive${p}`;
+// --- Unearth API ---
+
+/** Unearth API base. Dev: /unearth-stage/api, etc. Prod: /unearth-api. No trailing slash. */
+export function getUnearthApiBaseUrl(): string {
+  const target = getUnearthTarget();
+  let url: string;
+  if (import.meta.env.DEV) {
+    if (target === "prod") url = "/unearth/api";
+    else if (target === "local") url = "/unearth-local/api";
+    else url = "/unearth-stage/api";
+  } else {
+    url = "/unearth-api";
+  }
+  return url.replace(/\/+$/, "");
 }
 
-/** Garbo target. Used for all garbo URLs (auth, crawler, etc.). */
-export function getGarboTarget(): ApiTarget {
-  const v = import.meta.env.VITE_GARBO_TARGET as string | undefined;
-  if (v === "local" || v === "stage" || v === "prod") return v;
-  return jointMode();
-}
+// --- Garbo monolith (queue-archive only) ---
 
-// --- Garbo (single target: auth, crawler, etc.) ---
-
-/** Garbo base URL (auth = base + "/auth", etc.). Dev: /garbo-local, /garbo-stage, or /garbo (Vite proxy). Prod: /garbo-api (proxied by ingress/nginx). No trailing slash. */
+/** Garbo monolith base. Dev: /garbo-stage/api, etc. Prod: /garbo-api. No trailing slash. */
 export function getGarboApiBaseUrl(): string {
   const target = getGarboTarget();
   let url: string;
@@ -81,26 +97,38 @@ export function getGarboApiBaseUrl(): string {
     else if (target === "local") url = "/garbo-local/api";
     else url = "/garbo-stage/api";
   } else {
-    // Production: use relative path; nginx/k8s proxies /garbo-api to Garbo (stage or prod per deployment).
     url = "/garbo-api";
   }
   return url.replace(/\/+$/, "");
 }
 
-// --- Error browser: always stage + prod (no target) ---
-
-/** Garbo stage API URL. Use for comparison only (errors tab). Path e.g. /api/companies. No trailing slash. */
-export function getStageGarboUrl(path: string): string {
+/** Queue-archive paths on the Garbo monolith (`/api/queue-archive/…` on the server). */
+export function getGarboQueueArchiveUrl(path: string): string {
+  const base = getGarboApiBaseUrl().replace(/\/+$/, "");
   const p = (path.startsWith("/") ? path : `/${path}`).replace(/\/+$/, "");
-  if (import.meta.env.DEV) return `/garbo-stage${p}`;
-  // Production: go via same-origin nginx proxy to avoid CORS.
-  return `/garbo-stage-api${p}`;
+  return `${base}/queue-archive${p}`;
 }
 
-/** Garbo prod API URL. Use for comparison (errors tab) or prod-only (e.g. company reference). Path e.g. /api/companies. No trailing slash. */
-export function getProdGarboUrl(path: string): string {
+// --- Errors tab: fixed Unearth stage + prod (ignores target) ---
+
+export function getStageUnearthUrl(path: string): string {
   const p = (path.startsWith("/") ? path : `/${path}`).replace(/\/+$/, "");
-  if (import.meta.env.DEV) return `/garbo${p}`;
-  // Production: go via same-origin nginx proxy to avoid CORS.
-  return `/garbo-prod-api${p}`;
+  if (import.meta.env.DEV) return `/unearth-stage${p}`;
+  return `/unearth-stage-api${p}`;
+}
+
+export function getProdUnearthUrl(path: string): string {
+  const p = (path.startsWith("/") ? path : `/${path}`).replace(/\/+$/, "");
+  if (import.meta.env.DEV) return `/unearth${p}`;
+  return `/unearth-prod-api${p}`;
+}
+
+/** @deprecated Use {@link getStageUnearthUrl} */
+export function getStageGarboUrl(path: string): string {
+  return getStageUnearthUrl(path);
+}
+
+/** @deprecated Use {@link getProdUnearthUrl} */
+export function getProdGarboUrl(path: string): string {
+  return getProdUnearthUrl(path);
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -966,6 +966,8 @@
     "addEntryDescription": "Manually register a report URL. Source URL is pre-filled from the report URL and can be adjusted.",
     "addEntrySuccess": "Registry entry added.",
     "addEntryError": "Could not add registry entry: {{message}}",
+    "editReportSuccess": "Registry entry updated.",
+    "editReportError": "Could not update registry entry: {{message}}",
     "companyNameRequired": "Company name is required",
     "reportYearRequired": "Report year is required"
   },

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -966,6 +966,8 @@
     "addEntryDescription": "Registrera en rapport-URL manuellt. Käll-URL fylls i från rapport-URL och kan justeras.",
     "addEntrySuccess": "Registerpost tillagd.",
     "addEntryError": "Kunde inte lägga till registerpost: {{message}}",
+    "editReportSuccess": "Registerpost uppdaterad.",
+    "editReportError": "Kunde inte uppdatera registerpost: {{message}}",
     "companyNameRequired": "Företagsnamn krävs",
     "reportYearRequired": "Rapportår krävs"
   },

--- a/src/lib/auth-api.ts
+++ b/src/lib/auth-api.ts
@@ -1,12 +1,12 @@
 /**
- * Auth API client (garbo base + /auth). Follows garbo target (VITE_GARBO_TARGET or VITE_API_MODE).
+ * Auth API client (Unearth base + /auth). Follows VITE_UNEARTH_TARGET or VITE_API_MODE.
  */
 
 import axios from "axios";
-import { getGarboApiBaseUrl } from "@/config/api-env";
+import { getUnearthApiBaseUrl } from "@/config/api-env";
 
 export const authApi = axios.create({
-  baseURL: getGarboApiBaseUrl() + "/auth",
+  baseURL: getUnearthApiBaseUrl() + "/auth",
   headers: {
     Accept: "application/json",
     "Content-Type": "application/json",
@@ -44,6 +44,6 @@ function getCallbackUrl(): string {
 export function getGithubAuthUrl(): string {
   const callbackUrl = getCallbackUrl();
   const redirectUri = encodeURIComponent(callbackUrl);
-  const base = getGarboApiBaseUrl() + "/auth";
+  const base = getUnearthApiBaseUrl() + "/auth";
   return `${base}/github?redirect_uri=${redirectUri}`;
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,11 +4,11 @@ import App from './App.tsx';
 import './index.css';
 import { BrowserRouter } from 'react-router-dom';
 import { I18nProvider } from '@/contexts/I18nContext';
-import { getGarboTarget, getPipelineTarget } from '@/config/api-env';
+import { getPipelineTarget, getUnearthTarget } from '@/config/api-env';
 
 // Dev: show active API targets in console
 if (import.meta.env.DEV) {
-  console.log("[validate] garbo target:", getGarboTarget(), "| pipeline target:", getPipelineTarget());
+  console.log("[validate] unearth target:", getUnearthTarget(), "| pipeline target:", getPipelineTarget());
 }
 
 createRoot(document.getElementById('root')!).render(

--- a/src/tabs/api-access/lib/api-access-api.ts
+++ b/src/tabs/api-access/lib/api-access-api.ts
@@ -1,4 +1,4 @@
-import { getGarboApiBaseUrl } from "@/config/api-env";
+import { getUnearthApiBaseUrl } from "@/config/api-env";
 import { garboAuthFetch, throwIfAuthError } from "@/lib/garbo-auth-fetch";
 import {
   clientApiKeyListSchema,
@@ -16,7 +16,7 @@ import {
 export { ApiAuthError } from "@/lib/garbo-auth-fetch";
 
 function apiAccessUrl(path: string): string {
-  const base = getGarboApiBaseUrl();
+  const base = getUnearthApiBaseUrl();
   const segment = path.replace(/^\//, "").replace(/\/+$/, "");
   const url = segment ? `${base}/${segment}` : base;
   return url.replace(/\/+$/, "");

--- a/src/tabs/crawler/lib/crawler-api.ts
+++ b/src/tabs/crawler/lib/crawler-api.ts
@@ -1,4 +1,4 @@
-import { getGarboApiBaseUrl } from "@/config/api-env";
+import { getUnearthApiBaseUrl } from "@/config/api-env";
 import type {
   crawlerSearchQuery,
   SaveReportsListResponse,
@@ -6,10 +6,10 @@ import type {
 } from "./crawler-types";
 import { garboAuthFetch } from "@/lib/garbo-auth-fetch";
 
-/** Crawler uses garbo API only. Base follows VITE_GARBO_TARGET / VITE_API_MODE. */
+/** Crawler uses Unearth API. Base follows VITE_UNEARTH_TARGET / VITE_API_MODE. */
 
 export function reportsUrl(path: string): string {
-  const base = getGarboApiBaseUrl();
+  const base = getUnearthApiBaseUrl();
   const segment = path.replace(/^\//, "").replace(/\/+$/, "");
   const url = segment ? `${base}/${segment}` : base;
   return url.replace(/\/+$/, "");

--- a/src/tabs/editor/EditorTab.tsx
+++ b/src/tabs/editor/EditorTab.tsx
@@ -3,7 +3,7 @@ import { motion } from "framer-motion";
 import { useNavigate, useParams } from "react-router-dom";
 import { useI18n } from "@/contexts/I18nContext";
 import { ViewModePills } from "@/ui/view-mode-pills";
-import { getGarboTarget } from "@/config/api-env";
+import { getUnearthTarget } from "@/config/api-env";
 import { ManageTagOptions } from "./components/tag-options/ManageTagOptions";
 import { MultiCompanyView } from "./components/multi-company/MultiCompanyView";
 import { SingleCompanyView } from "./components/single-company/SingleCompanyView";
@@ -64,7 +64,7 @@ export function EditorTab() {
           <div className="text-sm text-gray-01 font-medium">
             {t("editor.dataSourceLabel")}{" "}
             <span className="ml-1 inline-flex items-center rounded-full border border-gray-03 bg-gray-04 px-2 py-0.5 text-xs font-semibold text-gray-01">
-              {getGarboTarget().toUpperCase()}
+              {getUnearthTarget().toUpperCase()}
             </span>
           </div>
         </div>

--- a/src/tabs/editor/lib/api-utils.ts
+++ b/src/tabs/editor/lib/api-utils.ts
@@ -1,6 +1,6 @@
-import { getGarboApiBaseUrl } from "@/config/api-env";
+import { getUnearthApiBaseUrl } from "@/config/api-env";
 
-const BASE = getGarboApiBaseUrl();
+const BASE = getUnearthApiBaseUrl();
 
 export function apiUrl(path: string): string {
   const p = path.startsWith("/") ? path : `/${path}`;

--- a/src/tabs/errors/lib/api.ts
+++ b/src/tabs/errors/lib/api.ts
@@ -1,14 +1,14 @@
 /**
  * Errors tab: always stage + prod garbo (comparison).
  */
-import { getStageGarboUrl, getProdGarboUrl } from "@/config/api-env";
+import { getStageUnearthUrl, getProdUnearthUrl } from "@/config/api-env";
 
 const COMPANIES_PATH = "/api/companies";
 
 export function getStageApiUrl(): string {
-  return getStageGarboUrl(COMPANIES_PATH);
+  return getStageUnearthUrl(COMPANIES_PATH);
 }
 
 export function getProdApiUrl(): string {
-  return getProdGarboUrl(COMPANIES_PATH);
+  return getProdUnearthUrl(COMPANIES_PATH);
 }

--- a/src/tabs/jobbstatus/lib/company-reference-api.ts
+++ b/src/tabs/jobbstatus/lib/company-reference-api.ts
@@ -1,5 +1,5 @@
 import React from "react";
-import { getProdGarboUrl } from "@/config/api-env";
+import { getProdUnearthUrl } from "@/config/api-env";
 
 /**
  * Shared API helpers for fetching company reference data (used by scope sections
@@ -11,7 +11,7 @@ export async function fetchCompanyById(
   signal: AbortSignal
 ): Promise<any> {
   const response = await fetch(
-    getProdGarboUrl(`/api/companies/${encodeURIComponent(companyId)}`),
+    getProdUnearthUrl(`/api/companies/${encodeURIComponent(companyId)}`),
     { signal }
   );
   if (!response.ok) throw new Error(`HTTP ${response.status}`);

--- a/src/tabs/registry/RegistryTab.tsx
+++ b/src/tabs/registry/RegistryTab.tsx
@@ -199,8 +199,11 @@ export function RegistryTab() {
           item.id === updatedEntry.id ? updatedEntry : item,
         ),
       );
+      toast.success(t("registry.editReportSuccess"));
     } catch (error) {
       console.error("Failed to edit registry entry", error);
+      const message = error instanceof Error ? error.message : String(error);
+      toast.error(t("registry.editReportError", { message }));
     } finally {
       setEditingReportIds((current) => current.filter((id) => id !== reportId));
     }

--- a/src/tabs/registry/lib/registry-api.ts
+++ b/src/tabs/registry/lib/registry-api.ts
@@ -1,4 +1,4 @@
-import { getGarboApiBaseUrl, getPipelineUrl } from "@/config/api-env";
+import { getUnearthApiBaseUrl, getPipelineUrl } from "@/config/api-env";
 import { authenticatedFetch } from "@/lib/api-helpers";
 import { garboAuthFetch, throwIfAuthError } from "@/lib/garbo-auth-fetch";
 import type {
@@ -9,7 +9,7 @@ import type {
 import { filterRegistryEntries } from "./registry-utils";
 
 function registryUrl(path: string): string {
-  const base = getGarboApiBaseUrl().replace(/\/+$/, "");
+  const base = getUnearthApiBaseUrl().replace(/\/+$/, "");
   const segment = path.replace(/^\//, "");
   return `${base}/${segment}`;
 }
@@ -178,9 +178,15 @@ export const editRegistryEntry = async (entry: RegistryEntryUpdate) => {
     });
 
     if (!response.ok) {
-      const errorMsg = `Failed to edit registry entry: ${response.status} ${response.statusText}`;
-      console.error(errorMsg);
-      throw new Error(errorMsg);
+      let message = `Failed to edit registry entry: ${response.status} ${response.statusText}`;
+      try {
+        const body = (await response.json()) as { message?: string };
+        if (body.message) message = body.message;
+      } catch {
+        // ignore non-JSON error bodies
+      }
+      console.error(message);
+      throw new Error(message);
     }
     const updatedEntry = (await response.json()) as RegistryEntry;
     return updatedEntry;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,20 +3,24 @@ import react from "@vitejs/plugin-react";
 import path from "path";
 import fs from "fs";
 import { fileURLToPath } from "url";
-import { GARBO_PROD_API, GARBO_STAGE_API } from "./src/config/api-env";
+import {
+  GARBO_PROD_API,
+  GARBO_STAGE_API,
+  UNEARTH_PROD_API,
+  UNEARTH_STAGE_API,
+} from "./src/config/api-env";
 
 // https://vitejs.dev/config/
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-/** Pipeline URLs and garbo "on this machine" backend. Garbo stage/prod from api-env. */
 const URLS_BY_TARGET = {
   pipeline: {
     local: "http://localhost:3001",
     stage: "https://stage-pipeline-api.klimatkollen.se",
     prod: "https://pipeline-api.klimatkollen.se",
   },
-  /** Garbo backend when target is local (garbo running on this machine, e.g. localhost:3000). */
-  garboBackendLocal: "http://localhost:3000",
+  /** Local API when target is local (Unearth and/or Garbo on this machine, e.g. localhost:3000). */
+  apiBackendLocal: "http://localhost:3000",
 } as const;
 
 function normalizeUrl(url: string): string {
@@ -32,15 +36,20 @@ function targetFromEnv(
   return v === "local" || v === "prod" ? v : "stage";
 }
 
-/** Resolve proxy targets from pipeline target and garbo target (joint or overrides). */
+function unearthTargetFromEnv(env: Record<string, string>, joint: string): "local" | "stage" | "prod" {
+  const v = env.VITE_UNEARTH_TARGET || env.VITE_GARBO_TARGET || env.VITE_API_MODE || joint;
+  return v === "local" || v === "prod" ? v : "stage";
+}
+
+/** Resolve proxy targets from pipeline and Unearth/Garbo targets (joint or overrides). */
 function getProxyTargets(env: Record<string, string>) {
   const joint = env.VITE_API_MODE || "stage";
   const pipelineTarget = targetFromEnv(env, "VITE_PIPELINE_TARGET", joint);
-  const garboTarget = targetFromEnv(env, "VITE_GARBO_TARGET", joint);
+  const unearthTarget = unearthTargetFromEnv(env, joint);
 
   return {
     pipelineTarget,
-    garboTarget,
+    unearthTarget,
     pipelineLocal: normalizeUrl(
       env.VITE_PIPELINE_API_URL ?? URLS_BY_TARGET.pipeline.local,
     ),
@@ -53,10 +62,14 @@ function getProxyTargets(env: Record<string, string>) {
     screenshots: normalizeUrl(
       env.VITE_SCREENSHOTS_API_URL ?? "http://localhost:3000",
     ),
-    garboProd: normalizeUrl(env.VITE_GARBO_PROD_URL ?? GARBO_PROD_API),
+    unearthStage: normalizeUrl(env.VITE_UNEARTH_STAGE_URL ?? UNEARTH_STAGE_API),
+    unearthProd: normalizeUrl(env.VITE_UNEARTH_PROD_URL ?? UNEARTH_PROD_API),
     garboStage: normalizeUrl(env.VITE_GARBO_STAGE_URL ?? GARBO_STAGE_API),
-    garboBackendLocal: normalizeUrl(
-      env.VITE_GARBO_LOCAL_URL ?? URLS_BY_TARGET.garboBackendLocal,
+    garboProd: normalizeUrl(env.VITE_GARBO_PROD_URL ?? GARBO_PROD_API),
+    apiBackendLocal: normalizeUrl(
+      env.VITE_UNEARTH_LOCAL_URL ??
+        env.VITE_GARBO_LOCAL_URL ??
+        URLS_BY_TARGET.apiBackendLocal,
     ),
   };
 }
@@ -167,10 +180,21 @@ function pipelineProxyConfigure(targetUrl: string) {
 
 // Proxy targets: .env.development or .env.development.example.
 
-function setGarboProxyApiKey(proxyReq: { setHeader: (n: string, v: string) => void }, key: string | undefined) {
+function setProxyApiKey(
+  proxyReq: { setHeader: (n: string, v: string) => void },
+  key: string | undefined,
+) {
   if (key) {
     proxyReq.setHeader("X-API-Key", key);
   }
+}
+
+function unearthStageApiKey(env: Record<string, string>): string | undefined {
+  return env.UNEARTH_STAGE_ALL_ACCESS_API_KEY || env.GARBO_STAGE_ALL_ACCESS_API_KEY;
+}
+
+function unearthProdApiKey(env: Record<string, string>): string | undefined {
+  return env.UNEARTH_PROD_ALL_ACCESS_API_KEY || env.GARBO_PROD_ALL_ACCESS_API_KEY;
 }
 
 export default defineConfig(({ mode }) => {
@@ -190,12 +214,19 @@ export default defineConfig(({ mode }) => {
       pipelineUrl,
     );
     console.log(
-      "[vite] garbo target:",
-      urls.garboTarget,
+      "[vite] unearth target:",
+      urls.unearthTarget,
+      "->",
+      urls.unearthStage,
+      urls.unearthProd,
+    );
+    console.log(
+      "[vite] garbo (queue-archive) target:",
+      urls.unearthTarget,
       "->",
       urls.garboStage,
       urls.garboProd,
-      urls.garboBackendLocal,
+      urls.apiBackendLocal,
     );
   }
 
@@ -260,38 +291,71 @@ export default defineConfig(({ mode }) => {
           proxyTimeout: PROXY_TIMEOUT_MS,
           configure: pipelineProxyConfigure(urls.pipelineProd),
         },
-        // More specific first: /garbo-stage and /garbo-local (this machine) then /garbo (prod)
-        "/garbo-stage": {
+        "/garbo-stage/api/queue-archive": {
           target: urls.garboStage,
           changeOrigin: true,
-          secure: !urls.garboStage.startsWith("http://"),
+          secure: true,
           rewrite: (path) => path.replace(/^\/garbo-stage/, ""),
           timeout: PROXY_TIMEOUT_MS,
           proxyTimeout: PROXY_TIMEOUT_MS,
           configure: (proxy) => {
             proxy.on("proxyReq", (proxyReq) => {
-              setGarboProxyApiKey(proxyReq, env.GARBO_STAGE_ALL_ACCESS_API_KEY);
+              setProxyApiKey(proxyReq, unearthStageApiKey(env));
             });
           },
         },
-        "/garbo-local": {
-          target: urls.garboBackendLocal,
-          changeOrigin: true,
-          secure: !urls.garboBackendLocal.startsWith("http://"),
-          rewrite: (path) => path.replace(/^\/garbo-local/, ""),
-          timeout: PROXY_TIMEOUT_MS,
-          proxyTimeout: PROXY_TIMEOUT_MS,
-        },
-        "/garbo": {
+        "/garbo/api/queue-archive": {
           target: urls.garboProd,
           changeOrigin: true,
-          secure: !urls.garboProd.startsWith("http://"),
+          secure: true,
           rewrite: (path) => path.replace(/^\/garbo/, ""),
           timeout: PROXY_TIMEOUT_MS,
           proxyTimeout: PROXY_TIMEOUT_MS,
           configure: (proxy) => {
             proxy.on("proxyReq", (proxyReq) => {
-              setGarboProxyApiKey(proxyReq, env.GARBO_PROD_ALL_ACCESS_API_KEY);
+              setProxyApiKey(proxyReq, unearthProdApiKey(env));
+            });
+          },
+        },
+        "/garbo-local/api/queue-archive": {
+          target: urls.apiBackendLocal,
+          changeOrigin: true,
+          secure: !urls.apiBackendLocal.startsWith("http://"),
+          rewrite: (path) => path.replace(/^\/garbo-local/, ""),
+          timeout: PROXY_TIMEOUT_MS,
+          proxyTimeout: PROXY_TIMEOUT_MS,
+        },
+        "/unearth-stage": {
+          target: urls.unearthStage,
+          changeOrigin: true,
+          secure: !urls.unearthStage.startsWith("http://"),
+          rewrite: (path) => path.replace(/^\/unearth-stage/, ""),
+          timeout: PROXY_TIMEOUT_MS,
+          proxyTimeout: PROXY_TIMEOUT_MS,
+          configure: (proxy) => {
+            proxy.on("proxyReq", (proxyReq) => {
+              setProxyApiKey(proxyReq, unearthStageApiKey(env));
+            });
+          },
+        },
+        "/unearth-local": {
+          target: urls.apiBackendLocal,
+          changeOrigin: true,
+          secure: !urls.apiBackendLocal.startsWith("http://"),
+          rewrite: (path) => path.replace(/^\/unearth-local/, ""),
+          timeout: PROXY_TIMEOUT_MS,
+          proxyTimeout: PROXY_TIMEOUT_MS,
+        },
+        "/unearth": {
+          target: urls.unearthProd,
+          changeOrigin: true,
+          secure: !urls.unearthProd.startsWith("http://"),
+          rewrite: (path) => path.replace(/^\/unearth/, ""),
+          timeout: PROXY_TIMEOUT_MS,
+          proxyTimeout: PROXY_TIMEOUT_MS,
+          configure: (proxy) => {
+            proxy.on("proxyReq", (proxyReq) => {
+              setProxyApiKey(proxyReq, unearthProdApiKey(env));
             });
           },
         },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -189,13 +189,6 @@ function setProxyApiKey(
   }
 }
 
-function unearthStageApiKey(env: Record<string, string>): string | undefined {
-  return env.UNEARTH_STAGE_ALL_ACCESS_API_KEY || env.GARBO_STAGE_ALL_ACCESS_API_KEY;
-}
-
-function unearthProdApiKey(env: Record<string, string>): string | undefined {
-  return env.UNEARTH_PROD_ALL_ACCESS_API_KEY || env.GARBO_PROD_ALL_ACCESS_API_KEY;
-}
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
@@ -300,7 +293,7 @@ export default defineConfig(({ mode }) => {
           proxyTimeout: PROXY_TIMEOUT_MS,
           configure: (proxy) => {
             proxy.on("proxyReq", (proxyReq) => {
-              setProxyApiKey(proxyReq, unearthStageApiKey(env));
+              setProxyApiKey(proxyReq, env.GARBO_STAGE_ALL_ACCESS_API_KEY);
             });
           },
         },
@@ -313,7 +306,7 @@ export default defineConfig(({ mode }) => {
           proxyTimeout: PROXY_TIMEOUT_MS,
           configure: (proxy) => {
             proxy.on("proxyReq", (proxyReq) => {
-              setProxyApiKey(proxyReq, unearthProdApiKey(env));
+              setProxyApiKey(proxyReq, env.GARBO_PROD_ALL_ACCESS_API_KEY);
             });
           },
         },
@@ -334,7 +327,7 @@ export default defineConfig(({ mode }) => {
           proxyTimeout: PROXY_TIMEOUT_MS,
           configure: (proxy) => {
             proxy.on("proxyReq", (proxyReq) => {
-              setProxyApiKey(proxyReq, unearthStageApiKey(env));
+              setProxyApiKey(proxyReq, env.GARBO_STAGE_ALL_ACCESS_API_KEY);
             });
           },
         },
@@ -355,7 +348,7 @@ export default defineConfig(({ mode }) => {
           proxyTimeout: PROXY_TIMEOUT_MS,
           configure: (proxy) => {
             proxy.on("proxyReq", (proxyReq) => {
-              setProxyApiKey(proxyReq, unearthProdApiKey(env));
+              setProxyApiKey(proxyReq, env.GARBO_PROD_ALL_ACCESS_API_KEY);
             });
           },
         },


### PR DESCRIPTION
### ✨ What’s Changed?

add back in the garbo api for the queue api endpoints, renamed the var and the api paths to fit the unearth and garbo name, and fix small bug in registry edit that did not give errors on save

### 🔎 Context

<!-- Link relevant tickets, Slack threads, data examples, screenshots, etc. -->

### ✅ Validation / Test Plan (if applicable)

<!-- How did you verify this works? Include commands + key scenarios. -->

- [x] Manual verification (describe below)
- [ ] Automated tests added/updated (or N/A)

### 📸 Screenshots / Screen recordings (if applicable)

<!-- Especially for editor/UI changes. Include before/after when useful. -->

### 💥 Impact (check all that apply)

- [x] **Docs updated** (README/docs)
- [x] **Routes/query params updated** (deep-links / URL state)
- [ ] **Breaking change**
- [ ] **Backfill/migration needed**
- [ ] **Data/validation behavior changed** (rules, units, rounding, derived calcs, defaults)
- [ ] **Visual or setup change only** (styling, ui, gh templates, etc)

### 📋 Checklist

- [x] PR title starts with an issue reference (e.g. `[#123] ...`) or uses a prefix like `[fix]` / `[feat]` / `[chore]`
- [x] Labels set (and milestone if relevant)
- [ ] I’ve verified the change locally (repro steps included above when non-trivial)
- [x] Any new env vars/config are documented (and safe defaults exist)
- [ ] Follow-ups created as issues (or N/A)

### 🛠 Related Issue

Closes #[issue-number] <!-- or: Related to #[issue-number] -->
