### PR TITLE
Chunk registry bulk PDF uploads with progress

### DIFF
--- a/k8s/base/ingress.yaml
+++ b/k8s/base/ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: validate-frontend
   annotations:
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
-    nginx.ingress.kubernetes.io/proxy-body-size: "450m"
+    nginx.ingress.kubernetes.io/proxy-body-size: "550m"
 spec:
   ingressClassName: nginx
   rules:

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -5,7 +5,7 @@ server {
     index index.html;
 
     # Allow large file uploads (match ingress proxy-body-size)
-    client_max_body_size 450m;
+    client_max_body_size 550m;
 
     # Gzip compression
     gzip on;

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -69,10 +69,10 @@ server {
         proxy_set_header X-API-Key ${GARBO_ALL_ACCESS_API_KEY};
         proxy_cache_bypass $http_upgrade;
 
-        # Overview aggregation can exceed default gateway timeouts
+        # Overview aggregation and bulk PDF uploads can exceed default gateway timeouts
         proxy_connect_timeout 120s;
-        proxy_send_timeout 120s;
-        proxy_read_timeout 120s;
+        proxy_send_timeout 600s;
+        proxy_read_timeout 600s;
     }
 
     # Overview prod→stage tab: fixed stage Pipeline API (not env-controlled)
@@ -132,8 +132,8 @@ server {
         proxy_cache_bypass $http_upgrade;
 
         proxy_connect_timeout 120s;
-        proxy_send_timeout 120s;
-        proxy_read_timeout 120s;
+        proxy_send_timeout 600s;
+        proxy_read_timeout 600s;
     }
 
     location = /unearth-prod-api {
@@ -152,8 +152,8 @@ server {
         proxy_cache_bypass $http_upgrade;
 
         proxy_connect_timeout 120s;
-        proxy_send_timeout 120s;
-        proxy_read_timeout 120s;
+        proxy_send_timeout 600s;
+        proxy_read_timeout 600s;
     }
 
     # Proxy /api/screenshots to screenshots service (if different)

--- a/src/hooks/usePdfFileDrop.ts
+++ b/src/hooks/usePdfFileDrop.ts
@@ -6,6 +6,15 @@ export interface DroppedPdfFile {
   file: File;
 }
 
+export type PdfFileDropResult = {
+  added: number;
+  rejectedTooLarge: number;
+};
+
+type UsePdfFileDropOptions = {
+  maxFileBytes?: number;
+};
+
 function mergeDroppedPdfFiles(
   prev: DroppedPdfFile[],
   files: File[],
@@ -24,16 +33,54 @@ function mergeDroppedPdfFiles(
   return { next: [...prev, ...toAdd], added: toAdd.length };
 }
 
-export function usePdfFileDrop() {
+function partitionByMaxSize(
+  files: File[],
+  maxFileBytes?: number,
+): { accepted: File[]; rejectedTooLarge: number } {
+  if (maxFileBytes == null) {
+    return { accepted: files, rejectedTooLarge: 0 };
+  }
+  const accepted: File[] = [];
+  let rejectedTooLarge = 0;
+  for (const file of files) {
+    if (file.size > maxFileBytes) {
+      rejectedTooLarge += 1;
+      continue;
+    }
+    accepted.push(file);
+  }
+  return { accepted, rejectedTooLarge };
+}
+
+export function usePdfFileDrop(options: UsePdfFileDropOptions = {}) {
+  const { maxFileBytes } = options;
   const [isDragging, setIsDragging] = useState(false);
   const [droppedFiles, setDroppedFiles] = useState<DroppedPdfFile[]>([]);
 
-  const appendFiles = useCallback((files: File[]) => {
-    if (files.length === 0) return 0;
+  const appendFiles = useCallback(
+    (files: File[]): PdfFileDropResult => {
+      if (files.length === 0) {
+        return { added: 0, rejectedTooLarge: 0 };
+      }
 
-    setDroppedFiles((prev) => mergeDroppedPdfFiles(prev, files).next);
-    return files.length;
-  }, []);
+      const { accepted, rejectedTooLarge } = partitionByMaxSize(
+        files,
+        maxFileBytes,
+      );
+      if (accepted.length === 0) {
+        return { added: 0, rejectedTooLarge };
+      }
+
+      let added = 0;
+      setDroppedFiles((prev) => {
+        const merged = mergeDroppedPdfFiles(prev, accepted);
+        added = merged.added;
+        return merged.next;
+      });
+      return { added, rejectedTooLarge };
+    },
+    [maxFileBytes],
+  );
 
   const handleDragOver = useCallback((e: React.DragEvent) => {
     e.preventDefault();
@@ -46,7 +93,7 @@ export function usePdfFileDrop() {
   }, []);
 
   const handleDrop = useCallback(
-    async (e: React.DragEvent) => {
+    async (e: React.DragEvent): Promise<PdfFileDropResult> => {
       e.preventDefault();
       setIsDragging(false);
       const files = await collectPdfFilesFromDataTransfer(e.dataTransfer);
@@ -56,7 +103,7 @@ export function usePdfFileDrop() {
   );
 
   const handleInputChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
+    (e: React.ChangeEvent<HTMLInputElement>): PdfFileDropResult => {
       const files = Array.from(e.target.files ?? []).filter(
         (file) =>
           file.type === "application/pdf" ||

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1250,6 +1250,8 @@
     "addEntriesSuccess": "{{count}} registry entries added.",
     "addEntriesPartial": "{{saved}} entries saved, but some failed: {{message}}",
     "addEntriesCount": "Add {{count}} entries",
+    "bulkUploadProgressUpload": "Uploading PDFs {{completed}} / {{total}}…",
+    "bulkUploadProgressSave": "Saving registry entries {{completed}} / {{total}}…",
     "dragDropPdf": "Drag and drop PDF files or folders here",
     "dragDropPdfHint": "Or click to select PDF files",
     "droppedFilesHeading": "Files to add ({{count}})",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1252,6 +1252,7 @@
     "addEntriesCount": "Add {{count}} entries",
     "bulkUploadProgressUpload": "Uploading PDFs {{completed}} / {{total}}…",
     "bulkUploadProgressSave": "Saving registry entries {{completed}} / {{total}}…",
+    "fileTooLarge": "{{count}} file(s) exceeded the {{maxMb}} MB limit and were skipped.",
     "dragDropPdf": "Drag and drop PDF files or folders here",
     "dragDropPdfHint": "Or click to select PDF files",
     "droppedFilesHeading": "Files to add ({{count}})",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -1252,6 +1252,7 @@
     "addEntriesCount": "Lägg till {{count}} poster",
     "bulkUploadProgressUpload": "Laddar upp PDF:er {{completed}} / {{total}}…",
     "bulkUploadProgressSave": "Sparar registerposter {{completed}} / {{total}}…",
+    "fileTooLarge": "{{count}} fil(er) överskred gränsen {{maxMb}} MB och hoppades över.",
     "dragDropPdf": "Dra och släpp PDF-filer eller mappar här",
     "dragDropPdfHint": "Eller klicka för att välja PDF-filer",
     "droppedFilesHeading": "Filer att lägga till ({{count}})",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -1250,6 +1250,8 @@
     "addEntriesSuccess": "{{count}} registerposter tillagda.",
     "addEntriesPartial": "{{saved}} poster sparades, men några misslyckades: {{message}}",
     "addEntriesCount": "Lägg till {{count}} poster",
+    "bulkUploadProgressUpload": "Laddar upp PDF:er {{completed}} / {{total}}…",
+    "bulkUploadProgressSave": "Sparar registerposter {{completed}} / {{total}}…",
     "dragDropPdf": "Dra och släpp PDF-filer eller mappar här",
     "dragDropPdfHint": "Eller klicka för att välja PDF-filer",
     "droppedFilesHeading": "Filer att lägga till ({{count}})",

--- a/src/lib/chunk-array.ts
+++ b/src/lib/chunk-array.ts
@@ -1,0 +1,30 @@
+export function chunkArray<T>(items: T[], chunkSize: number): T[][] {
+  if (chunkSize < 1) throw new Error("chunkSize must be at least 1");
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += chunkSize) {
+    chunks.push(items.slice(i, i + chunkSize));
+  }
+  return chunks;
+}
+
+/** Run async work over items with a fixed concurrency limit. */
+export async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  if (items.length === 0) return [];
+  const limit = Math.max(1, Math.min(concurrency, items.length));
+  const results: R[] = new Array(items.length);
+  let nextIndex = 0;
+
+  async function worker() {
+    while (nextIndex < items.length) {
+      const index = nextIndex++;
+      results[index] = await fn(items[index], index);
+    }
+  }
+
+  await Promise.all(Array.from({ length: limit }, () => worker()));
+  return results;
+}

--- a/src/lib/chunk-array.ts
+++ b/src/lib/chunk-array.ts
@@ -7,6 +7,38 @@ export function chunkArray<T>(items: T[], chunkSize: number): T[][] {
   return chunks;
 }
 
+/** Pack files into upload chunks bounded by count and total byte size. */
+export function chunkFilesBySize(
+  files: File[],
+  maxFiles: number,
+  maxBytes: number,
+): File[][] {
+  if (maxFiles < 1) throw new Error("maxFiles must be at least 1");
+  if (maxBytes < 1) throw new Error("maxBytes must be at least 1");
+
+  const chunks: File[][] = [];
+  let current: File[] = [];
+  let currentBytes = 0;
+
+  for (const file of files) {
+    const exceedsCount = current.length >= maxFiles;
+    const exceedsBytes =
+      current.length > 0 && currentBytes + file.size > maxBytes;
+
+    if (exceedsCount || exceedsBytes) {
+      chunks.push(current);
+      current = [];
+      currentBytes = 0;
+    }
+
+    current.push(file);
+    currentBytes += file.size;
+  }
+
+  if (current.length > 0) chunks.push(current);
+  return chunks;
+}
+
 /** Run async work over items with a fixed concurrency limit. */
 export async function mapWithConcurrency<T, R>(
   items: T[],

--- a/src/tabs/registry/RegistryTab.tsx
+++ b/src/tabs/registry/RegistryTab.tsx
@@ -10,7 +10,12 @@ import { useRunReportsPipeline } from "@/hooks/useRunReportsPipeline";
 import RegistryControls from "./components/RegistryControls";
 import RegistryStats from "./components/RegistryStats";
 import RegistryResultsList from "./components/RegistryResultsList";
-import type { RegistryEntry, RegistryEntryUpdate } from "./lib/registry-types";
+import type {
+  RegistryBulkFileAddInput,
+  RegistryBulkProgress,
+  RegistryEntry,
+  RegistryEntryUpdate,
+} from "./lib/registry-types";
 import { writeRegistryEntriesToCsv } from "./lib/registry-utils";
 import {
   defaultRegistryViewFilters,
@@ -60,6 +65,8 @@ function RegistryTabContent() {
   const [isRunReportsOpen, setIsRunReportsOpen] = useState<boolean>(false);
   const [isAddEntryOpen, setIsAddEntryOpen] = useState<boolean>(false);
   const [isAddingEntry, setIsAddingEntry] = useState<boolean>(false);
+  const [bulkAddProgress, setBulkAddProgress] =
+    useState<RegistryBulkProgress | null>(null);
   const [filters, setFilters] = useState(defaultRegistryViewFilters);
   const patchFilters = useCallback((patch: Partial<RegistryViewFilters>) => {
     setFilters((f) => mergeRegistryViewFilters(f, patch));
@@ -257,8 +264,12 @@ function RegistryTabContent() {
 
   const handleAddFiles = async (input: RegistryBulkFileAddInput) => {
     setIsAddingEntry(true);
+    setBulkAddProgress(null);
     try {
-      const newEntries = await addRegistryEntriesFromFiles(input);
+      const newEntries = await addRegistryEntriesFromFiles({
+        ...input,
+        onProgress: setBulkAddProgress,
+      });
       await loadRegistry();
       refetchRegistryBatches();
       toast.success(
@@ -282,6 +293,7 @@ function RegistryTabContent() {
       throw error;
     } finally {
       setIsAddingEntry(false);
+      setBulkAddProgress(null);
     }
   };
 
@@ -357,6 +369,7 @@ function RegistryTabContent() {
           onAddMany={handleAddMany}
           onAddFiles={handleAddFiles}
           isAdding={isAddingEntry}
+          bulkProgress={bulkAddProgress}
         />
 
         <RegistryFiltersAndSort

--- a/src/tabs/registry/components/RegistryAddModal.tsx
+++ b/src/tabs/registry/components/RegistryAddModal.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/ui/dialog";
 import type {
   RegistryBulkFileAddInput,
+  RegistryBulkProgress,
   RegistryNewEntry,
 } from "../lib/registry-types";
 import { isValidHttpUrl, isValidOptionalHttpUrl } from "../lib/registry-utils";
@@ -36,6 +37,7 @@ interface RegistryAddModalProps {
   onAddMany: (entries: RegistryNewEntry[]) => Promise<void>;
   onAddFiles: (input: RegistryBulkFileAddInput) => Promise<void>;
   isAdding: boolean;
+  bulkProgress?: RegistryBulkProgress | null;
 }
 
 const inputClass = (hasError: boolean) =>
@@ -50,6 +52,7 @@ const RegistryAddModal = ({
   onAddMany,
   onAddFiles,
   isAdding,
+  bulkProgress = null,
 }: RegistryAddModalProps) => {
   const { t } = useI18n();
   const {
@@ -321,9 +324,19 @@ const RegistryAddModal = ({
       ? isAdding
         ? t("registry.addEntryAdding")
         : t("registry.addEntry")
-      : isAdding
-        ? t("registry.addEntryAdding")
-        : t("registry.addEntriesCount", { count: submitCount });
+      : isAdding && bulkProgress
+        ? bulkProgress.phase === "upload"
+          ? t("registry.bulkUploadProgressUpload", {
+              completed: bulkProgress.completed,
+              total: bulkProgress.total,
+            })
+          : t("registry.bulkUploadProgressSave", {
+              completed: bulkProgress.completed,
+              total: bulkProgress.total,
+            })
+        : isAdding
+          ? t("registry.addEntryAdding")
+          : t("registry.addEntriesCount", { count: submitCount });
 
   const batchOptions = (
     <RegistryAddBatchOptions
@@ -511,6 +524,20 @@ const RegistryAddModal = ({
             </div>
           </TabsContent>
         </Tabs>
+
+        {bulkProgress && (
+          <p className="text-sm text-gray-02" role="status">
+            {bulkProgress.phase === "upload"
+              ? t("registry.bulkUploadProgressUpload", {
+                  completed: bulkProgress.completed,
+                  total: bulkProgress.total,
+                })
+              : t("registry.bulkUploadProgressSave", {
+                  completed: bulkProgress.completed,
+                  total: bulkProgress.total,
+                })}
+          </p>
+        )}
 
         <DialogFooter>
           <Button

--- a/src/tabs/registry/components/RegistryAddModal.tsx
+++ b/src/tabs/registry/components/RegistryAddModal.tsx
@@ -8,6 +8,10 @@ import { useRegistryBatchesContext } from "@/tabs/registry/contexts/RegistryBatc
 import { NEW_BATCH_DROPDOWN_VALUE } from "@/lib/garbo-batch-types";
 import { validateUrls } from "@/lib/utils";
 import { resolveRegistryBatchId } from "../lib/resolve-registry-batch-id";
+import {
+  REGISTRY_PDF_MAX_BYTES,
+  REGISTRY_PDF_MAX_MB,
+} from "../lib/registry-bulk-limits";
 import { Button } from "@/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/ui/tabs";
 import {
@@ -64,7 +68,7 @@ const RegistryAddModal = ({
     handleInputChange,
     removeFile,
     clearFiles,
-  } = usePdfFileDrop();
+  } = usePdfFileDrop({ maxFileBytes: REGISTRY_PDF_MAX_BYTES });
 
   const [addMode, setAddMode] = useState<AddMode>("single");
   const [multiInputMode, setMultiInputMode] = useState<MultiInputMode>("files");
@@ -203,23 +207,43 @@ const RegistryAddModal = ({
   };
 
   const handleDropWithToast = async (e: React.DragEvent) => {
-    const count = await handleDrop(e);
-    if (count === 0) {
-      toast.error(t("upload.onlyPdfAllowed"));
+    const { added, rejectedTooLarge } = await handleDrop(e);
+    if (rejectedTooLarge > 0) {
+      toast.error(
+        t("registry.fileTooLarge", {
+          maxMb: REGISTRY_PDF_MAX_MB,
+          count: rejectedTooLarge,
+        }),
+      );
+    }
+    if (added === 0) {
+      if (rejectedTooLarge === 0) {
+        toast.error(t("upload.onlyPdfAllowed"));
+      }
       return;
     }
-    toast.success(t("upload.filesUploaded", { count }));
+    toast.success(t("upload.filesUploaded", { count: added }));
   };
 
   const handleInputChangeWithToast = (
     e: React.ChangeEvent<HTMLInputElement>,
   ) => {
-    const count = handleInputChange(e);
-    if (count === 0) {
-      toast.error(t("upload.onlyPdfAllowed"));
+    const { added, rejectedTooLarge } = handleInputChange(e);
+    if (rejectedTooLarge > 0) {
+      toast.error(
+        t("registry.fileTooLarge", {
+          maxMb: REGISTRY_PDF_MAX_MB,
+          count: rejectedTooLarge,
+        }),
+      );
+    }
+    if (added === 0) {
+      if (rejectedTooLarge === 0) {
+        toast.error(t("upload.onlyPdfAllowed"));
+      }
       return;
     }
-    toast.success(t("upload.filesUploaded", { count }));
+    toast.success(t("upload.filesUploaded", { count: added }));
   };
 
   const handleAdd = async () => {

--- a/src/tabs/registry/lib/registry-api.ts
+++ b/src/tabs/registry/lib/registry-api.ts
@@ -8,7 +8,10 @@ import type {
   RegistryBulkFileAddInput,
 } from "./registry-types";
 import { filterRegistryEntries } from "./registry-utils";
+import { chunkArray } from "@/lib/chunk-array";
+import { REGISTRY_SAVE_CHUNK_SIZE } from "./registry-bulk-limits";
 import { uploadRegistryPdfs } from "./registry-upload-api";
+import type { RegistryBulkProgress } from "./registry-types";
 
 import type { RunReportsPipelineConfig } from "@/hooks/useRunReportsPipeline";
 
@@ -144,6 +147,7 @@ async function cachePdfToS3(sourceUrl: string): Promise<PdfCacheResult | null> {
 
 async function saveRegistryPayloads(
   payloads: RegistryNewEntry[],
+  onProgress?: (progress: RegistryBulkProgress) => void,
 ): Promise<{ saved: RegistryEntry[]; partialFailure?: string }> {
   const url = registryUrl("internal-companies/reports/save-reports");
   const response = await garboAuthFetch(url, {
@@ -186,11 +190,48 @@ async function saveRegistryPayloads(
   if (saved.length === 0) {
     throw new Error("No entries returned from server");
   }
+  onProgress?.({
+    phase: "save",
+    completed: saved.length,
+    total: payloads.length,
+  });
   return { saved };
+}
+
+async function saveRegistryPayloadsInChunks(
+  payloads: RegistryNewEntry[],
+  onProgress?: (progress: RegistryBulkProgress) => void,
+): Promise<{ saved: RegistryEntry[]; partialFailure?: string }> {
+  if (payloads.length <= REGISTRY_SAVE_CHUNK_SIZE) {
+    return saveRegistryPayloads(payloads, onProgress);
+  }
+
+  const chunks = chunkArray(payloads, REGISTRY_SAVE_CHUNK_SIZE);
+  const allSaved: RegistryEntry[] = [];
+
+  for (const chunk of chunks) {
+    const { saved, partialFailure } = await saveRegistryPayloads(
+      chunk,
+      (chunkProgress) => {
+        onProgress?.({
+          phase: "save",
+          completed: allSaved.length + chunkProgress.completed,
+          total: payloads.length,
+        });
+      },
+    );
+    allSaved.push(...saved);
+    if (partialFailure) {
+      return { saved: allSaved, partialFailure };
+    }
+  }
+
+  return { saved: allSaved };
 }
 
 export const addRegistryEntries = async (
   entries: RegistryNewEntry[],
+  onProgress?: (progress: RegistryBulkProgress) => void,
 ): Promise<RegistryEntry[]> => {
   if (entries.length === 0) {
     throw new Error("At least one registry entry is required");
@@ -212,7 +253,10 @@ export const addRegistryEntries = async (
   );
 
   try {
-    const { saved, partialFailure } = await saveRegistryPayloads(payloads);
+    const { saved, partialFailure } = await saveRegistryPayloadsInChunks(
+      payloads,
+      onProgress,
+    );
     if (partialFailure) {
       const err = new Error(partialFailure) as Error & {
         partialSuccess?: RegistryEntry[];
@@ -237,7 +281,9 @@ export const addRegistryEntry = async (
 export const addRegistryEntriesFromFiles = async (
   input: RegistryBulkFileAddInput,
 ): Promise<RegistryEntry[]> => {
-  const uploads = await uploadRegistryPdfs(input.files);
+  const uploads = await uploadRegistryPdfs(input.files, (progress) => {
+    input.onProgress?.(progress);
+  });
   if (uploads.length === 0) {
     throw new Error("No PDF files to add");
   }
@@ -259,7 +305,9 @@ export const addRegistryEntriesFromFiles = async (
     ...(input.batchId ? { batchId: input.batchId } : {}),
   }));
 
-  return addRegistryEntries(entries);
+  return addRegistryEntries(entries, (progress) => {
+    input.onProgress?.(progress);
+  });
 };
 
 export const editRegistryEntry = async (entry: RegistryEntryUpdate) => {

--- a/src/tabs/registry/lib/registry-bulk-limits.ts
+++ b/src/tabs/registry/lib/registry-bulk-limits.ts
@@ -1,11 +1,11 @@
 /** Max PDF size accepted by the Unearth upload-pdfs API (keep in sync with API PDF_MAX_BYTES). */
-export const REGISTRY_PDF_MAX_BYTES = 100 * 1024 * 1024;
+export const REGISTRY_PDF_MAX_BYTES = 250 * 1024 * 1024;
 
 /** Max PDFs per multipart upload request (API multipart `files` limit is 20). */
 export const REGISTRY_UPLOAD_CHUNK_SIZE = 15;
 
-/** Max total bytes per upload chunk (stay under API ingress proxy-body-size). */
-export const REGISTRY_UPLOAD_MAX_CHUNK_BYTES = 300 * 1024 * 1024;
+/** Max total bytes per upload chunk (stay under ingress proxy-body-size). */
+export const REGISTRY_UPLOAD_MAX_CHUNK_BYTES = 400 * 1024 * 1024;
 
 /** Parallel upload-pdfs requests while adding many registry PDFs. */
 export const REGISTRY_UPLOAD_CONCURRENCY = 2;

--- a/src/tabs/registry/lib/registry-bulk-limits.ts
+++ b/src/tabs/registry/lib/registry-bulk-limits.ts
@@ -1,0 +1,8 @@
+/** Max PDFs per multipart upload request (API multipart `files` limit is 20). */
+export const REGISTRY_UPLOAD_CHUNK_SIZE = 15;
+
+/** Parallel upload-pdfs requests while adding many registry PDFs. */
+export const REGISTRY_UPLOAD_CONCURRENCY = 2;
+
+/** Registry rows per save-reports JSON request. */
+export const REGISTRY_SAVE_CHUNK_SIZE = 50;

--- a/src/tabs/registry/lib/registry-bulk-limits.ts
+++ b/src/tabs/registry/lib/registry-bulk-limits.ts
@@ -1,8 +1,16 @@
+/** Max PDF size accepted by the Unearth upload-pdfs API (keep in sync with API PDF_MAX_BYTES). */
+export const REGISTRY_PDF_MAX_BYTES = 100 * 1024 * 1024;
+
 /** Max PDFs per multipart upload request (API multipart `files` limit is 20). */
 export const REGISTRY_UPLOAD_CHUNK_SIZE = 15;
+
+/** Max total bytes per upload chunk (stay under API ingress proxy-body-size). */
+export const REGISTRY_UPLOAD_MAX_CHUNK_BYTES = 300 * 1024 * 1024;
 
 /** Parallel upload-pdfs requests while adding many registry PDFs. */
 export const REGISTRY_UPLOAD_CONCURRENCY = 2;
 
 /** Registry rows per save-reports JSON request. */
 export const REGISTRY_SAVE_CHUNK_SIZE = 50;
+
+export const REGISTRY_PDF_MAX_MB = REGISTRY_PDF_MAX_BYTES / 1024 / 1024;

--- a/src/tabs/registry/lib/registry-types.ts
+++ b/src/tabs/registry/lib/registry-types.ts
@@ -41,6 +41,12 @@ export interface RegistryNewEntry {
   batchId?: string;
 }
 
+export type RegistryBulkProgress = {
+  phase: "upload" | "save";
+  completed: number;
+  total: number;
+};
+
 /** Bulk add from dropped PDF files; metadata is optional (fill in later via edit). */
 export interface RegistryBulkFileAddInput {
   companyName?: string;
@@ -49,6 +55,7 @@ export interface RegistryBulkFileAddInput {
   sourceUrl?: string;
   files: File[];
   batchId?: string;
+  onProgress?: (progress: RegistryBulkProgress) => void;
 }
 
 export interface RegistryStats {

--- a/src/tabs/registry/lib/registry-upload-api.ts
+++ b/src/tabs/registry/lib/registry-upload-api.ts
@@ -1,6 +1,12 @@
+import { chunkArray, mapWithConcurrency } from "@/lib/chunk-array";
 import { getUnearthApiBaseUrl } from "@/config/api-env";
 import { garboAuthFetch } from "@/lib/garbo-auth-fetch";
 import type { UploadPdfUploadMeta } from "@/tabs/upload/lib/upload-api";
+import {
+  REGISTRY_UPLOAD_CHUNK_SIZE,
+  REGISTRY_UPLOAD_CONCURRENCY,
+} from "./registry-bulk-limits";
+import type { RegistryBulkProgress } from "./registry-types";
 
 function registryUploadUrl(path: string): string {
   const base = getUnearthApiBaseUrl().replace(/\/+$/, "");
@@ -38,14 +44,9 @@ function parseUploadError(errorText: string): string {
   return message;
 }
 
-/**
- * Upload PDFs to object storage via Unearth API (storage only, no pipeline jobs).
- */
-export async function uploadRegistryPdfs(
+async function uploadRegistryPdfChunk(
   files: File[],
 ): Promise<UploadPdfUploadMeta[]> {
-  if (files.length === 0) return [];
-
   const formData = new FormData();
   for (const file of files) {
     formData.append("files", file);
@@ -70,4 +71,35 @@ export async function uploadRegistryPdfs(
   }
 
   return body.uploads;
+}
+
+/**
+ * Upload PDFs to object storage via Unearth API (storage only, no pipeline jobs).
+ * Large drops are split into multipart chunks with limited parallel requests.
+ */
+export async function uploadRegistryPdfs(
+  files: File[],
+  onProgress?: (progress: RegistryBulkProgress) => void,
+): Promise<UploadPdfUploadMeta[]> {
+  if (files.length === 0) return [];
+
+  const chunks = chunkArray(files, REGISTRY_UPLOAD_CHUNK_SIZE);
+  let uploadedCount = 0;
+
+  const chunkResults = await mapWithConcurrency(
+    chunks,
+    REGISTRY_UPLOAD_CONCURRENCY,
+    async (chunk) => {
+      const uploads = await uploadRegistryPdfChunk(chunk);
+      uploadedCount += chunk.length;
+      onProgress?.({
+        phase: "upload",
+        completed: uploadedCount,
+        total: files.length,
+      });
+      return uploads;
+    },
+  );
+
+  return chunkResults.flat();
 }

--- a/src/tabs/registry/lib/registry-upload-api.ts
+++ b/src/tabs/registry/lib/registry-upload-api.ts
@@ -1,10 +1,11 @@
-import { chunkArray, mapWithConcurrency } from "@/lib/chunk-array";
+import { chunkFilesBySize, mapWithConcurrency } from "@/lib/chunk-array";
 import { getUnearthApiBaseUrl } from "@/config/api-env";
 import { garboAuthFetch } from "@/lib/garbo-auth-fetch";
 import type { UploadPdfUploadMeta } from "@/tabs/upload/lib/upload-api";
 import {
   REGISTRY_UPLOAD_CHUNK_SIZE,
   REGISTRY_UPLOAD_CONCURRENCY,
+  REGISTRY_UPLOAD_MAX_CHUNK_BYTES,
 } from "./registry-bulk-limits";
 import type { RegistryBulkProgress } from "./registry-types";
 
@@ -83,7 +84,11 @@ export async function uploadRegistryPdfs(
 ): Promise<UploadPdfUploadMeta[]> {
   if (files.length === 0) return [];
 
-  const chunks = chunkArray(files, REGISTRY_UPLOAD_CHUNK_SIZE);
+  const chunks = chunkFilesBySize(
+    files,
+    REGISTRY_UPLOAD_CHUNK_SIZE,
+    REGISTRY_UPLOAD_MAX_CHUNK_BYTES,
+  );
   let uploadedCount = 0;
 
   const chunkResults = await mapWithConcurrency(

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -158,7 +158,7 @@ function climatePlansManifest(): Plugin {
 
 const PROXY_TIMEOUT_MS = 30000;
 /** Overview / internal Unearth routes — aggregation can be slow until SQL pagination lands. */
-const UNEARTH_PROXY_TIMEOUT_MS = 120000;
+const UNEARTH_PROXY_TIMEOUT_MS = 600000;
 
 function pipelineProxyConfigure(targetUrl: string) {
   return (proxy: any, _options: any) => {


### PR DESCRIPTION
## Summary
- Split large PDF drops into 15-file upload chunks (2 parallel requests)
- Save registry rows in 50-entry chunks
- Show upload/save progress in Add Entry modal
- Increase Unearth proxy timeouts for bulk uploads (vite + nginx)

## Test plan
- [ ] Drop 30+ PDFs in Registry Add Entry (multi/files)
- [ ] Network: multiple upload-pdfs requests, not one giant POST
- [ ] Progress text updates during upload and save
- [ ] All entries appear in registry after completion

Deploy after API ingress PR (UnearthData/api#20) is on staging.

Made with [Cursor](https://cursor.com)