### PR TITLE
Migrate editor and errors tabs to internal company id.

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ In **staging/production**, nginx proxies `/unearth-api/` → `UNEARTH_API_URL` a
 
 For path names, env vars, and Jobbstatus live vs archive, see [API and proxy setup](./docs/API_AND_PROXY_SETUP.md).
 
+### Company editor routing
+
+The company editor uses **full internal UUID** in paths (`/editor/company/:id`). Staff API mutations also take `company.id` in path segments. Partner/integration **read** endpoints still accept Wikidata ID, full UUID, or 8-char prefix (legacy `/editor/company/Q123` bookmarks keep working).
+
+Public Klimatkollen links use `wikidataId` when present, otherwise the 8-char UUID prefix — see `src/lib/company-routing.ts` and [ROUTING_URL_STATE.md](./docs/ROUTING_URL_STATE.md).
+
 ## Development
 
 ### Project Structure

--- a/docs/ROUTING_URL_STATE.md
+++ b/docs/ROUTING_URL_STATE.md
@@ -28,7 +28,7 @@ Use path segments for:
 Use query params for:
 
 - **Tabs/subtabs inside a page**
-  - Example: `/editor/company/Q123?tab=emissions`
+  - Example: `/editor/company/a1b2c3d4-e5f6-7890-abcd-ef1234567890?tab=emissions` (full internal UUID; legacy `/editor/company/Q123` still resolves via read API)
 - **Filters and search**
   - Example: `?q=volvo&tags=auto,sweden&years=2023,2024`
 - **Sorting and paging**

--- a/src/lib/company-routing.ts
+++ b/src/lib/company-routing.ts
@@ -1,0 +1,14 @@
+/** Public Klimatkollen URL segment: prefer wikidataId, else 8-char UUID prefix. */
+export function getCompanyUrlSegment(company: {
+  id: string;
+  wikidataId?: string | null;
+}): string {
+  return company.wikidataId ?? company.id.split("-")[0];
+}
+
+export function getKlimatkollenCompanyPath(company: {
+  id: string;
+  wikidataId?: string | null;
+}): string {
+  return `https://klimatkollen.se/companies/${getCompanyUrlSegment(company)}`;
+}

--- a/src/tabs/crawler/components/CompaniesNamesResultItem.tsx
+++ b/src/tabs/crawler/components/CompaniesNamesResultItem.tsx
@@ -1,6 +1,6 @@
 import { CheckCircle2 } from "lucide-react";
 import { memo } from "react";
-import { GARBO_PROD_ORIGIN } from "@/config/api-env";
+import { getKlimatkollenCompanyPath } from "@/lib/company-routing";
 import { CompanyDetails } from "../lib/crawler-types";
 import { useI18n } from "@/contexts/I18nContext";
 
