### PR TITLE
Registry: paginated browse and API-backed multi-search

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1164,7 +1164,7 @@
   "registry": {
     "title": "Registry",
     "subtitle": "Search and inspect registry entries before wiring full workflows.",
-    "searchPlaceholder": "Search company name or Wikidata ID (e.g. Q12345)",
+    "searchPlaceholder": "Search company name, Wikidata ID, or URL — paste one company per line from Excel",
     "runReports": "Run Reports",
     "runningReports": "Running Reports...",
     "runReportsDescription": "Run selected reports with upload options ({{count}} selected).",
@@ -1175,7 +1175,7 @@
     "noReportUrls": "No valid report URLs found in selection.",
     "exportCsv": "Export CSV",
     "deleteSelected": "Delete Selected",
-    "loading": "Searching registry...",
+    "loading": "Loading registry…",
     "empty": "Registry is empty.",
     "fetchError": "Failed to fetch registry.",
     "noResults": "No registry entries matched your search.",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -1164,7 +1164,7 @@
   "registry": {
     "title": "Register",
     "subtitle": "Sök och granska registerposter innan fulla flöden kopplas in.",
-    "searchPlaceholder": "Sök företagsnamn eller Wikidata-ID (t.ex. Q12345)",
+    "searchPlaceholder": "Sök företagsnamn, Wikidata-ID eller URL — klistra in ett företag per rad från Excel",
     "runReports": "Kör rapporter",
     "runningReports": "Kör rapporter...",
     "runReportsDescription": "Kör valda rapporter med uppladdningsalternativ ({{count}} valda).",
@@ -1175,7 +1175,7 @@
     "noReportUrls": "Inga giltiga rapport-URL:er hittades i urvalet.",
     "exportCsv": "Exportera CSV",
     "deleteSelected": "Ta bort valda",
-    "loading": "Söker i registret...",
+    "loading": "Laddar register…",
     "empty": "Registret är tomt.",
     "fetchError": "Kunde inte hämta registret.",
     "noResults": "Inga registerposter matchade din sökning.",

--- a/src/tabs/registry/RegistryTab.tsx
+++ b/src/tabs/registry/RegistryTab.tsx
@@ -1,10 +1,9 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { motion } from "framer-motion";
 import { Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { useI18n } from "@/contexts/I18nContext";
 import { Callout } from "@/ui/callout";
-import { ApiAuthError } from "@/lib/garbo-auth-fetch";
 import { RunReportsModal } from "@/components/RunReportsModal";
 import { useRunReportsPipeline } from "@/hooks/useRunReportsPipeline";
 import RegistryControls from "./components/RegistryControls";
@@ -28,14 +27,13 @@ import {
   RegistryBatchesProvider,
   useRegistryBatchesContext,
 } from "./contexts/RegistryBatchesContext";
-import { useRegistryDisplayedView } from "./hooks/useRegistryDisplayedView";
+import { useRegistryData } from "./hooks/useRegistryData";
 import {
   addRegistryEntry,
   addRegistryEntries,
   addRegistryEntriesFromFiles,
   deleteReportFromRegistry,
   editRegistryEntry,
-  fetchRegistryList,
   getRegistryRunReportsPipelineConfig,
 } from "./lib/registry-api";
 import RegistryFiltersAndSort from "./components/RegistryFiltersAndSort";
@@ -52,11 +50,8 @@ export function RegistryTab() {
 function RegistryTabContent() {
   const { t } = useI18n();
   const [query, setQuery] = useState<string>("");
-  const [isLoading, setIsLoading] = useState<boolean>(false);
-  const [loadError, setLoadError] = useState<string | null>(null);
-  const [isAuthError, setIsAuthError] = useState(false);
+  const [page, setPage] = useState(1);
   const [selectedReports, setSelectedReports] = useState<RegistryEntry[]>([]);
-  const [registry, setRegistry] = useState<RegistryEntry[]>([]);
   const [isDeletingSelected, setIsDeletingSelected] = useState<boolean>(false);
   const [editingReportIds, setEditingReportIds] = useState<string[]>([]);
   const [isRunReportsOpen, setIsRunReportsOpen] = useState<boolean>(false);
@@ -65,9 +60,17 @@ function RegistryTabContent() {
   const [bulkAddProgress, setBulkAddProgress] =
     useState<RegistryBulkProgress | null>(null);
   const [filters, setFilters] = useState(defaultRegistryViewFilters);
-  const patchFilters = useCallback((patch: Partial<RegistryViewFilters>) => {
-    setFilters((f) => mergeRegistryViewFilters(f, patch));
+  const resetListView = useCallback(() => {
+    setPage(1);
+    setSelectedReports([]);
   }, []);
+  const patchFilters = useCallback(
+    (patch: Partial<RegistryViewFilters>) => {
+      setFilters((f) => mergeRegistryViewFilters(f, patch));
+      resetListView();
+    },
+    [resetListView],
+  );
   const {
     wikidataToTags,
     loading: companyTagsLoading,
@@ -95,57 +98,38 @@ function RegistryTabContent() {
     },
   });
 
-  const batchFilterOptions = useMemo(() => {
-    const byId = new Map(registryBatches.map((b) => [b.id, b.batchName]));
-    for (const entry of registry) {
-      const id = entry.batchId?.trim();
-      if (!id) continue;
-      if (!byId.has(id)) {
-        byId.set(id, entry.batchName?.trim() || id);
-      }
-    }
-    return [...byId.entries()]
-      .sort((a, b) =>
-        a[1].localeCompare(b[1], undefined, { sensitivity: "base" }),
-      )
-      .map(([id, batchName]) => ({ id, batchName }));
-  }, [registryBatches, registry]);
+  const batchFilterOptions = useMemo(
+    () =>
+      [...registryBatches]
+        .sort((a, b) =>
+          a.batchName.localeCompare(b.batchName, undefined, {
+            sensitivity: "base",
+          }),
+        )
+        .map(({ id, batchName }) => ({ id, batchName })),
+    [registryBatches],
+  );
 
   const {
-    displayedRegistry,
-    distinctReportYears,
-    hasStructuredFilters,
+    rows: displayedRegistry,
+    meta,
+    reportYears: distinctReportYears,
     stats,
-  } = useRegistryDisplayedView(registry, query, filters, wikidataToTags);
-
-  const loadRegistry = useCallback(async () => {
-    setIsLoading(true);
-    setLoadError(null);
-    setIsAuthError(false);
-    try {
-      const data = await fetchRegistryList();
-      setRegistry(Array.isArray(data) ? data : []);
-      setSelectedReports([]);
-    } catch (error) {
-      console.error("Failed to load registry", error);
-      setRegistry([]);
-      setSelectedReports([]);
-      if (error instanceof ApiAuthError) {
-        setIsAuthError(true);
-      } else {
-        setLoadError(error instanceof Error ? error.message : "Unknown error");
-      }
-    } finally {
-      setIsLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    void loadRegistry();
-  }, [loadRegistry]);
+    isLoading,
+    loadError,
+    isAuthError,
+    hasStructuredFilters,
+    refresh,
+  } = useRegistryData({
+    page,
+    query,
+    filters,
+    wikidataToTags,
+    companyTagsLoading,
+  });
 
   const handleRefresh = () => {
-    void loadRegistry();
+    void refresh();
   };
 
   const handleExport = () => {
@@ -195,12 +179,10 @@ function RegistryTabContent() {
     try {
       await deleteReportFromRegistry(selectedReportIds);
       const deletedIds = new Set(selectedReportIds);
-      setRegistry((current) =>
-        current.filter((item) => !item.id || !deletedIds.has(item.id)),
-      );
       setSelectedReports((current) =>
         current.filter((item) => !item.id || !deletedIds.has(item.id)),
       );
+      await refresh();
     } catch (error) {
       console.error("Failed to delete selected reports", error);
     } finally {
@@ -219,7 +201,7 @@ function RegistryTabContent() {
     setIsAddingEntry(true);
     try {
       await addRegistryEntry(entry);
-      await loadRegistry();
+      await refresh();
       refetchRegistryBatches();
       toast.success(t("registry.addEntrySuccess"));
     } catch (error) {
@@ -235,13 +217,13 @@ function RegistryTabContent() {
     setIsAddingEntry(true);
     try {
       const saved = await addRegistryEntries(entries);
-      await loadRegistry();
+      await refresh();
       refetchRegistryBatches();
       toast.success(t("registry.addEntriesSuccess", { count: saved.length }));
     } catch (error) {
       const partial = error as Error & { partialSuccess?: RegistryEntry[] };
       if (partial.partialSuccess?.length) {
-        await loadRegistry();
+        await refresh();
         refetchRegistryBatches();
         toast.warning(
           t("registry.addEntriesPartial", {
@@ -271,7 +253,7 @@ function RegistryTabContent() {
         ...input,
         onProgress: setBulkAddProgress,
       });
-      await loadRegistry();
+      await refresh();
       refetchRegistryBatches();
       toast.success(
         t("registry.addEntriesSuccess", { count: newEntries.length }),
@@ -279,7 +261,7 @@ function RegistryTabContent() {
     } catch (error) {
       const partial = error as Error & { partialSuccess?: RegistryEntry[] };
       if (partial.partialSuccess?.length) {
-        await loadRegistry();
+        await refresh();
         refetchRegistryBatches();
         toast.warning(
           t("registry.addEntriesPartial", {
@@ -307,11 +289,6 @@ function RegistryTabContent() {
 
     try {
       const updatedEntry = await editRegistryEntry(entry);
-      setRegistry((current) =>
-        current.map((item) =>
-          item.id === updatedEntry.id ? updatedEntry : item,
-        ),
-      );
       setSelectedReports((current) =>
         current.map((item) =>
           item.id === updatedEntry.id ? updatedEntry : item,
@@ -319,6 +296,7 @@ function RegistryTabContent() {
       );
       toast.success(t("registry.editReportSuccess"));
       refetchRegistryBatches();
+      await refresh();
     } catch (error) {
       console.error("Failed to edit registry entry", error);
       const message = error instanceof Error ? error.message : String(error);
@@ -327,6 +305,10 @@ function RegistryTabContent() {
       setEditingReportIds((current) => current.filter((id) => id !== reportId));
     }
   };
+
+  const paginationFrom =
+    meta.total === 0 ? 0 : (meta.page - 1) * meta.pageSize + 1;
+  const paginationTo = Math.min(meta.page * meta.pageSize, meta.total);
 
   return (
     <div className="flex flex-col gap-6">
@@ -346,7 +328,7 @@ function RegistryTabContent() {
           query={query}
           onQueryChange={(value) => {
             setQuery(value);
-            setSelectedReports([]);
+            resetListView();
           }}
           onRefresh={handleRefresh}
           isRefreshing={isLoading}
@@ -374,7 +356,7 @@ function RegistryTabContent() {
         />
 
         <RegistryFiltersAndSort
-          disabled={isLoading || registry.length === 0}
+          disabled={isLoading && displayedRegistry.length === 0}
           filters={filters}
           onFiltersChange={patchFilters}
           distinctYears={distinctReportYears}
@@ -419,15 +401,19 @@ function RegistryTabContent() {
         <p className="text-sm text-red-01">{t("registry.fetchError")}</p>
       )}
 
-      {!isLoading && !isAuthError && !loadError && registry.length === 0 && (
-        <p className="text-sm text-gray-02">{t("registry.empty")}</p>
-      )}
+      {!isLoading &&
+        !isAuthError &&
+        !loadError &&
+        meta.total === 0 &&
+        !query.trim() &&
+        !hasStructuredFilters && (
+          <p className="text-sm text-gray-02">{t("registry.empty")}</p>
+        )}
 
       {!isLoading &&
         !isAuthError &&
         !loadError &&
-        registry.length > 0 &&
-        displayedRegistry.length === 0 &&
+        meta.total === 0 &&
         (query.trim().length > 0 || hasStructuredFilters) && (
           <p className="text-sm text-gray-02">{t("registry.noResults")}</p>
         )}
@@ -446,6 +432,14 @@ function RegistryTabContent() {
               onToggleSelect={handleToggleSelect}
               onEdit={handleEditEntry}
               editingReportIds={editingReportIds}
+              pagination={{
+                from: paginationFrom,
+                to: paginationTo,
+                total: meta.total,
+                page: meta.page,
+                totalPages: meta.totalPages,
+                onPageChange: setPage,
+              }}
             />
           </>
         )}

--- a/src/tabs/registry/components/RegistryControls.tsx
+++ b/src/tabs/registry/components/RegistryControls.tsx
@@ -38,11 +38,12 @@ const RegistryControls = ({
   return (
     <div className="flex flex-col gap-4">
       <div className="flex flex-col md:flex-row gap-3 md:items-center">
-        <input
+        <textarea
           value={query}
           onChange={(event) => onQueryChange(event.target.value)}
           placeholder={t("registry.searchPlaceholder")}
-          className="bg-gray-03/20 w-full border p-2 flex items-center justify-center border-gray-03 rounded-lg text-gray-01 placeholder:text-gray-02 focus:outline-none focus:ring-2 focus:ring-orange-03"
+          rows={2}
+          className="bg-gray-03/20 w-full min-h-[2.75rem] border p-2 border-gray-03 rounded-lg text-gray-01 placeholder:text-gray-02 focus:outline-none focus:ring-2 focus:ring-orange-03 resize-y"
         />
       </div>
       <div className="flex gap-2">

--- a/src/tabs/registry/components/RegistryResultsList.tsx
+++ b/src/tabs/registry/components/RegistryResultsList.tsx
@@ -6,8 +6,18 @@ import {
   DataTableHead,
   DataTableShell,
 } from "@/ui/data-table";
+import { ClientTablePagination } from "@/ui/client-table-pagination";
 import type { RegistryEntry, RegistryEntryUpdate } from "../lib/registry-types";
 import RegistryResultItem from "./RegistryResultItem";
+
+type RegistryPagination = {
+  from: number;
+  to: number;
+  total: number;
+  page: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+};
 
 interface RegistryResultsListProps {
   registry: RegistryEntry[];
@@ -17,6 +27,7 @@ interface RegistryResultsListProps {
   onToggleSelect: (entry: RegistryEntry) => void;
   onEdit: (entry: RegistryEntryUpdate) => Promise<void>;
   editingReportIds: string[];
+  pagination: RegistryPagination;
 }
 
 const RegistryResultsList = ({
@@ -27,6 +38,7 @@ const RegistryResultsList = ({
   onToggleSelect,
   onEdit,
   editingReportIds,
+  pagination,
 }: RegistryResultsListProps) => {
   const { t } = useI18n();
 
@@ -99,6 +111,17 @@ const RegistryResultsList = ({
             })}
           </DataTableBody>
         </DataTable>
+        <ClientTablePagination
+          from={pagination.from}
+          to={pagination.to}
+          filteredTotal={pagination.total}
+          page={pagination.page}
+          totalPages={pagination.totalPages}
+          showAll={false}
+          canPaginate={pagination.totalPages > 1}
+          onPageChange={pagination.onPageChange}
+          onShowAllChange={() => undefined}
+        />
       </DataTableShell>
     </motion.div>
   );

--- a/src/tabs/registry/hooks/useRegistryData.ts
+++ b/src/tabs/registry/hooks/useRegistryData.ts
@@ -1,0 +1,213 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { RegistryEntry, RegistryStats } from "../lib/registry-types";
+import {
+  fetchRegistryPage,
+  searchRegistryPage,
+  type RegistryBrowseParams,
+  REGISTRY_PAGE_SIZE,
+} from "../lib/registry-api";
+import { parseRegistrySearchTerms } from "../lib/registry-utils";
+import {
+  isWikidataIdPresent,
+  type RegistryViewFilters,
+} from "../lib/registry-table-utils";
+import { ApiAuthError } from "@/lib/garbo-auth-fetch";
+
+export type RegistryPageMeta = {
+  total: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+};
+
+type UseRegistryDataOptions = {
+  page: number;
+  query: string;
+  filters: RegistryViewFilters;
+  wikidataToTags: Record<string, string[]> | null;
+  companyTagsLoading: boolean;
+};
+
+function wikidataIdsForTagFilter(
+  tagMode: RegistryViewFilters["tagMode"],
+  tagSlugs: string[],
+  wikidataToTags: Record<string, string[]> | null,
+): string[] | undefined {
+  if (!wikidataToTags || tagMode === "ignore") return undefined;
+
+  const ids: string[] = [];
+  for (const [qid, tags] of Object.entries(wikidataToTags)) {
+    if (!isWikidataIdPresent(qid)) continue;
+    if (tagMode === "no_tags_in_garbo" && tags.length === 0) {
+      ids.push(qid);
+    } else if (tagMode === "has_any_of") {
+      const slugs = new Set(tagSlugs.map((s) => s.trim().toLowerCase()));
+      if (tags.some((tag) => slugs.has(tag.toLowerCase()))) {
+        ids.push(qid);
+      }
+    }
+  }
+  return ids;
+}
+
+function browseParamsFromFilters(
+  filters: RegistryViewFilters,
+  wikidataToTags: Record<string, string[]> | null,
+): RegistryBrowseParams {
+  const tagWikidataIds = wikidataIdsForTagFilter(
+    filters.tagMode,
+    filters.tagSlugs,
+    wikidataToTags,
+  );
+
+  return {
+    reportYear: filters.year,
+    batchId: filters.batch,
+    wikidata: filters.wikidata,
+    sort: filters.sort,
+    ...(tagWikidataIds ? { wikidataIds: tagWikidataIds } : {}),
+  };
+}
+
+export function useRegistryData({
+  page,
+  query,
+  filters,
+  wikidataToTags,
+  companyTagsLoading,
+}: UseRegistryDataOptions) {
+  const [rows, setRows] = useState<RegistryEntry[]>([]);
+  const [meta, setMeta] = useState<RegistryPageMeta>({
+    total: 0,
+    page: 1,
+    pageSize: REGISTRY_PAGE_SIZE,
+    totalPages: 1,
+  });
+  const [reportYears, setReportYears] = useState<string[]>([]);
+  const [stats, setStats] = useState<RegistryStats>({
+    uniqueCompanies: 0,
+    totalReports: 0,
+  });
+  const [isLoading, setIsLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [isAuthError, setIsAuthError] = useState(false);
+
+  const searchTerms = useMemo(() => parseRegistrySearchTerms(query), [query]);
+  const isSearchMode = searchTerms.length > 0;
+
+  const browseParams = useMemo(
+    () => browseParamsFromFilters(filters, wikidataToTags),
+    [filters, wikidataToTags],
+  );
+
+  const tagFilterBlocksFetch =
+    (filters.tagMode === "has_any_of" && filters.tagSlugs.length > 0) ||
+    filters.tagMode === "no_tags_in_garbo"
+      ? companyTagsLoading || !wikidataToTags
+      : false;
+
+  const tagFilterHasNoMatches =
+    !companyTagsLoading &&
+    wikidataToTags != null &&
+    ((filters.tagMode === "has_any_of" &&
+      filters.tagSlugs.length > 0 &&
+      (browseParams.wikidataIds?.length ?? 0) === 0) ||
+      (filters.tagMode === "no_tags_in_garbo" &&
+        (browseParams.wikidataIds?.length ?? 0) === 0));
+
+  const load = useCallback(async () => {
+    if (tagFilterBlocksFetch) {
+      return;
+    }
+
+    setIsLoading(true);
+    setLoadError(null);
+    setIsAuthError(false);
+
+    if (tagFilterHasNoMatches) {
+      setRows([]);
+      setMeta({
+        total: 0,
+        page: 1,
+        pageSize: REGISTRY_PAGE_SIZE,
+        totalPages: 1,
+      });
+      setReportYears([]);
+      setStats({ uniqueCompanies: 0, totalReports: 0 });
+      setIsLoading(false);
+      return;
+    }
+
+    try {
+      const response = isSearchMode
+        ? await searchRegistryPage(
+            searchTerms,
+            page,
+            REGISTRY_PAGE_SIZE,
+            browseParams,
+          )
+        : await fetchRegistryPage(page, REGISTRY_PAGE_SIZE, browseParams);
+
+      setRows(response.rows);
+      setMeta({
+        total: response.total,
+        page: response.page,
+        pageSize: response.pageSize,
+        totalPages: response.totalPages,
+      });
+      setReportYears(response.reportYears);
+      setStats({
+        totalReports: response.stats.totalReports,
+        uniqueCompanies: response.stats.uniqueCompanies ?? 0,
+      });
+    } catch (error) {
+      console.error("Failed to load registry page", error);
+      setRows([]);
+      setMeta({
+        total: 0,
+        page: 1,
+        pageSize: REGISTRY_PAGE_SIZE,
+        totalPages: 1,
+      });
+      setReportYears([]);
+      setStats({ uniqueCompanies: 0, totalReports: 0 });
+      if (error instanceof ApiAuthError) {
+        setIsAuthError(true);
+      } else {
+        setLoadError(error instanceof Error ? error.message : "Unknown error");
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, [
+    browseParams,
+    isSearchMode,
+    page,
+    searchTerms,
+    tagFilterBlocksFetch,
+    tagFilterHasNoMatches,
+  ]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const hasStructuredFilters =
+    filters.year !== "all" ||
+    filters.batch !== "all" ||
+    filters.wikidata !== "all" ||
+    filters.tagMode !== "ignore";
+
+  return {
+    rows,
+    meta,
+    reportYears,
+    stats,
+    isLoading: isLoading || tagFilterBlocksFetch,
+    loadError,
+    isAuthError,
+    isSearchMode,
+    hasStructuredFilters,
+    refresh: load,
+  };
+}

--- a/src/tabs/registry/lib/registry-api.ts
+++ b/src/tabs/registry/lib/registry-api.ts
@@ -7,15 +7,37 @@ import type {
   RegistryNewEntry,
   RegistryBulkFileAddInput,
 } from "./registry-types";
-import { filterRegistryEntries } from "./registry-utils";
 import { chunkArray } from "@/lib/chunk-array";
 import { REGISTRY_SAVE_CHUNK_SIZE } from "./registry-bulk-limits";
 import { uploadRegistryPdfs } from "./registry-upload-api";
 import type { RegistryBulkProgress } from "./registry-types";
+import type { RegistrySortKey } from "./registry-table-utils";
 
 import type { RunReportsPipelineConfig } from "@/hooks/useRunReportsPipeline";
 
 const REGISTRY_BATCHES_LIMIT = 500;
+export const REGISTRY_PAGE_SIZE = 75;
+
+export type RegistryBrowseParams = {
+  reportYear?: string;
+  batchId?: string;
+  wikidata?: "all" | "present" | "missing";
+  wikidataIds?: string[];
+  sort?: RegistrySortKey;
+};
+
+export type RegistryPageResponse = {
+  rows: RegistryEntry[];
+  total: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+  reportYears: string[];
+  stats: {
+    totalReports: number;
+    uniqueCompanies: number | null;
+  };
+};
 
 function registryUrl(path: string): string {
   const base = getUnearthApiBaseUrl().replace(/\/+$/, "");
@@ -33,24 +55,102 @@ export function getRegistryRunReportsPipelineConfig(): RunReportsPipelineConfig 
   };
 }
 
-export const fetchRegistryList = async () => {
-  const url = registryUrl("reports/registry");
+function appendBrowseParams(
+  params: URLSearchParams,
+  browse: RegistryBrowseParams | undefined,
+): void {
+  if (!browse) return;
+  if (browse.reportYear && browse.reportYear !== "all") {
+    params.set("reportYear", browse.reportYear);
+  }
+  if (browse.batchId && browse.batchId !== "all") {
+    params.set("batchId", browse.batchId);
+  }
+  if (browse.wikidata && browse.wikidata !== "all") {
+    params.set("wikidata", browse.wikidata);
+  }
+  if (browse.sort) {
+    params.set("sort", browse.sort);
+  }
+  if (browse.wikidataIds?.length) {
+    params.set("wikidataIds", browse.wikidataIds.join(","));
+  }
+}
+
+async function parseRegistryPageResponse(
+  response: Response,
+  url: string,
+): Promise<RegistryPageResponse> {
+  if (!response.ok) {
+    throwIfAuthError(response.status);
+    const msg = `Failed to fetch registry: ${response.status} ${response.statusText} (${url})`;
+    console.error(msg);
+    throw new Error(msg);
+  }
+  return (await response.json()) as RegistryPageResponse;
+}
+
+export async function fetchRegistryPage(
+  page: number,
+  pageSize = REGISTRY_PAGE_SIZE,
+  browse?: RegistryBrowseParams,
+): Promise<RegistryPageResponse> {
+  const params = new URLSearchParams({
+    page: String(page),
+    pageSize: String(pageSize),
+  });
+  appendBrowseParams(params, browse);
+  const url = registryUrl(`reports/registry?${params.toString()}`);
   try {
     const response = await garboAuthFetch(url, { cache: "no-store" });
-    if (response.ok) {
-      const data = await response.json();
-      return data;
-    } else {
-      throwIfAuthError(response.status);
-      const msg = `Failed to fetch registry: ${response.status} ${response.statusText} (${url})`;
-      console.error(msg);
-      throw new Error(msg);
-    }
+    return parseRegistryPageResponse(response, url);
   } catch (error) {
-    const msg = `Failed to fetch company names (${url})`;
+    const msg = `Failed to fetch registry page (${url})`;
     console.error(msg, error);
     throw error instanceof Error ? error : new Error(msg);
   }
+}
+
+export async function searchRegistryPage(
+  terms: string[],
+  page: number,
+  pageSize = REGISTRY_PAGE_SIZE,
+  browse?: RegistryBrowseParams,
+): Promise<RegistryPageResponse> {
+  const normalized = terms.map((term) => term.trim()).filter(Boolean);
+  if (normalized.length === 0) {
+    return fetchRegistryPage(page, pageSize, browse);
+  }
+
+  const params = new URLSearchParams({
+    page: String(page),
+    pageSize: String(pageSize),
+  });
+  appendBrowseParams(params, browse);
+
+  if (normalized.length === 1) {
+    params.set("q", normalized[0]!);
+  } else {
+    for (const term of normalized) {
+      params.append("term", term);
+    }
+  }
+
+  const url = registryUrl(`reports/registry/search?${params.toString()}`);
+  try {
+    const response = await garboAuthFetch(url, { cache: "no-store" });
+    return parseRegistryPageResponse(response, url);
+  } catch (error) {
+    const msg = `Failed to search registry (${url})`;
+    console.error(msg, error);
+    throw error instanceof Error ? error : new Error(msg);
+  }
+}
+
+/** @deprecated Use fetchRegistryPage — kept for callers not yet migrated. */
+export const fetchRegistryList = async () => {
+  const page = await fetchRegistryPage(1, REGISTRY_PAGE_SIZE);
+  return page.rows;
 };
 
 export async function fetchRegistryBatches() {
@@ -66,33 +166,6 @@ export async function fetchRegistryBatches() {
     batches?: { id: string; batchName: string }[];
   };
   return Array.isArray(data.batches) ? data.batches : [];
-}
-
-export async function searchRegistryEntries(
-  query: string,
-): Promise<RegistryEntry[]> {
-  const trimmedQuery = query.trim();
-  if (!trimmedQuery) {
-    return [];
-  }
-
-  //Swap to actual API call when available.
-  const url = registryUrl(
-    `registry/search?query=${encodeURIComponent(trimmedQuery)}`,
-  );
-
-  try {
-    const response = await fetch(url);
-    if (!response.ok) {
-      throw new Error(`Registry search failed with status ${response.status}`);
-    }
-
-    const entries = (await response.json()) as RegistryEntry[];
-    return filterRegistryEntries(entries, trimmedQuery);
-  } catch (error) {
-    console.warn("Registry API unavailable. ", error);
-    return [];
-  }
 }
 
 export const deleteReportFromRegistry = async (reportIds: string[]) => {

--- a/src/tabs/registry/lib/registry-utils.test.ts
+++ b/src/tabs/registry/lib/registry-utils.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import {
+  filterRegistryEntries,
+  parseRegistrySearchTerms,
+  registryEntryMatchesSearchTerm,
+} from "./registry-utils";
+import type { RegistryEntry } from "./registry-types";
+
+const sampleEntries: RegistryEntry[] = [
+  {
+    id: "1",
+    companyName: "Skue Sparebank",
+    wikidataId: "Q111",
+    reportYear: "2024",
+    url: "https://example.com/skue.pdf",
+  },
+  {
+    id: "2",
+    companyName: "Magnora ASA",
+    wikidataId: "Q222",
+    reportYear: "2024",
+    url: "https://example.com/magnora.pdf",
+  },
+  {
+    id: "3",
+    companyName: "Tekna Holding ASA",
+    wikidataId: "Q333",
+    reportYear: "2023",
+    url: "https://example.com/tekna.pdf",
+  },
+];
+
+describe("parseRegistrySearchTerms", () => {
+  it("splits newline-separated company names", () => {
+    expect(
+      parseRegistrySearchTerms("Skue Sparebank\nMagnora ASA\nTekna Holding ASA"),
+    ).toEqual(["Skue Sparebank", "Magnora ASA", "Tekna Holding ASA"]);
+  });
+
+  it("splits tab-separated names from Excel row paste", () => {
+    expect(parseRegistrySearchTerms("Skue Sparebank\tMagnora ASA")).toEqual([
+      "Skue Sparebank",
+      "Magnora ASA",
+    ]);
+  });
+
+  it("dedupes terms case-insensitively", () => {
+    expect(parseRegistrySearchTerms("Skue Sparebank\nskue sparebank")).toEqual([
+      "Skue Sparebank",
+    ]);
+  });
+});
+
+describe("filterRegistryEntries", () => {
+  it("matches a single term like before", () => {
+    expect(filterRegistryEntries(sampleEntries, "Q222")).toEqual([
+      sampleEntries[1],
+    ]);
+  });
+
+  it("returns union of matches for multi-line paste", () => {
+    const query = "Skue Sparebank\nTekna Holding ASA";
+    const result = filterRegistryEntries(sampleEntries, query);
+    expect(result.map((e) => e.id)).toEqual(["1", "3"]);
+  });
+
+  it("returns all entries when query is empty", () => {
+    expect(filterRegistryEntries(sampleEntries, "")).toEqual(sampleEntries);
+    expect(filterRegistryEntries(sampleEntries, "   \n  ")).toEqual(
+      sampleEntries,
+    );
+  });
+});
+
+describe("registryEntryMatchesSearchTerm", () => {
+  it("matches company name and wikidata id", () => {
+    expect(registryEntryMatchesSearchTerm(sampleEntries[0]!, "skue")).toBe(true);
+    expect(registryEntryMatchesSearchTerm(sampleEntries[0]!, "Q111")).toBe(true);
+    expect(registryEntryMatchesSearchTerm(sampleEntries[0]!, "Q999")).toBe(
+      false,
+    );
+  });
+});

--- a/src/tabs/registry/lib/registry-utils.test.ts
+++ b/src/tabs/registry/lib/registry-utils.test.ts
@@ -33,7 +33,9 @@ const sampleEntries: RegistryEntry[] = [
 describe("parseRegistrySearchTerms", () => {
   it("splits newline-separated company names", () => {
     expect(
-      parseRegistrySearchTerms("Skue Sparebank\nMagnora ASA\nTekna Holding ASA"),
+      parseRegistrySearchTerms(
+        "Skue Sparebank\nMagnora ASA\nTekna Holding ASA",
+      ),
     ).toEqual(["Skue Sparebank", "Magnora ASA", "Tekna Holding ASA"]);
   });
 
@@ -74,8 +76,12 @@ describe("filterRegistryEntries", () => {
 
 describe("registryEntryMatchesSearchTerm", () => {
   it("matches company name and wikidata id", () => {
-    expect(registryEntryMatchesSearchTerm(sampleEntries[0]!, "skue")).toBe(true);
-    expect(registryEntryMatchesSearchTerm(sampleEntries[0]!, "Q111")).toBe(true);
+    expect(registryEntryMatchesSearchTerm(sampleEntries[0]!, "skue")).toBe(
+      true,
+    );
+    expect(registryEntryMatchesSearchTerm(sampleEntries[0]!, "Q111")).toBe(
+      true,
+    );
     expect(registryEntryMatchesSearchTerm(sampleEntries[0]!, "Q999")).toBe(
       false,
     );

--- a/src/tabs/registry/lib/registry-utils.ts
+++ b/src/tabs/registry/lib/registry-utils.ts
@@ -16,25 +16,65 @@ export function isValidOptionalHttpUrl(raw: string): boolean {
   return isValidHttpUrl(raw);
 }
 
+/** Split pasted Excel lists (one company per line or tab-separated). */
+export function parseRegistrySearchTerms(query: string): string[] {
+  const seen = new Set<string>();
+  const terms: string[] = [];
+  for (const part of query.split(/[\r\n\t]+/)) {
+    const trimmed = part.trim();
+    if (!trimmed) continue;
+    const key = trimmed.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    terms.push(trimmed);
+  }
+  return terms;
+}
+
+function registryEntryKey(entry: RegistryEntry): string {
+  return entry.id ?? entry.wikidataId ?? entry.url;
+}
+
+export function registryEntryMatchesSearchTerm(
+  entry: RegistryEntry,
+  term: string,
+): boolean {
+  const normalizedTerm = term.trim().toLowerCase();
+  if (!normalizedTerm) return false;
+  return (
+    entry.companyName?.toLowerCase().includes(normalizedTerm) ||
+    (entry.wikidataId?.toLowerCase().includes(normalizedTerm) ?? false) ||
+    (entry.reportYear?.includes(normalizedTerm) ?? false) ||
+    entry.url.toLowerCase().includes(normalizedTerm) ||
+    (entry.sourceUrl?.toLowerCase().includes(normalizedTerm) ?? false) ||
+    (entry.s3Url?.toLowerCase().includes(normalizedTerm) ?? false)
+  );
+}
+
 export function filterRegistryEntries(
   entries: RegistryEntry[],
   query: string,
 ): RegistryEntry[] {
-  const normalizedQuery = query.trim().toLowerCase();
-  if (!normalizedQuery) {
+  const terms = parseRegistrySearchTerms(query);
+  if (terms.length === 0) {
     return entries;
   }
 
-  return entries.filter((entry) => {
-    return (
-      entry.companyName?.toLowerCase().includes(normalizedQuery) ||
-      (entry.wikidataId?.toLowerCase().includes(normalizedQuery) ?? false) ||
-      entry.reportYear?.includes(normalizedQuery) ||
-      entry.url.toLowerCase().includes(normalizedQuery) ||
-      (entry.sourceUrl?.toLowerCase().includes(normalizedQuery) ?? false) ||
-      (entry.s3Url?.toLowerCase().includes(normalizedQuery) ?? false)
+  if (terms.length === 1) {
+    return entries.filter((entry) =>
+      registryEntryMatchesSearchTerm(entry, terms[0]!),
     );
-  });
+  }
+
+  const matched = new Map<string, RegistryEntry>();
+  for (const term of terms) {
+    for (const entry of entries) {
+      if (registryEntryMatchesSearchTerm(entry, term)) {
+        matched.set(registryEntryKey(entry), entry);
+      }
+    }
+  }
+  return [...matched.values()];
 }
 
 export function buildRegistryStats(entries: RegistryEntry[]): RegistryStats {


### PR DESCRIPTION
## Summary
- Stop loading the entire registry on tab open; fetch 75 rows per page from the Unearth API.
- Route text and multi-line company search to `GET /reports/registry/search`; browse uses paginated `GET /reports/registry`.
- Add `useRegistryData` hook, pagination UI, and multi-line search textarea (Excel paste).
- Pass year/batch/wikidata/sort filters to the API; resolve tag filters to `wikidataIds` client-side.
## Test plan
- [ ] Open Registry tab — only one page (~75 rows) loads, pagination controls appear when total > 75
- [ ] Single company search hits search endpoint and returns filtered results
- [ ] Paste multiple company names (newline/tab) returns union of matches
- [ ] Year/batch/wikidata/sort filters refetch from API and reset to page 1
- [ ] Tag filters still work (via wikidataIds param)
- [ ] Add/edit/delete refreshes current page
- [ ] Requires API PR deployed or local API on feature branch
