### PR TITLE
[Fix]: Registry item selects uses id instead of wikidataId

### DIFF
--- a/src/tabs/registry/RegistryTab.tsx
+++ b/src/tabs/registry/RegistryTab.tsx
@@ -16,7 +16,11 @@ import type {
   RegistryEntryUpdate,
   RegistryNewEntry,
 } from "./lib/registry-types";
-import { writeRegistryEntriesToCsv } from "./lib/registry-utils";
+import {
+  isSameRegistryEntrySelection,
+  registryEntrySelectionKey,
+  writeRegistryEntriesToCsv,
+} from "./lib/registry-utils";
 import {
   defaultRegistryViewFilters,
   mergeRegistryViewFilters,
@@ -141,16 +145,15 @@ function RegistryTabContent() {
   };
 
   const handleToggleSelect = (entry: RegistryEntry) => {
-    const entryId = entry.wikidataId ?? entry.url;
     setSelectedReports((current) => {
-      const isSelected = current.some(
-        (r) => (r.wikidataId ?? r.url) === entryId,
+      const isSelected = current.some((r) =>
+        isSameRegistryEntrySelection(r, entry),
       );
       if (isSelected) {
-        return current.filter((r) => (r.wikidataId ?? r.url) !== entryId);
-      } else {
-        return [...current, entry];
+        const key = registryEntrySelectionKey(entry);
+        return current.filter((r) => registryEntrySelectionKey(r) !== key);
       }
+      return [...current, entry];
     });
   };
 

--- a/src/tabs/registry/components/RegistryResultsList.tsx
+++ b/src/tabs/registry/components/RegistryResultsList.tsx
@@ -8,6 +8,10 @@ import {
 } from "@/ui/data-table";
 import { ClientTablePagination } from "@/ui/client-table-pagination";
 import type { RegistryEntry, RegistryEntryUpdate } from "../lib/registry-types";
+import {
+  isSameRegistryEntrySelection,
+  registryEntrySelectionKey,
+} from "../lib/registry-utils";
 import RegistryResultItem from "./RegistryResultItem";
 
 type RegistryPagination = {
@@ -91,10 +95,9 @@ const RegistryResultsList = ({
 
           <DataTableBody>
             {registry.map((entry) => {
-              const entryId = entry.wikidataId ?? entry.url;
-              const rowKey = entry.id ?? entryId;
-              const isSelected = selectedReports.some(
-                (r) => (r.wikidataId ?? r.url) === entryId,
+              const rowKey = registryEntrySelectionKey(entry);
+              const isSelected = selectedReports.some((r) =>
+                isSameRegistryEntrySelection(r, entry),
               );
               return (
                 <RegistryResultItem

--- a/src/tabs/registry/lib/registry-utils.test.ts
+++ b/src/tabs/registry/lib/registry-utils.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
   filterRegistryEntries,
+  isSameRegistryEntrySelection,
   parseRegistrySearchTerms,
   registryEntryMatchesSearchTerm,
+  registryEntrySelectionKey,
 } from "./registry-utils";
 import type { RegistryEntry } from "./registry-types";
 
@@ -70,6 +72,41 @@ describe("filterRegistryEntries", () => {
     expect(filterRegistryEntries(sampleEntries, "")).toEqual(sampleEntries);
     expect(filterRegistryEntries(sampleEntries, "   \n  ")).toEqual(
       sampleEntries,
+    );
+  });
+});
+
+describe("registryEntrySelectionKey", () => {
+  it("uses id when present so same wikidataId rows stay distinct", () => {
+    const abb2023: RegistryEntry = {
+      id: "report-2023",
+      companyName: "ABB",
+      wikidataId: "Q52846",
+      reportYear: "2023",
+      url: "https://example.com/abb-2023.pdf",
+    };
+    const abb2024: RegistryEntry = {
+      id: "report-2024",
+      companyName: "ABB",
+      wikidataId: "Q52846",
+      reportYear: "2024",
+      url: "https://example.com/abb-2024.pdf",
+    };
+
+    expect(registryEntrySelectionKey(abb2023)).not.toBe(
+      registryEntrySelectionKey(abb2024),
+    );
+    expect(isSameRegistryEntrySelection(abb2023, abb2024)).toBe(false);
+  });
+
+  it("falls back to url when id is missing", () => {
+    const entry: RegistryEntry = {
+      companyName: "ABB",
+      wikidataId: "Q52846",
+      url: "https://example.com/abb.pdf",
+    };
+    expect(registryEntrySelectionKey(entry)).toBe(
+      "https://example.com/abb.pdf",
     );
   });
 });

--- a/src/tabs/registry/lib/registry-utils.ts
+++ b/src/tabs/registry/lib/registry-utils.ts
@@ -35,6 +35,18 @@ function registryEntryKey(entry: RegistryEntry): string {
   return entry.id ?? entry.wikidataId ?? entry.url;
 }
 
+/** One key per registry row — use for checkbox selection, not wikidataId. */
+export function registryEntrySelectionKey(entry: RegistryEntry): string {
+  return entry.id ?? entry.url;
+}
+
+export function isSameRegistryEntrySelection(
+  a: RegistryEntry,
+  b: RegistryEntry,
+): boolean {
+  return registryEntrySelectionKey(a) === registryEntrySelectionKey(b);
+}
+
 export function registryEntryMatchesSearchTerm(
   entry: RegistryEntry,
   term: string,


### PR DESCRIPTION
### ✨ What’s Changed?

With this change we are now going for id instead of wikidataId on selection of items to ensure only one unique item gets selected in the Registry.

### ✅ Validation / Test Plan (if applicable)

<!-- How did you verify this works? Include commands + key scenarios. -->

- [x] Manual verification (describe below)
- [x] Automated tests added/updated (or N/A)

### 💥 Impact (check all that apply)

- [ ] **Docs updated** (README/docs)
- [ ] **Routes/query params updated** (deep-links / URL state)
- [ ] **Breaking change**
- [ ] **Backfill/migration needed**
- [ ] **Data/validation behavior changed** (rules, units, rounding, derived calcs, defaults)
- [x] **Visual or setup change only** (styling, ui, gh templates, etc)

### 📋 Checklist

- [x] PR title starts with an issue reference (e.g. `[#123] ...`) or uses a prefix like `[fix]` / `[feat]` / `[chore]`
- [x] Labels set (and milestone if relevant)
- [x] I’ve verified the change locally (repro steps included above when non-trivial)
- [x] Any new env vars/config are documented (and safe defaults exist)
- [x] Follow-ups created as issues (or N/A)

