### PR TITLE
[Fix]: Fetch registry batches once per tab instead of per row

### DIFF
--- a/src/hooks/useBatches.ts
+++ b/src/hooks/useBatches.ts
@@ -5,11 +5,15 @@ import type { GarboBatchOption } from "@/lib/garbo-batch-types";
 
 const BATCHES_LIMIT = 500;
 
-export function useBatches(batchesListUrl?: string): {
+export function useBatches(
+  batchesListUrl?: string,
+  options?: { enabled?: boolean },
+): {
   batches: GarboBatchOption[];
   isLoading: boolean;
   refetch: () => void;
 } {
+  const enabled = options?.enabled !== false;
   const [batches, setBatches] = useState<GarboBatchOption[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [version, setVersion] = useState(0);
@@ -18,10 +22,15 @@ export function useBatches(batchesListUrl?: string): {
     getGarboQueueArchiveUrl(`/batches?limit=${BATCHES_LIMIT}`);
 
   const refetch = useCallback(() => {
+    if (!enabled) return;
     setVersion((v) => v + 1);
-  }, []);
+  }, [enabled]);
 
   useEffect(() => {
+    if (!enabled) {
+      setIsLoading(false);
+      return;
+    }
     let cancelled = false;
     setIsLoading(true);
     (async () => {
@@ -44,7 +53,11 @@ export function useBatches(batchesListUrl?: string): {
     return () => {
       cancelled = true;
     };
-  }, [version, listUrl]);
+  }, [version, listUrl, enabled]);
 
-  return { batches, isLoading, refetch };
+  return {
+    batches: enabled ? batches : [],
+    isLoading: enabled ? isLoading : false,
+    refetch,
+  };
 }

--- a/src/hooks/useRunReportsPipeline.ts
+++ b/src/hooks/useRunReportsPipeline.ts
@@ -3,7 +3,10 @@ import { toast } from "sonner";
 import { useI18n } from "@/contexts/I18nContext";
 import { useBatches } from "@/hooks/useBatches";
 import { DEFAULT_RUN_ONLY, type RunOnlyWorkerId } from "@/lib/run-only-workers";
-import { NEW_BATCH_DROPDOWN_VALUE, type GarboBatchOption } from "@/lib/garbo-batch-types";
+import {
+  NEW_BATCH_DROPDOWN_VALUE,
+  type GarboBatchOption,
+} from "@/lib/garbo-batch-types";
 import { resolvePipelineBatchId } from "@/lib/resolve-pipeline-batch-id";
 import { useTagOptions } from "@/tabs/upload/hooks/useTagOptions";
 import {
@@ -64,12 +67,10 @@ export function useRunReportsPipeline(config?: RunReportsPipelineConfig) {
     batchesOverride ? undefined : config?.batchesListUrl,
     { enabled: !batchesOverride },
   );
-  const existingBatches =
-    batchesOverride?.batches ?? internalBatches.batches;
+  const existingBatches = batchesOverride?.batches ?? internalBatches.batches;
   const batchesLoading =
     batchesOverride?.isLoading ?? internalBatches.isLoading;
-  const refetchBatches =
-    batchesOverride?.refetch ?? internalBatches.refetch;
+  const refetchBatches = batchesOverride?.refetch ?? internalBatches.refetch;
   const {
     tagOptions,
     loading: tagsLoading,

--- a/src/hooks/useRunReportsPipeline.ts
+++ b/src/hooks/useRunReportsPipeline.ts
@@ -3,7 +3,7 @@ import { toast } from "sonner";
 import { useI18n } from "@/contexts/I18nContext";
 import { useBatches } from "@/hooks/useBatches";
 import { DEFAULT_RUN_ONLY, type RunOnlyWorkerId } from "@/lib/run-only-workers";
-import { NEW_BATCH_DROPDOWN_VALUE } from "@/lib/garbo-batch-types";
+import { NEW_BATCH_DROPDOWN_VALUE, type GarboBatchOption } from "@/lib/garbo-batch-types";
 import { resolvePipelineBatchId } from "@/lib/resolve-pipeline-batch-id";
 import { useTagOptions } from "@/tabs/upload/hooks/useTagOptions";
 import {
@@ -31,6 +31,12 @@ export type RunReportsPipelineConfig = {
   batchesListUrl?: string;
   parsePdfEndpoint?: string;
   toastKeys?: Partial<RunReportsPipelineToastKeys>;
+  /** Reuse registry tab batch list instead of fetching again. */
+  batchesOverride?: {
+    batches: GarboBatchOption[];
+    isLoading: boolean;
+    refetch: () => void;
+  };
 };
 
 const DEFAULT_TOAST_KEYS: RunReportsPipelineToastKeys = {
@@ -53,11 +59,17 @@ export function useRunReportsPipeline(config?: RunReportsPipelineConfig) {
   const [customBatchName, setCustomBatchName] = useState("");
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
 
-  const {
-    batches: existingBatches,
-    isLoading: batchesLoading,
-    refetch: refetchBatches,
-  } = useBatches(config?.batchesListUrl);
+  const batchesOverride = config?.batchesOverride;
+  const internalBatches = useBatches(
+    batchesOverride ? undefined : config?.batchesListUrl,
+    { enabled: !batchesOverride },
+  );
+  const existingBatches =
+    batchesOverride?.batches ?? internalBatches.batches;
+  const batchesLoading =
+    batchesOverride?.isLoading ?? internalBatches.isLoading;
+  const refetchBatches =
+    batchesOverride?.refetch ?? internalBatches.refetch;
   const {
     tagOptions,
     loading: tagsLoading,

--- a/src/tabs/registry/RegistryTab.tsx
+++ b/src/tabs/registry/RegistryTab.tsx
@@ -18,7 +18,10 @@ import {
   type RegistryViewFilters,
 } from "./lib/registry-table-utils";
 import { useGarboCompanyTagsMap } from "./hooks/useGarboCompanyTagsMap";
-import { useRegistryBatches } from "./hooks/useRegistryBatches";
+import {
+  RegistryBatchesProvider,
+  useRegistryBatchesContext,
+} from "./contexts/RegistryBatchesContext";
 import { useRegistryDisplayedView } from "./hooks/useRegistryDisplayedView";
 import {
   addRegistryEntry,
@@ -27,6 +30,7 @@ import {
   deleteReportFromRegistry,
   editRegistryEntry,
   fetchRegistryList,
+  getRegistryRunReportsPipelineConfig,
 } from "./lib/registry-api";
 import RegistryFiltersAndSort from "./components/RegistryFiltersAndSort";
 import RegistryAddModal from "./components/RegistryAddModal";
@@ -36,6 +40,14 @@ import type {
 } from "./lib/registry-types";
 
 export function RegistryTab() {
+  return (
+    <RegistryBatchesProvider>
+      <RegistryTabContent />
+    </RegistryBatchesProvider>
+  );
+}
+
+function RegistryTabContent() {
   const { t } = useI18n();
   const [query, setQuery] = useState<string>("");
   const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -58,6 +70,11 @@ export function RegistryTab() {
     error: companyTagsError,
   } = useGarboCompanyTagsMap();
   const {
+    batches: registryBatches,
+    isLoading: registryBatchesLoading,
+    refetch: refetchRegistryBatches,
+  } = useRegistryBatchesContext();
+  const {
     runForUrls,
     isRunningReports,
     autoApprove,
@@ -65,12 +82,14 @@ export function RegistryTab() {
     runOptions,
     tagOptions,
     tagsLoading,
-  } = useRunReportsPipeline();
-  const {
-    batches: registryBatches,
-    isLoading: registryBatchesLoading,
-    refetch: refetchRegistryBatches,
-  } = useRegistryBatches();
+  } = useRunReportsPipeline({
+    ...getRegistryRunReportsPipelineConfig(),
+    batchesOverride: {
+      batches: registryBatches,
+      isLoading: registryBatchesLoading,
+      refetch: refetchRegistryBatches,
+    },
+  });
 
   const batchFilterOptions = useMemo(() => {
     const byId = new Map(registryBatches.map((b) => [b.id, b.batchName]));

--- a/src/tabs/registry/components/RegistryAddModal.tsx
+++ b/src/tabs/registry/components/RegistryAddModal.tsx
@@ -4,7 +4,7 @@ import { toast } from "sonner";
 import { useI18n } from "@/contexts/I18nContext";
 import { FileDropZone } from "@/components/FileDropZone";
 import { usePdfFileDrop } from "@/hooks/usePdfFileDrop";
-import { useRegistryBatches } from "@/tabs/registry/hooks/useRegistryBatches";
+import { useRegistryBatchesContext } from "@/tabs/registry/contexts/RegistryBatchesContext";
 import { NEW_BATCH_DROPDOWN_VALUE } from "@/lib/garbo-batch-types";
 import { validateUrls } from "@/lib/utils";
 import { resolveRegistryBatchId } from "../lib/resolve-registry-batch-id";
@@ -85,7 +85,7 @@ const RegistryAddModal = ({
     batches: existingBatches,
     isLoading: batchesLoading,
     refetch: refetchBatches,
-  } = useRegistryBatches();
+  } = useRegistryBatchesContext();
 
   const multiUrlLineCount = urlInput
     .split("\n")

--- a/src/tabs/registry/components/RegistryEditModal.tsx
+++ b/src/tabs/registry/components/RegistryEditModal.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { useI18n } from "@/contexts/I18nContext";
 import { NEW_BATCH_DROPDOWN_VALUE } from "@/lib/garbo-batch-types";
-import { useRegistryBatches } from "@/tabs/registry/hooks/useRegistryBatches";
+import { useRegistryBatchesContext } from "@/tabs/registry/contexts/RegistryBatchesContext";
 import { resolveRegistryBatchId } from "@/tabs/registry/lib/resolve-registry-batch-id";
 import { Button } from "@/ui/button";
 import {
@@ -53,7 +53,7 @@ const RegistryEditModal = ({
     batches: existingBatches,
     isLoading: batchesLoading,
     refetch: refetchBatches,
-  } = useRegistryBatches();
+  } = useRegistryBatchesContext();
 
   useEffect(() => {
     setCompanyName(entry.companyName ?? "");

--- a/src/tabs/registry/contexts/RegistryBatchesContext.tsx
+++ b/src/tabs/registry/contexts/RegistryBatchesContext.tsx
@@ -1,0 +1,31 @@
+import { createContext, useContext, type ReactNode } from "react";
+import { useRegistryBatches } from "@/tabs/registry/hooks/useRegistryBatches";
+import type { GarboBatchOption } from "@/lib/garbo-batch-types";
+
+type RegistryBatchesContextValue = {
+  batches: GarboBatchOption[];
+  isLoading: boolean;
+  refetch: () => void;
+};
+
+const RegistryBatchesContext =
+  createContext<RegistryBatchesContextValue | null>(null);
+
+export function RegistryBatchesProvider({ children }: { children: ReactNode }) {
+  const value = useRegistryBatches();
+  return (
+    <RegistryBatchesContext.Provider value={value}>
+      {children}
+    </RegistryBatchesContext.Provider>
+  );
+}
+
+export function useRegistryBatchesContext(): RegistryBatchesContextValue {
+  const ctx = useContext(RegistryBatchesContext);
+  if (!ctx) {
+    throw new Error(
+      "useRegistryBatchesContext must be used within RegistryBatchesProvider",
+    );
+  }
+  return ctx;
+}

--- a/src/tabs/registry/lib/registry-api.ts
+++ b/src/tabs/registry/lib/registry-api.ts
@@ -10,12 +10,24 @@ import type {
 import { filterRegistryEntries } from "./registry-utils";
 import { uploadRegistryPdfs } from "./registry-upload-api";
 
+import type { RunReportsPipelineConfig } from "@/hooks/useRunReportsPipeline";
+
 const REGISTRY_BATCHES_LIMIT = 500;
 
 function registryUrl(path: string): string {
   const base = getUnearthApiBaseUrl().replace(/\/+$/, "");
   const segment = path.replace(/^\//, "");
   return `${base}/${segment}`;
+}
+
+/** Run-reports modal uses Unearth registry batches (not Garbo queue-archive). */
+export function getRegistryRunReportsPipelineConfig(): RunReportsPipelineConfig {
+  return {
+    batchesListUrl: registryUrl(
+      `reports/registry/batches?limit=${REGISTRY_BATCHES_LIMIT}`,
+    ),
+    batchesApiUrl: registryUrl("reports/registry/batches"),
+  };
 }
 
 export const fetchRegistryList = async () => {


### PR DESCRIPTION
## Summary
- Add `RegistryBatchesProvider` so the registry tab fetches `GET /reports/registry/batches` once
- Add/edit modals and run-reports reuse the shared list via context (`batchesOverride`) instead of N parallel requests per row

## Test plan
- [ ] Open Registry tab with many entries (stage or local)
- [ ] Network tab: only **one** `/reports/registry/batches?limit=500` on load (React Strict Mode may show two in dev)
- [ ] Add Entry / Edit Entry batch dropdown still populated
- [ ] Run Reports modal batch picker still works