### PR TITLE
Fix editor identifiers: show Wikidata ID and internal ID separately.

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -230,6 +230,7 @@
     "companyDetail": {
       "identifiers": "Identifiers",
       "wikidataId": "Wikidata ID",
+      "internalId": "Internal ID",
       "lei": "LEI",
       "tags": "Tags"
     },

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -94,6 +94,7 @@
     "companyDetail": {
       "identifiers": "Identifierare",
       "wikidataId": "Wikidata-ID",
+      "internalId": "Internt ID",
       "lei": "LEI",
       "tags": "Taggar"
     },

--- a/src/tabs/editor/components/single-company/CompanyDetailTab.tsx
+++ b/src/tabs/editor/components/single-company/CompanyDetailTab.tsx
@@ -254,6 +254,18 @@ export function CompanyDetailTab({
                   </label>
                   <input
                     type="text"
+                    value={company.wikidataId ?? ""}
+                    readOnly
+                    placeholder={dash}
+                    className={inputClassName + " bg-gray-04/60 !max-w-none"}
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-01 mb-1">
+                    {t("editor.companyDetail.internalId")}
+                  </label>
+                  <input
+                    type="text"
                     value={company.id}
                     readOnly
                     className={inputClassName + " bg-gray-04/60 !max-w-none"}


### PR DESCRIPTION
### ✨ What’s Changed?

The Wikidata field was incorrectly bound to company.id; it now shows wikidataId when present, with a dedicated read-only internal ID field.

- [x] Manual verification (describe below)
- [ ] Automated tests added/updated (or N/A)

### 💥 Impact (check all that apply)

- [ ] **Docs updated** (README/docs)
- [ ] **Routes/query params updated** (deep-links / URL state)
- [ ] **Breaking change**
- [ ] **Backfill/migration needed**
- [ ] **Data/validation behavior changed** (rules, units, rounding, derived calcs, defaults)
- [x] **Visual or setup change only** (styling, ui, gh templates, etc)

### 📋 Checklist

- [x] PR title starts with an issue reference (e.g. `[#123] ...`) or uses a prefix like `[fix]` / `[feat]` / `[chore]`
- [x] Labels set (and milestone if relevant)
- [x] I’ve verified the change locally (repro steps included above when non-trivial)
- [x] Any new env vars/config are documented (and safe defaults exist)
- [x] Follow-ups created as issues (or N/A)