@@ -15,7 +15,7 @@ const CompaniesNamesResultItem = ({
   isSelected,
   onToggle,
 }: CompaniesNamesResultItemProps) => {
-  const { wikidataId, name, reportingPeriods } = companyDetails;
+  const { id, wikidataId, name, reportingPeriods } = companyDetails;
   const { t } = useI18n();
 
   const latestReportYear =
@@ -27,7 +27,7 @@ const CompaniesNamesResultItem = ({
         <div className="flex items-center justify-between gap-3">
           <div className="flex flex-col">
             <a
-              href={`${GARBO_PROD_ORIGIN}/companies/${wikidataId}`}
+              href={getKlimatkollenCompanyPath({ id, wikidataId })}
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/src/tabs/editor/components/multi-company/MultiCompanyTable.tsx
+++ b/src/tabs/editor/components/multi-company/MultiCompanyTable.tsx
@@ -10,7 +10,7 @@ export function MultiCompanyTable({
   selectedYear,
   allFilteredSelected,
   onToggleSelectAll,
-  selectedWikidataIds,
+  selectedCompanyIds,
   onToggleCompanySelection,
   actionLoading,
   onEdit,
@@ -19,8 +19,8 @@ export function MultiCompanyTable({
   selectedYear: string;
   allFilteredSelected: boolean;
   onToggleSelectAll: () => void;
-  selectedWikidataIds: Set<string>;
-  onToggleCompanySelection: (wikidataId: string) => void;
+  selectedCompanyIds: Set<string>;
+  onToggleCompanySelection: (companyId: string) => void;
   actionLoading: boolean;
   onEdit: (state: EditState) => void;
 }) {
@@ -70,16 +70,16 @@ export function MultiCompanyTable({
               : null;
             const scope1 = period?.emissions?.scope1?.total ?? null;
             const scope2 = getScope2Total(period);
-            const checked = selectedWikidataIds.has(c.wikidataId);
+            const checked = selectedCompanyIds.has(c.id);
 
             return (
-              <tr key={c.wikidataId} className="hover:bg-gray-04/50">
+              <tr key={c.id} className="hover:bg-gray-04/50">
                 <td className="w-10 px-2 py-3">
                   <label className="flex items-center justify-center cursor-pointer">
                     <input
                       type="checkbox"
                       checked={checked}
-                      onChange={() => onToggleCompanySelection(c.wikidataId)}
+                      onChange={() => onToggleCompanySelection(c.id)}
                       className="sr-only"
                       aria-label={t("editor.companies.select")}
                     />
@@ -100,7 +100,7 @@ export function MultiCompanyTable({
                     type="button"
                     onClick={() =>
                       onEdit({
-                        wikidataId: c.wikidataId,
+                        companyId: c.id,
                         companyName: c.name,
                         field: "tags",
                         currentValue: c.tags?.join(", ") ?? "",
@@ -132,7 +132,7 @@ export function MultiCompanyTable({
                         type="button"
                         onClick={() =>
                           onEdit({
-                            wikidataId: c.wikidataId,
+                            companyId: c.id,
                             companyName: c.name,
                             field: "reportURL",
                             year: Number(selectedYear),
@@ -154,7 +154,7 @@ export function MultiCompanyTable({
                         type="button"
                         onClick={() =>
                           onEdit({
-                            wikidataId: c.wikidataId,
+                            companyId: c.id,
                             companyName: c.name,
                             field: "scope1",
                             year: Number(selectedYear),
@@ -176,7 +176,7 @@ export function MultiCompanyTable({
                         type="button"
                         onClick={() =>
                           onEdit({
-                            wikidataId: c.wikidataId,
+                            companyId: c.id,
                             companyName: c.name,
                             field: "scope2",
                             year: Number(selectedYear),
@@ -198,7 +198,7 @@ export function MultiCompanyTable({
                           type="button"
                           onClick={() =>
                             onEdit({
-                              wikidataId: c.wikidataId,
+                              companyId: c.id,
                               companyName: c.name,
                               field: "scope1",
                               year: Number(selectedYear),

--- a/src/tabs/editor/components/multi-company/MultiCompanyView.tsx
+++ b/src/tabs/editor/components/multi-company/MultiCompanyView.tsx
@@ -25,10 +25,12 @@ function companyMatchesSearch(company: GarboCompanyListItem, query: string): boo
   const name = (company.name ?? "").toLowerCase();
   const wikidataId = (company.wikidataId ?? "").toLowerCase();
   const internalId = (company.id ?? "").toLowerCase();
+  const idPrefix = internalId.split("-")[0];
   return (
     name.includes(q) ||
     wikidataId.includes(q) ||
-    internalId.includes(q)
+    internalId.includes(q) ||
+    idPrefix.includes(q)
   );
 }
 
@@ -49,7 +51,7 @@ export function MultiCompanyView() {
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [actionLoading, setActionLoading] = useState(false);
   const [editState, setEditState] = useState<EditState | null>(null);
-  const [selectedWikidataIds, setSelectedWikidataIds] = useState<Set<string>>(new Set());
+  const [selectedCompanyIds, setSelectedCompanyIds] = useState<Set<string>>(new Set());
   const [bulkTagModalOpen, setBulkTagModalOpen] = useState(false);
 
   const filteredCompanies = useMemo(() => {
@@ -72,32 +74,32 @@ export function MultiCompanyView() {
     return filteredList;
   }, [companies, searchQuery, selectedYear, selectedTags]);
 
-  const toggleCompanySelection = useCallback((wikidataId: string) => {
-    setSelectedWikidataIds((prev) => {
+  const toggleCompanySelection = useCallback((companyId: string) => {
+    setSelectedCompanyIds((prev) => {
       const next = new Set(prev);
-      if (next.has(wikidataId)) next.delete(wikidataId);
-      else next.add(wikidataId);
+      if (next.has(companyId)) next.delete(companyId);
+      else next.add(companyId);
       return next;
     });
   }, []);
 
   const selectAllFiltered = useCallback(() => {
-    setSelectedWikidataIds(new Set(filteredCompanies.map((company) => company.wikidataId)));
+    setSelectedCompanyIds(new Set(filteredCompanies.map((company) => company.id)));
   }, [filteredCompanies]);
 
   const clearSelection = useCallback(() => {
-    setSelectedWikidataIds(new Set());
+    setSelectedCompanyIds(new Set());
   }, []);
 
   const allFilteredSelected =
     filteredCompanies.length > 0 &&
-    filteredCompanies.every((company) => selectedWikidataIds.has(company.wikidataId));
+    filteredCompanies.every((company) => selectedCompanyIds.has(company.id));
 
   const bulkTagInitialSelectedSlugs = useMemo(() => {
-    const selectedIds = Array.from(selectedWikidataIds);
+    const selectedIds = Array.from(selectedCompanyIds);
     if (selectedIds.length === 0) return [];
     const selectedCompanies = selectedIds
-      .map((id) => companies.find((c) => c.wikidataId === id))
+      .map((id) => companies.find((c) => c.id === id))
       .filter(Boolean) as GarboCompanyListItem[];
     if (selectedCompanies.length === 0) return [];
 
@@ -106,23 +108,23 @@ export function MultiCompanyView() {
     return firstTags.filter((slug) =>
       selectedCompanies.every((c) => (c.tags ?? []).includes(slug))
     );
-  }, [companies, selectedWikidataIds]);
+  }, [companies, selectedCompanyIds]);
 
   const handleBulkTagSubmit = useCallback(
     async (tags: string[]) => {
-      const selectedIds = Array.from(selectedWikidataIds);
+      const selectedIds = Array.from(selectedCompanyIds);
       setActionLoading(true);
       try {
         let success = 0;
         let failed = 0;
-        for (const wikidataId of selectedIds) {
-          const company = companies.find((listedCompany) => listedCompany.wikidataId === wikidataId);
+        for (const companyId of selectedIds) {
+          const company = companies.find((listedCompany) => listedCompany.id === companyId);
           if (!company) {
             failed++;
             continue;
           }
           try {
-            await updateCompany(wikidataId, { name: company.name, tags });
+            await updateCompany(companyId, { name: company.name, tags });
             success++;
           } catch {
             failed++;
@@ -132,7 +134,7 @@ export function MultiCompanyView() {
           toast.success(t("editor.companies.bulkUpdateTagsSuccess", { count: selectedIds.length }));
           setCompanies((prev) =>
             prev.map((company) =>
-              selectedWikidataIds.has(company.wikidataId) ? { ...company, tags } : company
+              selectedCompanyIds.has(company.id) ? { ...company, tags } : company
             )
           );
         } else {
@@ -142,7 +144,7 @@ export function MultiCompanyView() {
           );
         }
         setBulkTagModalOpen(false);
-        setSelectedWikidataIds(new Set());
+        setSelectedCompanyIds(new Set());
         await loadCompanies();
       } catch (error) {
         toast.error(error instanceof Error ? error.message : String(error));
@@ -151,7 +153,7 @@ export function MultiCompanyView() {
         setActionLoading(false);
       }
     },
-    [selectedWikidataIds, companies, t, loadCompanies, setCompanies]
+    [selectedCompanyIds, companies, t, loadCompanies, setCompanies]
   );
 
   const handleSaveEdit = useCallback(
@@ -164,14 +166,14 @@ export function MultiCompanyView() {
       try {
         if (editState.field === "tags") {
           const tags = parseTagSlugs(value);
-          await updateCompany(editState.wikidataId, {
+          await updateCompany(editState.companyId, {
             name: editState.companyName,
             tags,
           });
           toast.success(t("editor.tagOptions.updated"));
           setCompanies((prev) =>
             prev.map((company) =>
-              company.wikidataId === editState.wikidataId ? { ...company, tags } : company
+              company.id === editState.companyId ? { ...company, tags } : company
             )
           );
         } else if (
@@ -187,7 +189,7 @@ export function MultiCompanyView() {
           if (!reportingPeriodPayload) {
             throw new Error("Could not build reporting period payload.");
           }
-          await updateReportingPeriods(editState.wikidataId, {
+          await updateReportingPeriods(editState.companyId, {
             reportingPeriods: [reportingPeriodPayload],
             metadata: meta.source || meta.comment ? { source: meta.source, comment: meta.comment } : undefined,
           });
@@ -275,7 +277,7 @@ export function MultiCompanyView() {
       ) : (
         <>
           <MultiCompanySelectionBar
-            count={selectedWikidataIds.size}
+            count={selectedCompanyIds.size}
             onClear={clearSelection}
             onBulkUpdateTags={() => setBulkTagModalOpen(true)}
             bulkDisabled={actionLoading}
@@ -288,7 +290,7 @@ export function MultiCompanyView() {
             onToggleSelectAll={() =>
               allFilteredSelected ? clearSelection() : selectAllFiltered()
             }
-            selectedWikidataIds={selectedWikidataIds}
+            selectedCompanyIds={selectedCompanyIds}
             onToggleCompanySelection={toggleCompanySelection}
             actionLoading={actionLoading}
             onEdit={setEditState}
@@ -329,7 +331,7 @@ export function MultiCompanyView() {
       <BulkTagUpdateModal
         open={bulkTagModalOpen}
         onOpenChange={setBulkTagModalOpen}
-        companyCount={selectedWikidataIds.size}
+        companyCount={selectedCompanyIds.size}
         tagOptions={tagOptions}
         initialSelectedSlugs={bulkTagInitialSelectedSlugs}
         onSubmit={handleBulkTagSubmit}

--- a/src/tabs/editor/components/single-company/AddReportingPeriodFlow.tsx
+++ b/src/tabs/editor/components/single-company/AddReportingPeriodFlow.tsx
@@ -80,7 +80,7 @@ export function AddReportingPeriodFlow({
 
     setCreating(true);
     try {
-      await updateReportingPeriods(company.wikidataId, {
+      await updateReportingPeriods(company.id, {
         reportingPeriods: [
           {
             startDate,
@@ -89,7 +89,7 @@ export function AddReportingPeriodFlow({
           },
         ],
       });
-      const fresh = await getCompany(company.wikidataId);
+      const fresh = await getCompany(company.id);
       onSaved?.();
       const year = getPeriodYear({ startDate, endDate });
       if (!year) {

--- a/src/tabs/editor/components/single-company/CompanyDetailTab.tsx
+++ b/src/tabs/editor/components/single-company/CompanyDetailTab.tsx
@@ -69,7 +69,7 @@ export function CompanyDetailTab({
     setSubIndustryCode(company.industry?.subIndustryCode ?? "");
     setBaseYear(displayBaseYear(company.baseYear, dash));
   }, [
-    company.wikidataId,
+    company.id,
     company.name,
     company.lei,
     company.url,
@@ -95,7 +95,7 @@ export function CompanyDetailTab({
   const handleSaveCore = async (meta?: { comment?: string; source?: string }) => {
     setSavingCore(true);
     try {
-      await updateCompany(company.wikidataId, {
+      await updateCompany(company.id, {
         name,
         descriptions: [
           { language: "EN", text: descriptionEn },
@@ -128,7 +128,7 @@ export function CompanyDetailTab({
     setSavingIndustry(true);
     try {
       if (subIndustryCode) {
-        await updateCompanyIndustry(company.wikidataId, {
+        await updateCompanyIndustry(company.id, {
           industry: { subIndustryCode },
           metadata:
             meta?.comment?.trim() || meta?.source?.trim()
@@ -137,7 +137,7 @@ export function CompanyDetailTab({
         });
       }
       if (by != null) {
-        await updateCompanyBaseYear(company.wikidataId, {
+        await updateCompanyBaseYear(company.id, {
           baseYear: by,
           metadata:
             meta?.comment?.trim() || meta?.source?.trim()
@@ -254,7 +254,7 @@ export function CompanyDetailTab({
                   </label>
                   <input
                     type="text"
-                    value={company.wikidataId}
+                    value={company.id}
                     readOnly
                     className={inputClassName + " bg-gray-04/60 !max-w-none"}
                   />

--- a/src/tabs/editor/components/single-company/EconomyDataTab.tsx
+++ b/src/tabs/editor/components/single-company/EconomyDataTab.tsx
@@ -109,13 +109,13 @@ export function EconomyDataTab({
     visiblePeriods,
   } = useReportingPeriodColumnFilters<GarboReportingPeriodSummary & { id: string }>(
     periods,
-    company.wikidataId
+    company.id
   );
 
   useEffect(() => {
     setEdited({});
     setSaving(false);
-  }, [company.wikidataId]);
+  }, [company.id]);
 
   const setEditedField = (rpId: string, patch: Partial<EditedPeriodEconomy>) => {
     setEdited((prev) => ({
@@ -148,7 +148,7 @@ export function EconomyDataTab({
 
     setSaving(true);
     try {
-      await updateReportingPeriods(company.wikidataId, {
+      await updateReportingPeriods(company.id, {
         reportingPeriods: payloadPeriods,
         metadata:
           meta?.source?.trim() || meta?.comment?.trim()

--- a/src/tabs/editor/components/single-company/EmissionsDataTab.tsx
+++ b/src/tabs/editor/components/single-company/EmissionsDataTab.tsx
@@ -70,13 +70,13 @@ export function EmissionsDataTab({
     visiblePeriods,
   } = useReportingPeriodColumnFilters<GarboReportingPeriodSummary & { id: string }>(
     periods,
-    company.wikidataId
+    company.id
   );
 
   useEffect(() => {
     setEdited({});
     setSaving(false);
-  }, [company.wikidataId]);
+  }, [company.id]);
 
   const setEditedField = (rpId: string, patch: Partial<EditedPeriodEmissions>) => {
     setEdited((prev) => {
@@ -178,7 +178,7 @@ export function EmissionsDataTab({
 
     setSaving(true);
     try {
-      await updateReportingPeriods(company.wikidataId, {
+      await updateReportingPeriods(company.id, {
         reportingPeriods: payloadPeriods,
         metadata:
           meta?.source?.trim() || meta?.comment?.trim()

--- a/src/tabs/editor/components/single-company/ReportingPeriodQuickEditModal.tsx
+++ b/src/tabs/editor/components/single-company/ReportingPeriodQuickEditModal.tsx
@@ -62,12 +62,12 @@ export function ReportingPeriodQuickEditModal({
     if (!open) return;
     const controller = new AbortController();
     setLoadingDetail(true);
-    getCompany(company.wikidataId, controller.signal)
+    getCompany(company.id, controller.signal)
       .then((c) => setDetailCompany(c))
       .catch(() => setDetailCompany(null))
       .finally(() => setLoadingDetail(false));
     return () => controller.abort();
-  }, [open, company.wikidataId]);
+  }, [open, company.id]);
 
   const period: GarboReportingPeriodSummary | null = useMemo(() => {
     const periods = detailCompany?.reportingPeriods ?? company.reportingPeriods ?? [];
@@ -98,7 +98,7 @@ export function ReportingPeriodQuickEditModal({
     setSource("");
     setSaving(false);
     setShowAllScope3Categories(false);
-  }, [open, company.wikidataId, year, periodMatch?.startDate, periodMatch?.endDate]);
+  }, [open, company.id, year, periodMatch?.startDate, periodMatch?.endDate]);
 
   const setNullableEdit = (
     key: keyof ReportingPeriodQuickEditEdited,
@@ -149,7 +149,7 @@ export function ReportingPeriodQuickEditModal({
     setSaving(true);
     try {
       await updateReportingPeriods(
-        company.wikidataId,
+        company.id,
         buildReportingPeriodQuickEditPatch({
           period,
           edited,

--- a/src/tabs/editor/components/single-company/ReportingPeriodsDataTab.tsx
+++ b/src/tabs/editor/components/single-company/ReportingPeriodsDataTab.tsx
@@ -75,7 +75,7 @@ export function ReportingPeriodsDataTab({
     visiblePeriods,
   } = useReportingPeriodColumnFilters<
     GarboReportingPeriodSummary & { id: string }
-  >(periods, company.wikidataId);
+  >(periods, company.id);
 
   useEffect(() => {
     setEdited({});
@@ -83,7 +83,7 @@ export function ReportingPeriodsDataTab({
     setDeleteModalOpen(false);
     setDeletePeriodId(null);
     setIsDeletingPeriod(false);
-  }, [company.wikidataId]);
+  }, [company.id]);
 
   const periodPendingDelete = useMemo(
     () => periods.find((p) => p.id === deletePeriodId) ?? null,
@@ -173,7 +173,7 @@ export function ReportingPeriodsDataTab({
 
     setSaving(true);
     try {
-      await updateReportingPeriods(company.wikidataId, {
+      await updateReportingPeriods(company.id, {
         reportingPeriods: payloadPeriods,
         metadata:
           meta?.source?.trim() || meta?.comment?.trim()

--- a/src/tabs/editor/components/single-company/SingleCompanyOverviewTable.tsx
+++ b/src/tabs/editor/components/single-company/SingleCompanyOverviewTable.tsx
@@ -94,7 +94,7 @@ export function SingleCompanyOverviewTable({
               if (!open) onQuickEditChange(null);
             }}
             company={
-              list.companyList.find((x) => x.wikidataId === quickEdit.companyId)!
+              list.companyList.find((x) => x.id === quickEdit.companyId)!
             }
             year={quickEdit.year}
             onSaved={() => {
@@ -145,17 +145,19 @@ export function SingleCompanyOverviewTable({
           </DataTableHead>
           <DataTableBody>
             {list.sortedCompanies.map((c: GarboCompanyListItem) => {
-              const overview = list.companyOverviewById.get(c.wikidataId);
+              const overview = list.companyOverviewById.get(c.id);
               return (
                 <tr
-                  key={c.wikidataId}
-                  onClick={() => navigate(editorCompanyPath(c.wikidataId))}
+                  key={c.id}
+                  onClick={() => navigate(editorCompanyPath(c.id))}
                   className="hover:bg-gray-04/50 cursor-pointer text-gray-01 align-top"
                 >
                   <td className="px-4 py-3 font-medium">
                     <div className="flex flex-col">
                       <span>{c.name}</span>
-                      <span className="text-xs text-gray-02">{c.wikidataId}</span>
+                      <span className="text-xs text-gray-02">
+                        {c.wikidataId ?? c.id.split("-")[0]}
+                      </span>
                     </div>
                   </td>
                   <td className="px-4 py-3 text-gray-02">
@@ -180,7 +182,7 @@ export function SingleCompanyOverviewTable({
                             onClick={(e) => {
                               e.stopPropagation();
                               onQuickEditChange({
-                                companyId: c.wikidataId,
+                                companyId: c.id,
                                 year: p.year,
                               });
                             }}

--- a/src/tabs/editor/hooks/useSingleCompanyOverviewList.ts
+++ b/src/tabs/editor/hooks/useSingleCompanyOverviewList.ts
@@ -97,7 +97,7 @@ export function useSingleCompanyOverviewList() {
       ReturnType<typeof getCompanyVerificationOverview>
     >();
     companyList.forEach((c) => {
-      map.set(c.wikidataId, getCompanyVerificationOverview(c));
+      map.set(c.id, getCompanyVerificationOverview(c));
     });
     return map;
   }, [companyList]);

--- a/src/tabs/editor/lib/companies-api.ts
+++ b/src/tabs/editor/lib/companies-api.ts
@@ -120,13 +120,13 @@ export async function listCompanies(
     : [];
 }
 
-/** Get company detail by wikidataId (GET /api/companies/:wikidataId). Requires auth. */
+/** Get company detail (GET /api/internal-companies/:ref). ref: Q-id, full UUID, or 8-char prefix. */
 export async function getCompany(
-  wikidataId: string,
+  identifier: string,
   signal?: AbortSignal,
 ): Promise<GarboCompanyDetail> {
   const res = await garboAuthFetch(
-    apiUrl(internalCompaniesPath(encodeURIComponent(wikidataId))),
+    apiUrl(internalCompaniesPath(encodeURIComponent(identifier))),
     {
       method: "GET",
       headers: { Accept: "application/json" },
@@ -147,10 +147,42 @@ export async function getCompany(
   return normalizeCompany(data as GarboCompanyDetail);
 }
 
-/** Create or update company (POST /api/companies/:wikidataId). Body: name, descriptions, tags, internalComment, url, logoUrl, lei, metadata, verified. */
+/** Create company (POST /api/companies). */
+export async function createCompany(body: {
+  wikidataId?: string;
+  name: string;
+  descriptions?: Array<{ language: string; text: string; id?: string }>;
+  internalComment?: string;
+  tags?: string[];
+  url?: string;
+  logoUrl?: string | null;
+  lei?: string;
+  metadata?: GarboMetadata;
+  verified?: boolean;
+}): Promise<{ ok: boolean; id: string }> {
+  const res = await garboAuthFetch(apiUrl(companiesPath()), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+  if (res.status === 401) {
+    throw new Error("Please log in to create company.");
+  }
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Failed to create company: ${res.status} ${text}`);
+  }
+  return res.json();
+}
+
+/** Update company (POST /api/companies/:id). Body: name, descriptions, tags, etc. */
 export async function updateCompany(
-  wikidataId: string,
+  companyId: string,
   body: {
+    wikidataId?: string;
     name: string;
     descriptions?: Array<{ language: string; text: string; id?: string }>;
     internalComment?: string;
@@ -163,14 +195,14 @@ export async function updateCompany(
   },
 ): Promise<void> {
   const res = await garboAuthFetch(
-    apiUrl(companiesPath(encodeURIComponent(wikidataId))),
+    apiUrl(companiesPath(encodeURIComponent(companyId))),
     {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
         Accept: "application/json",
       },
-      body: JSON.stringify({ wikidataId, ...body }),
+      body: JSON.stringify(body),
     },
   );
   if (res.status === 401) {
@@ -190,9 +222,9 @@ export async function updateCompany(
   }
 }
 
-/** Create or update reporting periods and their emissions/economy (POST /api/companies/:wikidataId/reporting-periods). */
+/** Create or update reporting periods (POST /api/companies/:id/reporting-periods). */
 export async function updateReportingPeriods(
-  wikidataId: string,
+  companyId: string,
   body: {
     reportingPeriods: Array<{
       startDate: string;
@@ -209,7 +241,7 @@ export async function updateReportingPeriods(
 ): Promise<void> {
   const res = await garboAuthFetch(
     apiUrl(
-      companiesPath(`${encodeURIComponent(wikidataId)}/reporting-periods`),
+      companiesPath(`${encodeURIComponent(companyId)}/reporting-periods`),
     ),
     {
       method: "POST",
@@ -338,9 +370,9 @@ export async function fetchIndustryGics(
   return [];
 }
 
-/** Set company industry (POST /api/companies/:wikidataId/industry). */
+/** Set company industry (POST /api/companies/:id/industry). */
 export async function updateCompanyIndustry(
-  wikidataId: string,
+  companyId: string,
   body: {
     industry: { subIndustryCode: string };
     metadata?: GarboMetadata;
@@ -348,7 +380,7 @@ export async function updateCompanyIndustry(
   },
 ): Promise<void> {
   const res = await garboAuthFetch(
-    apiUrl(companiesPath(`${encodeURIComponent(wikidataId)}/industry`)),
+    apiUrl(companiesPath(`${encodeURIComponent(companyId)}/industry`)),
     {
       method: "POST",
       headers: {
@@ -366,13 +398,13 @@ export async function updateCompanyIndustry(
   }
 }
 
-/** Set company base year (POST /api/companies/:wikidataId/base-year). */
+/** Set company base year (POST /api/companies/:id/base-year). */
 export async function updateCompanyBaseYear(
-  wikidataId: string,
+  companyId: string,
   body: { baseYear: number; metadata?: GarboMetadata; verified?: boolean },
 ): Promise<void> {
   const res = await garboAuthFetch(
-    apiUrl(companiesPath(`${encodeURIComponent(wikidataId)}/base-year`)),
+    apiUrl(companiesPath(`${encodeURIComponent(companyId)}/base-year`)),
     {
       method: "POST",
       headers: {

--- a/src/tabs/editor/lib/companies-schemas.ts
+++ b/src/tabs/editor/lib/companies-schemas.ts
@@ -8,7 +8,7 @@ export const garboCompanyIdSchema = z.string().uuid();
 export const garboCompanyListItemSchema = z
   .object({
     id: garboCompanyIdSchema,
-    wikidataId: z.string().regex(WIKIDATA_ID_REGEX),
+    wikidataId: z.string().regex(WIKIDATA_ID_REGEX).nullable().optional(),
     name: z.string(),
     tags: z.array(z.string()).optional(),
     baseYear: z.unknown().optional(),

--- a/src/tabs/editor/lib/single-company-overview-list.ts
+++ b/src/tabs/editor/lib/single-company-overview-list.ts
@@ -27,10 +27,12 @@ export function companyMatchesSearch(
   const name = (company.name ?? "").toLowerCase();
   const wikidataId = (company.wikidataId ?? "").toLowerCase();
   const internalId = (company.id ?? "").toLowerCase();
+  const idPrefix = internalId.split("-")[0];
   return (
     name.includes(q) ||
     wikidataId.includes(q) ||
-    internalId.includes(q)
+    internalId.includes(q) ||
+    idPrefix.includes(q)
   );
 }
 
@@ -51,7 +53,7 @@ export function companyPassesOverviewFilters(
   c: GarboCompanyListItem,
   f: OverviewListFilterInput,
 ): boolean {
-  const overview = f.companyOverviewById.get(c.wikidataId);
+  const overview = f.companyOverviewById.get(c.id);
   if (!companyMatchesSearch(c, f.searchQuery)) return false;
   if (!companyMatchesTagFilter(c.tags, f.filterTags)) return false;
   if (!companyPassesExcludeTagFilter(c.tags, f.excludeFilterTags)) return false;

--- a/src/tabs/editor/lib/types.ts
+++ b/src/tabs/editor/lib/types.ts
@@ -33,7 +33,7 @@ export const WIKIDATA_ID_REGEX = /^Q\d+$/;
 export interface GarboCompanyListItem {
   /** Internal Garbo company id (CUID). */
   id: string;
-  wikidataId: string;
+  wikidataId?: string | null;
   name: string;
   tags?: string[];
   /** Present when list API includes base year (number or wrapped shape with metadata). */
@@ -146,7 +146,7 @@ export interface GarboMetadata {
 // --- Editor UI helper types ---
 
 export type EditState = {
-  wikidataId: string;
+  companyId: string;
   companyName: string;
   field: "tags" | "reportURL" | "scope1" | "scope2" | "economy";
   year?: number;

--- a/src/tabs/errors/components/BrowserView.tsx
+++ b/src/tabs/errors/components/BrowserView.tsx
@@ -3,6 +3,7 @@ import { XCircle, Download } from 'lucide-react';
 import { useI18n } from '@/contexts/I18nContext';
 import { LoadingSpinner } from '@/ui/loading-spinner';
 import { SingleSelectDropdown } from '@/ui/single-select-dropdown';
+import { getCompanyUrlSegment } from '@/lib/company-routing';
 import { DiscrepancyType, CompanyRow, DATA_POINTS } from '../types';
 import { computePerformanceMetrics, exportComparisonToCsv } from '../lib';
 import { CompanyTableRow } from './CompanyTableRow';
@@ -93,9 +94,12 @@ export function BrowserView({
     let rows = verifiedFilteredRows;
     if (searchQuery.trim()) {
       const query = searchQuery.toLowerCase();
-      rows = rows.filter(r =>
-        r.name.toLowerCase().includes(query) ||
-        r.wikidataId.toLowerCase().includes(query)
+      rows = rows.filter(
+        (r) =>
+          r.name.toLowerCase().includes(query) ||
+          r.id.toLowerCase().includes(query) ||
+          getCompanyUrlSegment(r).toLowerCase().includes(query) ||
+          (r.wikidataId?.toLowerCase().includes(query) ?? false)
       );
     }
     rows = rows.filter(r => visibleTypes.has(r.discrepancy));
@@ -221,7 +225,7 @@ export function BrowserView({
                 ) : (
                   filteredRows.map((row, index) => (
                     <CompanyTableRow
-                      key={row.wikidataId}
+                      key={row.id}
                       row={row}
                       index={index}
                       difficultCompanyIds={difficultCompanyIds}

--- a/src/tabs/errors/components/CompanyTableRow.tsx
+++ b/src/tabs/errors/components/CompanyTableRow.tsx
@@ -2,6 +2,7 @@ import { motion } from 'framer-motion';
 import { AlertTriangle, BadgeCheck } from 'lucide-react';
 import { useI18n } from '@/contexts/I18nContext';
 import { cn } from '@/lib/utils';
+import { getCompanyUrlSegment } from '@/lib/company-routing';
 import { CompanyRow } from '../types';
 import { DiscrepancyBadge } from './DiscrepancyBadge';
 
@@ -14,6 +15,7 @@ interface CompanyTableRowProps {
 export function CompanyTableRow({ row, index, difficultCompanyIds }: CompanyTableRowProps) {
   const { t, formatNumber } = useI18n();
   const isMissingCompany = !row.inStage || !row.inProd;
+  const displayId = getCompanyUrlSegment(row);
 
   return (
     <motion.tr
@@ -25,17 +27,17 @@ export function CompanyTableRow({ row, index, difficultCompanyIds }: CompanyTabl
       <td className="px-4 py-3">
         <div className="flex items-center gap-1.5 font-medium text-gray-01 text-sm">
           {row.name}
-          {difficultCompanyIds.has(row.wikidataId) && (
+          {difficultCompanyIds.has(row.id) && (
             <span
               className="text-red-400 cursor-help"
-              title={t("errors.difficultReportTooltip", { count: difficultCompanyIds.get(row.wikidataId) ?? 0 })}
+              title={t("errors.difficultReportTooltip", { count: difficultCompanyIds.get(row.id) ?? 0 })}
             >
               <AlertTriangle className="w-3.5 h-3.5" />
             </span>
           )}
         </div>
         <div className="flex items-center gap-2 mt-0.5">
-          <span className="text-xs text-gray-02">{row.wikidataId}</span>
+          <span className="text-xs text-gray-02">{displayId}</span>
           {isMissingCompany && (
             <span className="text-xs px-1.5 py-0.5 rounded bg-blue-500/20 text-blue-400">
               {!row.inStage ? t('errors.notInStage') : t('errors.notInProd')}

--- a/src/tabs/errors/components/HardestReportsView.tsx
+++ b/src/tabs/errors/components/HardestReportsView.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { motion } from 'framer-motion';
 import { Download } from 'lucide-react';
 import { useI18n } from '@/contexts/I18nContext';
+import { getCompanyUrlSegment } from '@/lib/company-routing';
 import { cn, downloadCsv } from '@/lib/utils';
 import { LoadingSpinner } from '@/ui/loading-spinner';
 import { DiscrepancyType, WorstCompany } from '../types';
@@ -16,7 +17,7 @@ interface HardestReportsViewProps {
 }
 
 function exportHardestReportsCsv(worstCompanies: WorstCompany[], selectedYear: number) {
-  const headers = ['Rank', 'Company', 'WikidataId', 'Errors', 'Total Data Points', 'Difficult', 'Error Types', 'Affected Data Points'];
+  const headers = ['Rank', 'Company', 'Identifier', 'Errors', 'Total Data Points', 'Difficult', 'Error Types', 'Affected Data Points'];
   const rows: string[][] = [headers];
 
   worstCompanies.forEach((company, index) => {
@@ -30,7 +31,7 @@ function exportHardestReportsCsv(worstCompanies: WorstCompany[], selectedYear: n
     rows.push([
       String(index + 1),
       `"${company.name.replace(/"/g, '""')}"`,
-      company.wikidataId,
+      getCompanyUrlSegment(company),
       String(company.errorCount),
       String(company.totalDataPoints),
       company.errorCount >= 5 ? 'yes' : 'no',
@@ -104,7 +105,7 @@ export function HardestReportsView({ isLoading, worstCompanies, totalWithBothRPs
                   </tr>
                 ) : (
                   worstCompanies.map((company, index) => (
-                    <HardestReportRow key={company.wikidataId} company={company} index={index} />
+                    <HardestReportRow key={company.id} company={company} index={index} />
                   ))
                 )}
               </tbody>
@@ -147,7 +148,7 @@ function HardestReportRow({ company, index }: { company: WorstCompany; index: nu
             </span>
           )}
         </div>
-        <div className="text-xs text-gray-02 mt-0.5">{company.wikidataId}</div>
+        <div className="text-xs text-gray-02 mt-0.5">{getCompanyUrlSegment(company)}</div>
       </td>
       <td className="px-4 py-3 text-center">
         <span className={cn(

--- a/src/tabs/errors/hooks/useErrorBrowserData.ts
+++ b/src/tabs/errors/hooks/useErrorBrowserData.ts
@@ -76,15 +76,15 @@ export function useErrorBrowserData(
       (tags ?? []).some((t) => selectedTags.includes(t));
 
     stageCompanies.forEach((c) => {
-      if (matches(c.tags)) idsWithSelectedTag.add(c.wikidataId);
+      if (matches(c.tags)) idsWithSelectedTag.add(c.id);
     });
     prodCompanies.forEach((c) => {
-      if (matches(c.tags)) idsWithSelectedTag.add(c.wikidataId);
+      if (matches(c.tags)) idsWithSelectedTag.add(c.id);
     });
 
     return {
-      stage: stageCompanies.filter((c) => idsWithSelectedTag.has(c.wikidataId)),
-      prod: prodCompanies.filter((c) => idsWithSelectedTag.has(c.wikidataId)),
+      stage: stageCompanies.filter((c) => idsWithSelectedTag.has(c.id)),
+      prod: prodCompanies.filter((c) => idsWithSelectedTag.has(c.id)),
     };
   }, [stageCompanies, prodCompanies, selectedTags]);
 
@@ -98,11 +98,11 @@ export function useErrorBrowserData(
 
     const prodCompanyVerifiedForYear = prodCompanyVerifiedForYearMap(prodMap, allIds);
 
-    for (const wikidataId of allIds) {
-      const stageCompany = stageMap.get(wikidataId);
-      const prodCompany = prodMap.get(wikidataId);
+    for (const companyId of allIds) {
+      const stageCompany = stageMap.get(companyId);
+      const prodCompany = prodMap.get(companyId);
 
-      const name = stageCompany?.name || prodCompany?.name || wikidataId;
+      const name = stageCompany?.name || prodCompany?.name || companyId;
       const tags = Array.from(
         new Set([...(stageCompany?.tags ?? []), ...(prodCompany?.tags ?? [])])
       );
@@ -119,13 +119,19 @@ export function useErrorBrowserData(
       const prodVerified = getDataPointVerified(prodRP?.emissions, selectedDataPoint);
 
       rows.push({
-        wikidataId, name, stageValue, prodValue, discrepancy, diff,
+        id: companyId,
+        wikidataId: stageCompany?.wikidataId ?? prodCompany?.wikidataId ?? null,
+        name,
+        stageValue,
+        prodValue,
+        discrepancy,
+        diff,
         tags,
         inStage: !!stageCompany,
         inProd: !!prodCompany,
         unitErrorFactor,
         prodVerified,
-        prodCompanyVerifiedForYear: prodCompanyVerifiedForYear.get(wikidataId) ?? false,
+        prodCompanyVerifiedForYear: prodCompanyVerifiedForYear.get(companyId) ?? false,
       });
     }
 
@@ -241,9 +247,9 @@ export function useErrorBrowserData(
         other => other.scope === dp.scope && other.id !== dp.id
       );
 
-      for (const wikidataId of allIds) {
-        const stageCompany = stageMap.get(wikidataId);
-        const prodCompany = prodMap.get(wikidataId);
+      for (const companyId of allIds) {
+        const stageCompany = stageMap.get(companyId);
+        const prodCompany = prodMap.get(companyId);
 
         if (!stageCompany || !prodCompany) continue;
 
@@ -259,7 +265,7 @@ export function useErrorBrowserData(
           const isVerified = getDataPointVerified(prodRP.emissions, dp.id);
           const isBothNull = stageValue === null && prodValue === null;
           const allowBothNull =
-            isBothNull && (prodCompanyVerifiedForYear.get(wikidataId) ?? false);
+            isBothNull && (prodCompanyVerifiedForYear.get(companyId) ?? false);
           if (!isVerified && !allowBothNull) continue;
         }
 
@@ -314,9 +320,9 @@ export function useErrorBrowserData(
 
     const prodCompanyVerifiedForYear = prodCompanyVerifiedForYearMap(prodMap, allIds);
 
-    for (const wikidataId of allIds) {
-      const stageCompany = stageMap.get(wikidataId);
-      const prodCompany = prodMap.get(wikidataId);
+    for (const companyId of allIds) {
+      const stageCompany = stageMap.get(companyId);
+      const prodCompany = prodMap.get(companyId);
 
       if (!stageCompany || !prodCompany) continue;
 
@@ -325,7 +331,7 @@ export function useErrorBrowserData(
 
       if (!stageRP || !prodRP) continue;
 
-      const name = stageCompany.name || prodCompany.name || wikidataId;
+      const name = stageCompany.name || prodCompany.name || companyId;
       let errorCount = 0;
       let totalDataPoints = 0;
       const breakdown: Record<string, number> = {};
@@ -339,7 +345,7 @@ export function useErrorBrowserData(
           const isVerified = getDataPointVerified(prodRP.emissions, dp.id);
           const isBothNull = stageValue === null && prodValue === null;
           const allowBothNull =
-            isBothNull && (prodCompanyVerifiedForYear.get(wikidataId) ?? false);
+            isBothNull && (prodCompanyVerifiedForYear.get(companyId) ?? false);
           if (!isVerified && !allowBothNull) continue;
         }
 
@@ -367,7 +373,15 @@ export function useErrorBrowserData(
       }
 
       if (errorCount > 0) {
-        companyErrors.push({ wikidataId, name, errorCount, totalDataPoints, breakdown, errorDataPoints });
+        companyErrors.push({
+          id: companyId,
+          wikidataId: stageCompany.wikidataId ?? prodCompany.wikidataId ?? null,
+          name,
+          errorCount,
+          totalDataPoints,
+          breakdown,
+          errorDataPoints,
+        });
       }
     }
 
@@ -378,7 +392,7 @@ export function useErrorBrowserData(
   const difficultCompanyIds = React.useMemo(() => {
     const ids = new Map<string, number>();
     for (const c of worstCompanies) {
-      if (c.errorCount >= 5) ids.set(c.wikidataId, c.errorCount);
+      if (c.errorCount >= 5) ids.set(c.id, c.errorCount);
     }
     return ids;
   }, [worstCompanies]);

--- a/src/tabs/errors/lib/csv.ts
+++ b/src/tabs/errors/lib/csv.ts
@@ -1,3 +1,4 @@
+import { getCompanyUrlSegment } from '@/lib/company-routing';
 import { downloadCsv } from '@/lib/utils';
 import type { CompanyRow, DataPointMetric } from '../types';
 
@@ -50,7 +51,7 @@ export function exportComparisonToCsv(
 ): void {
   const headers = [
     'Company',
-    'WikidataId',
+    'Identifier',
     'Stage',
     'Prod',
     'Diff',
@@ -63,7 +64,7 @@ export function exportComparisonToCsv(
   for (const row of rows) {
     csvRows.push([
       `"${row.name.replace(/"/g, '""')}"`,
-      row.wikidataId,
+      getCompanyUrlSegment(row),
       String(row.stageValue ?? ''),
       String(row.prodValue ?? ''),
       String(row.diff ?? ''),

--- a/src/tabs/errors/lib/discrepancy.ts
+++ b/src/tabs/errors/lib/discrepancy.ts
@@ -132,8 +132,8 @@ export function applyCategoryErrorToRows(
     )
       continue;
 
-    const stageCompany = stageMap.get(row.wikidataId);
-    const prodCompany = prodMap.get(row.wikidataId);
+    const stageCompany = stageMap.get(row.id);
+    const prodCompany = prodMap.get(row.id);
 
     if (
       (row.discrepancy === 'error' ||

--- a/src/tabs/errors/lib/discrepancy.ts
+++ b/src/tabs/errors/lib/discrepancy.ts
@@ -7,11 +7,15 @@ import {
 } from '../types';
 import { getDataPointValue, pickReportingPeriodForYear } from './emissions';
 
-/** Build a map of companies by wikidataId for quick lookup. */
+/** Build a map of companies by internal id for quick lookup. */
 export function companiesToMapById(companies: Company[]): Map<string, Company> {
   const map = new Map<string, Company>();
-  companies.forEach((c) => map.set(c.wikidataId, c));
+  companies.forEach((c) => map.set(c.id, c));
   return map;
+}
+
+export function companyUnionKey(company: Company): string {
+  return company.id;
 }
 
 const UNIT_ERROR_POWERS = [10, 100, 1000, 10000, 100000, 1000000] as const;

--- a/src/tabs/errors/lib/verification.ts
+++ b/src/tabs/errors/lib/verification.ts
@@ -25,8 +25,8 @@ export function buildProdCompanyVerifiedForYearMap(
   year: number
 ): Map<string, boolean> {
   const result = new Map<string, boolean>();
-  for (const wikidataId of ids) {
-    result.set(wikidataId, isProdCompanyFullyVerifiedForYear(prodMap.get(wikidataId), year));
+  for (const companyId of ids) {
+    result.set(companyId, isProdCompanyFullyVerifiedForYear(prodMap.get(companyId), year));
   }
   return result;
 }

--- a/src/tabs/errors/types.ts
+++ b/src/tabs/errors/types.ts
@@ -40,7 +40,8 @@ export const DATA_POINTS = [
 ];
 
 export interface Company {
-  wikidataId: string;
+  id: string;
+  wikidataId?: string | null;
   name: string;
   tags?: string[];
   reportingPeriods?: ReportingPeriod[];
@@ -78,7 +79,8 @@ export interface ReportingPeriod {
 }
 
 export interface CompanyRow {
-  wikidataId: string;
+  id: string;
+  wikidataId?: string | null;
   name: string;
   tags?: string[];
   stageValue: number | null;
@@ -116,7 +118,8 @@ export interface DataPointMetric {
 }
 
 export interface WorstCompany {
-  wikidataId: string;
+  id: string;
+  wikidataId?: string | null;
   name: string;
   errorCount: number;
   totalDataPoints: number;


### PR DESCRIPTION
### ✨ What’s Changed?

This pull request updates company routing and selection logic throughout the application to consistently use internal UUIDs (`company.id`) instead of Wikidata IDs for all internal operations, editing, and bulk actions, while maintaining backward compatibility for public-facing and legacy URLs. It also introduces utility functions for generating company URLs, and updates documentation to reflect these routing changes.

**Company Routing and URL Handling:**
- Introduced `getCompanyUrlSegment` and `getKlimatkollenCompanyPath` utilities in `src/lib/company-routing.ts` to standardize company URL segments, preferring `wikidataId` when present, otherwise using the 8-character UUID prefix.
- Updated documentation in `README.md` and `docs/ROUTING_URL_STATE.md` to clarify the use of internal UUIDs in editor paths and API mutations, and the continued support for legacy Wikidata ID-based URLs. 

**Internal Data Handling and Selection Logic:**
- Refactored all company selection logic in the editor's multi-company view and table to use `company.id` instead of `wikidataId`, including state management, selection toggling, and bulk actions.

**Component and API Usage Updates:**
- Updated all relevant components and API calls to use `company.id` for mutations and data fetching, including single-company flows and detail tabs. 
- Updated company search matching to allow searching by the 8-character UUID prefix in addition to full UUID and Wikidata ID.

**Public Link Generation:**
- Updated the Klimatkollen company link in the crawler results component to use the new URL utilities, ensuring proper fallback between `wikidataId` and UUID prefix. 

These changes ensure a consistent and future-proof approach to company identification and routing across the application, while preserving compatibility with legacy URLs and improving clarity for both users and developers.

Editor routes and staff mutations use full UUID; read APIs accept flexible identifiers. Key errors tab maps by internal id and add Klimatkollen public link helper.

### ✅ Validation / Test Plan (if applicable)

<!-- How did you verify this works? Include commands + key scenarios. -->

- [x] Manual verification (describe below)
- [ ] Automated tests added/updated (or N/A)

### 💥 Impact (check all that apply)

- [ ] **Docs updated** (README/docs)
- [ ] **Routes/query params updated** (deep-links / URL state)
- [x] **Breaking change**
- [ ] **Backfill/migration needed**
- [ ] **Data/validation behavior changed** (rules, units, rounding, derived calcs, defaults)
- [ ] **Visual or setup change only** (styling, ui, gh templates, etc)

### 📋 Checklist

- [x] PR title starts with an issue reference (e.g. `[#123] ...`) or uses a prefix like `[fix]` / `[feat]` / `[chore]`
- [x] Labels set (and milestone if relevant)
- [x] I’ve verified the change locally (repro steps included above when non-trivial)
- [x] Any new env vars/config are documented (and safe defaults exist)
- [x] Follow-ups created as issues (or N/A)
