### PR TITLE
Registry bulk upload progress bar and smoother progress

### DIFF
--- a/src/tabs/registry/RegistryTab.tsx
+++ b/src/tabs/registry/RegistryTab.tsx
@@ -15,6 +15,7 @@ import type {
   RegistryBulkProgress,
   RegistryEntry,
   RegistryEntryUpdate,
+  RegistryNewEntry,
 } from "./lib/registry-types";
 import { writeRegistryEntriesToCsv } from "./lib/registry-utils";
 import {
@@ -39,10 +40,6 @@ import {
 } from "./lib/registry-api";
 import RegistryFiltersAndSort from "./components/RegistryFiltersAndSort";
 import RegistryAddModal from "./components/RegistryAddModal";
-import type {
-  RegistryBulkFileAddInput,
-  RegistryNewEntry,
-} from "./lib/registry-types";
 
 export function RegistryTab() {
   return (
@@ -264,7 +261,11 @@ function RegistryTabContent() {
 
   const handleAddFiles = async (input: RegistryBulkFileAddInput) => {
     setIsAddingEntry(true);
-    setBulkAddProgress(null);
+    setBulkAddProgress({
+      phase: "upload",
+      completed: 0,
+      total: input.files.length,
+    });
     try {
       const newEntries = await addRegistryEntriesFromFiles({
         ...input,

--- a/src/tabs/registry/components/RegistryAddModal.tsx
+++ b/src/tabs/registry/components/RegistryAddModal.tsx
@@ -30,6 +30,7 @@ import type {
 import { isValidHttpUrl, isValidOptionalHttpUrl } from "../lib/registry-utils";
 import { RegistryDroppedFilesList } from "./RegistryDroppedFilesList";
 import { RegistryAddBatchOptions } from "./RegistryAddBatchOptions";
+import { RegistryBulkUploadProgress } from "./RegistryBulkUploadProgress";
 
 type AddMode = "single" | "multi";
 type MultiInputMode = "files" | "urls";
@@ -348,19 +349,9 @@ const RegistryAddModal = ({
       ? isAdding
         ? t("registry.addEntryAdding")
         : t("registry.addEntry")
-      : isAdding && bulkProgress
-        ? bulkProgress.phase === "upload"
-          ? t("registry.bulkUploadProgressUpload", {
-              completed: bulkProgress.completed,
-              total: bulkProgress.total,
-            })
-          : t("registry.bulkUploadProgressSave", {
-              completed: bulkProgress.completed,
-              total: bulkProgress.total,
-            })
-        : isAdding
-          ? t("registry.addEntryAdding")
-          : t("registry.addEntriesCount", { count: submitCount });
+      : isAdding
+        ? t("registry.addEntryAdding")
+        : t("registry.addEntriesCount", { count: submitCount });
 
   const batchOptions = (
     <RegistryAddBatchOptions
@@ -550,17 +541,7 @@ const RegistryAddModal = ({
         </Tabs>
 
         {bulkProgress && (
-          <p className="text-sm text-gray-02" role="status">
-            {bulkProgress.phase === "upload"
-              ? t("registry.bulkUploadProgressUpload", {
-                  completed: bulkProgress.completed,
-                  total: bulkProgress.total,
-                })
-              : t("registry.bulkUploadProgressSave", {
-                  completed: bulkProgress.completed,
-                  total: bulkProgress.total,
-                })}
-          </p>
+          <RegistryBulkUploadProgress progress={bulkProgress} />
         )}
 
         <DialogFooter>

--- a/src/tabs/registry/components/RegistryAddModal.tsx
+++ b/src/tabs/registry/components/RegistryAddModal.tsx
@@ -540,9 +540,7 @@ const RegistryAddModal = ({
           </TabsContent>
         </Tabs>
 
-        {bulkProgress && (
-          <RegistryBulkUploadProgress progress={bulkProgress} />
-        )}
+        {bulkProgress && <RegistryBulkUploadProgress progress={bulkProgress} />}
 
         <DialogFooter>
           <Button

--- a/src/tabs/registry/components/RegistryBulkUploadProgress.tsx
+++ b/src/tabs/registry/components/RegistryBulkUploadProgress.tsx
@@ -1,0 +1,49 @@
+import { useI18n } from "@/contexts/I18nContext";
+import type { RegistryBulkProgress } from "../lib/registry-types";
+
+type RegistryBulkUploadProgressProps = {
+  progress: RegistryBulkProgress;
+};
+
+export function RegistryBulkUploadProgress({
+  progress,
+}: RegistryBulkUploadProgressProps) {
+  const { t } = useI18n();
+  const { phase, completed, total } = progress;
+  const percent =
+    total > 0 ? Math.min(100, Math.round((completed / total) * 100)) : 0;
+  const isStarting = completed === 0 && total > 0;
+
+  const label =
+    phase === "upload"
+      ? t("registry.bulkUploadProgressUpload", { completed, total })
+      : t("registry.bulkUploadProgressSave", { completed, total });
+
+  return (
+    <div className="space-y-2" role="status" aria-live="polite">
+      <div className="flex items-center justify-between gap-3 text-sm text-gray-02">
+        <span>{label}</span>
+        <span className="tabular-nums shrink-0">
+          {isStarting ? "…" : `${percent}%`}
+        </span>
+      </div>
+      <div className="relative h-2 w-full rounded-full bg-gray-03 overflow-hidden">
+        {isStarting && (
+          <div
+            className="absolute inset-0 bg-orange-03/25 animate-pulse"
+            aria-hidden
+          />
+        )}
+        <div
+          className="relative h-full rounded-full bg-orange-03 transition-[width] duration-300 ease-out"
+          style={{ width: `${Math.max(isStarting ? 2 : 0, percent)}%` }}
+          role="progressbar"
+          aria-valuenow={completed}
+          aria-valuemin={0}
+          aria-valuemax={total}
+          aria-label={label}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/tabs/registry/lib/registry-api.ts
+++ b/src/tabs/registry/lib/registry-api.ts
@@ -202,6 +202,8 @@ async function saveRegistryPayloadsInChunks(
   payloads: RegistryNewEntry[],
   onProgress?: (progress: RegistryBulkProgress) => void,
 ): Promise<{ saved: RegistryEntry[]; partialFailure?: string }> {
+  onProgress?.({ phase: "save", completed: 0, total: payloads.length });
+
   if (payloads.length <= REGISTRY_SAVE_CHUNK_SIZE) {
     return saveRegistryPayloads(payloads, onProgress);
   }

--- a/src/tabs/registry/lib/registry-bulk-limits.ts
+++ b/src/tabs/registry/lib/registry-bulk-limits.ts
@@ -2,15 +2,15 @@
 export const REGISTRY_PDF_MAX_BYTES = 250 * 1024 * 1024;
 
 /** Max PDFs per multipart upload request (API multipart `files` limit is 20). */
-export const REGISTRY_UPLOAD_CHUNK_SIZE = 15;
+export const REGISTRY_UPLOAD_CHUNK_SIZE = 5;
 
 /** Max total bytes per upload chunk (stay under ingress proxy-body-size). */
 export const REGISTRY_UPLOAD_MAX_CHUNK_BYTES = 400 * 1024 * 1024;
 
 /** Parallel upload-pdfs requests while adding many registry PDFs. */
-export const REGISTRY_UPLOAD_CONCURRENCY = 2;
+export const REGISTRY_UPLOAD_CONCURRENCY = 3;
 
 /** Registry rows per save-reports JSON request. */
-export const REGISTRY_SAVE_CHUNK_SIZE = 50;
+export const REGISTRY_SAVE_CHUNK_SIZE = 10;
 
 export const REGISTRY_PDF_MAX_MB = REGISTRY_PDF_MAX_BYTES / 1024 / 1024;

--- a/src/tabs/registry/lib/registry-upload-api.ts
+++ b/src/tabs/registry/lib/registry-upload-api.ts
@@ -89,6 +89,9 @@ export async function uploadRegistryPdfs(
     REGISTRY_UPLOAD_CHUNK_SIZE,
     REGISTRY_UPLOAD_MAX_CHUNK_BYTES,
   );
+
+  onProgress?.({ phase: "upload", completed: 0, total: files.length });
+
   let uploadedCount = 0;
 
   const chunkResults = await mapWithConcurrency(


### PR DESCRIPTION
## Summary
- Add visual progress bar component for registry multi-file PDF upload (was only text in PR #226)
- Show 0/N immediately when upload starts; pulsing bar while waiting for first chunk
- Smaller upload chunks (5 files, 3 parallel) and save chunks (10) for smoother counter updates
- Fix duplicate \RegistryBulkFileAddInput\ import in \RegistryTab.tsx\ (breaks dev build on main)

## Why staging did not show the bar
PR #226 merged chunking and text progress only. \RegistryBulkUploadProgress.tsx\ was never pushed/merged.

## Test plan
- [ ] Registry → Add Entry → Multiple → drop 10+ PDFs → see bar at 0/N then 5, 10, …
- [ ] Merge → CI pushes GHCR → \kubectl rollout restart deployment validate-frontend -n validate-frontend-stage\ if tag unchanged

Made with [Cursor](https://cursor.com)