### PR TITLE
[Prod]: Minor Version Bump v1.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "garbo-validation-tool",
-  "version": "1.11.1-rc.2",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "garbo-validation-tool",
-      "version": "1.11.1-rc.2",
+      "version": "1.12.0",
       "dependencies": {
         "@mendable/firecrawl-js": "^4.12.1",
         "@radix-ui/react-dialog": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "garbo-validation-tool",
   "private": true,
-  "version": "1.11.1-rc.2",
+  "version": "1.12.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
# 🚀 Production Release PR (Validate)

## 📦 Release type
- [ ] Major
- [x] Minor
- [ ] Patch

## 🔁 Environment promotion

This release promotes changes **to production**.

## 🧾 Version / artifacts

- **Version being released**: v1.12.0
- **Rollback target version** (if needed): v1.11.1

## 📋 What’s being released

- Registry: paginated browse and API-backed multi-search ([#230](https://github.com/Klimatbyran/validate-frontend/pull/230))
      - Stops loading the full registry when the tab opens.
      - Browses 75 rows per page instead.
      - Routes text search and multi-line company search (e.g. paste from Excel) to a new registry search API endpoint.
      - New useRegistryData hook and expanded registry-api.ts / registry-utils.ts.
      - New tests in registry-utils.test.ts.
      - Updated search placeholder and loading text in EN/SV i18n.
      -  selection uses id instead of wikidataId ([#231](https://github.com/Klimatbyran/validate-frontend/pull/231))
      - Fixes registry item selection to use the internal id, not wikidataId.
      - Touches RegistryTab, RegistryResultsList, and related utils/tests.

## ✅ Validation / smoke check (production)

_Check anything you actually verified._

- [x] App loads
- [x] Key flows still work (open company, navigate tabs, save where applicable)
- [x] No obvious console/network errors
- [x] Any release notes/docs updated (if needed)

## ✅ Checklist

- [x] Version updated correctly (and changelog/release notes if you use them)
- [x] Changes QA’d in staging (if applicable)
- [x] Rollback target recorded above
- [x] Title follows: `[Prod] Release vX.X.X`
