### PR TITLE
Add Overview Coverage subtab for index list tracking

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1061,13 +1061,7 @@
       "companyYears": "Company years",
       "registryReports": "Registry reports",
       "prodToStage": "Prod → Stage",
-      "coverage": "Coverage",
-      "inRegistry": "In registry"
-    },
-    "registry": {
-      "present": "In registry",
-      "missing": "Not in registry",
-      "ambiguous": "Ambiguous"
+      "coverage": "Coverage"
     },
     "subtitleCoverage": "Track index constituent lists by year and see how many company names already exist in Garbo.",
     "subtitleProdToStage": "Prod CompanyReports with at least one fully verified reporting period where the matching stage report has no emissions data yet. Run selected re-uploads the prod report URL through the stage pipeline only.",
@@ -1126,6 +1120,10 @@
       "editYear": "Edit names",
       "deleteList": "Delete list",
       "deleteYear": "Delete year",
+      "confirmDeleteListTitle": "Delete coverage list?",
+      "confirmDeleteList": "Delete \"{{name}}\" and all its year editions? This cannot be undone.",
+      "confirmDeleteYearTitle": "Delete year edition?",
+      "confirmDeleteYear": "Delete the {{year}} edition from \"{{name}}\"? This cannot be undone.",
       "backToLists": "Back to lists",
       "noLists": "No coverage lists yet.",
       "noYears": "No year editions yet. Add a year to paste company names.",
@@ -1141,7 +1139,6 @@
       "namesPlaceholder": "Apple Inc.\nMicrosoft Corporation\n…",
       "namesCount": "{{count}} names",
       "yearPill": "{{year}} · {{percent}}%",
-      "yearStatsLine": "{{total}} names · {{matched}} matched · {{missing}} missing · {{ambiguous}} ambiguous · {{percent}}% coverage",
       "latestCoverageCell": "{{year}}: {{percent}}% ({{matched}}/{{total}})",
       "entryFilterLabel": "Entry filter",
       "searchPlaceholder": "Search names or matches…",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -8,6 +8,8 @@
     "clearFilters": "Clear filters",
     "refresh": "Refresh",
     "search": "Search",
+    "cancel": "Cancel",
+    "save": "Save",
     "scrollToTop": "Scroll to top",
     "yes": "Yes",
     "no": "No",
@@ -1058,8 +1060,16 @@
     "views": {
       "companyYears": "Company years",
       "registryReports": "Registry reports",
-      "prodToStage": "Prod → Stage"
+      "prodToStage": "Prod → Stage",
+      "coverage": "Coverage",
+      "inRegistry": "In registry"
     },
+    "registry": {
+      "present": "In registry",
+      "missing": "Not in registry",
+      "ambiguous": "Ambiguous"
+    },
+    "subtitleCoverage": "Track index constituent lists by year and see how many company names already exist in Garbo.",
     "subtitleProdToStage": "Prod CompanyReports with at least one fully verified reporting period where the matching stage report has no emissions data yet. Run selected re-uploads the prod report URL through the stage pipeline only.",
     "filtersTitle": "Search and filters",
     "searchLabel": "Company name or ID",
@@ -1107,6 +1117,55 @@
         "runnable": "Runnable",
         "selected": "Selected",
         "allCandidates": "All candidates"
+      }
+    },
+    "coverage": {
+      "errorTitle": "Coverage request failed",
+      "addList": "Add list",
+      "addYear": "Add year",
+      "editYear": "Edit names",
+      "deleteList": "Delete list",
+      "deleteYear": "Delete year",
+      "backToLists": "Back to lists",
+      "noLists": "No coverage lists yet.",
+      "noYears": "No year editions yet. Add a year to paste company names.",
+      "noEntries": "No entries match the current filter.",
+      "createListTitle": "Create coverage list",
+      "addYearTitle": "Add year edition",
+      "editYearTitle": "Edit year names",
+      "formHint": "Paste one company name per line. Coverage is computed live against Garbo company names.",
+      "listNameLabel": "List name",
+      "listNamePlaceholder": "e.g. MSCI World Index",
+      "yearLabel": "Year",
+      "namesLabel": "Company names",
+      "namesPlaceholder": "Apple Inc.\nMicrosoft Corporation\n…",
+      "namesCount": "{{count}} names",
+      "yearPill": "{{year}} · {{percent}}%",
+      "yearStatsLine": "{{total}} names · {{matched}} matched · {{missing}} missing · {{ambiguous}} ambiguous · {{percent}}% coverage",
+      "latestCoverageCell": "{{year}}: {{percent}}% ({{matched}}/{{total}})",
+      "entryFilterLabel": "Entry filter",
+      "searchPlaceholder": "Search names or matches…",
+      "filters": {
+        "all": "All",
+        "matched": "Matched",
+        "missing": "Missing",
+        "ambiguous": "Ambiguous"
+      },
+      "columns": {
+        "list": "List",
+        "years": "Years",
+        "latestCoverage": "Latest coverage",
+        "updated": "Updated",
+        "listName": "List name",
+        "status": "Status",
+        "dbMatch": "DB match"
+      },
+      "stats": {
+        "total": "Total names",
+        "matched": "Matched",
+        "missing": "Missing",
+        "ambiguous": "Ambiguous",
+        "coverage": "Coverage"
       }
     },
     "fetchError": "Could not load overview data.",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -1061,13 +1061,7 @@
       "companyYears": "Företagsår",
       "registryReports": "Register-rapporter",
       "prodToStage": "Prod → Stage",
-      "coverage": "Täckning",
-      "inRegistry": "I registret"
-    },
-    "registry": {
-      "present": "Finns i registret",
-      "missing": "Saknas i registret",
-      "ambiguous": "Tvetydig"
+      "coverage": "Täckning"
     },
     "subtitleCoverage": "Hantera indexlistor per år och se hur många företagsnamn som redan finns i Garbo.",
     "subtitleProdToStage": "Prod CompanyReports med minst en fullt verifierad rapporteringsperiod där motsvarande stage-rapport ännu saknar utsläppsdata. Kör valda laddar upp prod-rapportens URL via stage-pipeline endast.",
@@ -1126,6 +1120,10 @@
       "editYear": "Redigera namn",
       "deleteList": "Ta bort lista",
       "deleteYear": "Ta bort år",
+      "confirmDeleteListTitle": "Ta bort täckningslista?",
+      "confirmDeleteList": "Ta bort \"{{name}}\" och alla årsutgåvor? Detta går inte att ångra.",
+      "confirmDeleteYearTitle": "Ta bort årsutgåva?",
+      "confirmDeleteYear": "Ta bort årsutgåvan {{year}} från \"{{name}}\"? Detta går inte att ångra.",
       "backToLists": "Tillbaka till listor",
       "noLists": "Inga täckningslistor ännu.",
       "noYears": "Inga årsutgåvor ännu. Lägg till ett år och klistra in företagsnamn.",
@@ -1141,7 +1139,6 @@
       "namesPlaceholder": "Apple Inc.\nMicrosoft Corporation\n…",
       "namesCount": "{{count}} namn",
       "yearPill": "{{year}} · {{percent}}%",
-      "yearStatsLine": "{{total}} namn · {{matched}} matchade · {{missing}} saknas · {{ambiguous}} tvetydiga · {{percent}}% täckning",
       "latestCoverageCell": "{{year}}: {{percent}}% ({{matched}}/{{total}})",
       "entryFilterLabel": "Radfilter",
       "searchPlaceholder": "Sök namn eller matchningar…",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -8,6 +8,8 @@
     "clearFilters": "Rensa filter",
     "refresh": "Uppdatera",
     "search": "Sök",
+    "cancel": "Avbryt",
+    "save": "Spara",
     "scrollToTop": "Scrolla till toppen",
     "yes": "Ja",
     "no": "Nej",
@@ -1058,8 +1060,16 @@
     "views": {
       "companyYears": "Företagsår",
       "registryReports": "Register-rapporter",
-      "prodToStage": "Prod → Stage"
+      "prodToStage": "Prod → Stage",
+      "coverage": "Täckning",
+      "inRegistry": "I registret"
     },
+    "registry": {
+      "present": "Finns i registret",
+      "missing": "Saknas i registret",
+      "ambiguous": "Tvetydig"
+    },
+    "subtitleCoverage": "Hantera indexlistor per år och se hur många företagsnamn som redan finns i Garbo.",
     "subtitleProdToStage": "Prod CompanyReports med minst en fullt verifierad rapporteringsperiod där motsvarande stage-rapport ännu saknar utsläppsdata. Kör valda laddar upp prod-rapportens URL via stage-pipeline endast.",
     "filtersTitle": "Sök och filter",
     "searchLabel": "Företagsnamn eller ID",
@@ -1107,6 +1117,55 @@
         "runnable": "Körbara",
         "selected": "Valda",
         "allCandidates": "Alla kandidater"
+      }
+    },
+    "coverage": {
+      "errorTitle": "Täckningsanrop misslyckades",
+      "addList": "Lägg till lista",
+      "addYear": "Lägg till år",
+      "editYear": "Redigera namn",
+      "deleteList": "Ta bort lista",
+      "deleteYear": "Ta bort år",
+      "backToLists": "Tillbaka till listor",
+      "noLists": "Inga täckningslistor ännu.",
+      "noYears": "Inga årsutgåvor ännu. Lägg till ett år och klistra in företagsnamn.",
+      "noEntries": "Inga rader matchar filtret.",
+      "createListTitle": "Skapa täckningslista",
+      "addYearTitle": "Lägg till årsutgåva",
+      "editYearTitle": "Redigera namn för år",
+      "formHint": "Klistra in ett företagsnamn per rad. Täckning beräknas live mot Garbo-företagsnamn.",
+      "listNameLabel": "Listnamn",
+      "listNamePlaceholder": "t.ex. MSCI World Index",
+      "yearLabel": "År",
+      "namesLabel": "Företagsnamn",
+      "namesPlaceholder": "Apple Inc.\nMicrosoft Corporation\n…",
+      "namesCount": "{{count}} namn",
+      "yearPill": "{{year}} · {{percent}}%",
+      "yearStatsLine": "{{total}} namn · {{matched}} matchade · {{missing}} saknas · {{ambiguous}} tvetydiga · {{percent}}% täckning",
+      "latestCoverageCell": "{{year}}: {{percent}}% ({{matched}}/{{total}})",
+      "entryFilterLabel": "Radfilter",
+      "searchPlaceholder": "Sök namn eller matchningar…",
+      "filters": {
+        "all": "Alla",
+        "matched": "Matchade",
+        "missing": "Saknas",
+        "ambiguous": "Tvetydiga"
+      },
+      "columns": {
+        "list": "Lista",
+        "years": "År",
+        "latestCoverage": "Senaste täckning",
+        "updated": "Uppdaterad",
+        "listName": "Listnamn",
+        "status": "Status",
+        "dbMatch": "DB-match"
+      },
+      "stats": {
+        "total": "Totalt antal namn",
+        "matched": "Matchade",
+        "missing": "Saknas",
+        "ambiguous": "Tvetydiga",
+        "coverage": "Täckning"
       }
     },
     "fetchError": "Kunde inte ladda översiktsdata.",

--- a/src/tabs/overview/OverviewTab.tsx
+++ b/src/tabs/overview/OverviewTab.tsx
@@ -17,6 +17,7 @@ import { ProdToStageFilters } from "./components/ProdToStageFilters";
 import { OverviewStatsBar } from "./components/OverviewStatsBar";
 import { OverviewTable } from "./components/OverviewTable";
 import { ProdToStageTable } from "./components/ProdToStageTable";
+import { CoverageView } from "./components/CoverageView";
 import type {
   OverviewRow,
   OverviewViewMode,
@@ -27,6 +28,7 @@ const VIEW_MODES: { value: OverviewViewMode; labelKey: string }[] = [
   { value: "companyYears", labelKey: "overview.views.companyYears" },
   { value: "registryReports", labelKey: "overview.views.registryReports" },
   { value: "prodToStage", labelKey: "overview.views.prodToStage" },
+  { value: "coverage", labelKey: "overview.views.coverage" },
 ];
 
 export function OverviewTab() {
@@ -46,6 +48,7 @@ export function OverviewTab() {
   );
 
   const isProdToStage = data.viewMode === "prodToStage";
+  const isCoverage = data.viewMode === "coverage";
   const activePipeline = isProdToStage ? stagePipeline : envPipeline;
 
   const selectedOverviewRows = useMemo(
@@ -124,7 +127,9 @@ export function OverviewTab() {
       ? t("overview.subtitleCompanyYears")
       : data.viewMode === "registryReports"
         ? t("overview.subtitleRegistryReports")
-        : t("overview.subtitleProdToStage");
+        : data.viewMode === "coverage"
+          ? t("overview.subtitleCoverage")
+          : t("overview.subtitleProdToStage");
 
   const selectedCount = isProdToStage
     ? selectedProdToStageRows.length
@@ -158,35 +163,39 @@ export function OverviewTab() {
             />
           </div>
           <div className="flex flex-wrap gap-2">
-            <Button
-              variant="outline"
-              onClick={() => data.refresh()}
-              disabled={data.isRefreshing}
-            >
-              {data.isRefreshing ? (
-                <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-              ) : (
-                <RefreshCw className="w-4 h-4 mr-2" />
-              )}
-              {t("common.refresh")}
-            </Button>
-            <Button
-              onClick={() => setIsRunReportsOpen(true)}
-              disabled={
-                runItems.length === 0 || activePipeline.isRunningReports
-              }
-            >
-              {activePipeline.isRunningReports ? (
-                <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-              ) : (
-                <Play className="w-4 h-4 mr-2" />
-              )}
-              {isProdToStage
-                ? t("overview.prodToStage.runOnStage", {
-                    count: runItems.length,
-                  })
-                : t("overview.runSelected", { count: runItems.length })}
-            </Button>
+            {!isCoverage ? (
+              <>
+                <Button
+                  variant="outline"
+                  onClick={() => data.refresh()}
+                  disabled={data.isRefreshing}
+                >
+                  {data.isRefreshing ? (
+                    <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                  ) : (
+                    <RefreshCw className="w-4 h-4 mr-2" />
+                  )}
+                  {t("common.refresh")}
+                </Button>
+                <Button
+                  onClick={() => setIsRunReportsOpen(true)}
+                  disabled={
+                    runItems.length === 0 || activePipeline.isRunningReports
+                  }
+                >
+                  {activePipeline.isRunningReports ? (
+                    <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                  ) : (
+                    <Play className="w-4 h-4 mr-2" />
+                  )}
+                  {isProdToStage
+                    ? t("overview.prodToStage.runOnStage", {
+                        count: runItems.length,
+                      })
+                    : t("overview.runSelected", { count: runItems.length })}
+                </Button>
+              </>
+            ) : null}
           </div>
         </div>
 
@@ -257,13 +266,13 @@ export function OverviewTab() {
           </div>
         ) : null}
 
-        {!isProdToStage ? (
+        {!isProdToStage && !isCoverage ? (
           <OverviewStatsBar
             stats={data.stats}
             selectedCount={selectedCount}
             viewMode={data.viewMode}
           />
-        ) : (
+        ) : isProdToStage ? (
           <MetricCardGrid className="grid-cols-2 sm:grid-cols-4">
             <MetricCard
               label={t("overview.prodToStage.stats.total")}
@@ -282,21 +291,23 @@ export function OverviewTab() {
               value={data.pagination.totalRows}
             />
           </MetricCardGrid>
-        )}
+        ) : null}
 
-        {isProdToStage ? (
-          <ProdToStageFilters data={data} />
-        ) : (
-          <OverviewFilters data={data} />
-        )}
+        {!isCoverage ? (
+          isProdToStage ? (
+            <ProdToStageFilters data={data} />
+          ) : (
+            <OverviewFilters data={data} />
+          )
+        ) : null}
 
-        {data.error ? (
+        {!isCoverage && data.error ? (
           <Callout variant="error" title={t("overview.apiErrorTitle")}>
             <p className="text-sm">{data.error}</p>
           </Callout>
         ) : null}
 
-        {!data.error && data.warnings.length > 0 ? (
+        {!isCoverage && !data.error && data.warnings.length > 0 ? (
           <Callout
             variant="warning"
             title={t("overview.apiWarningsTitle")}
@@ -320,11 +331,13 @@ export function OverviewTab() {
           </Callout>
         ) : null}
 
-        {data.isLoading ? (
+        {data.isLoading && !isCoverage ? (
           <div className="py-16 flex justify-center">
             <LoadingSpinner />
           </div>
-        ) : data.error ? null : isProdToStage ? (
+        ) : data.error && !isCoverage ? null : isCoverage ? (
+          <CoverageView />
+        ) : isProdToStage ? (
           <ProdToStageTable
             data={data}
             selectedKeys={selectedKeys}
@@ -341,16 +354,18 @@ export function OverviewTab() {
           />
         )}
 
-        <div className="flex flex-wrap gap-2 pt-2">
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => data.clearFilters()}
-            disabled={!data.filtersAreActive}
-          >
-            {t("common.clearFilters")}
-          </Button>
-        </div>
+        {!isCoverage ? (
+          <div className="flex flex-wrap gap-2 pt-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => data.clearFilters()}
+              disabled={!data.filtersAreActive}
+            >
+              {t("common.clearFilters")}
+            </Button>
+          </div>
+        ) : null}
       </div>
 
       <RunReportsModal

--- a/src/tabs/overview/components/CoverageListTable.tsx
+++ b/src/tabs/overview/components/CoverageListTable.tsx
@@ -1,0 +1,85 @@
+import { useI18n } from "@/contexts/I18nContext";
+import { Button } from "@/ui/button";
+import type { CoverageListSummary } from "@/tabs/overview/lib/coverage-types";
+
+type CoverageListTableProps = {
+  lists: CoverageListSummary[];
+  onSelectList: (listId: string) => void;
+  onCreateList: () => void;
+};
+
+export function CoverageListTable({
+  lists,
+  onSelectList,
+  onCreateList,
+}: CoverageListTableProps) {
+  const { t } = useI18n();
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-end">
+        <Button onClick={onCreateList}>{t("overview.coverage.addList")}</Button>
+      </div>
+
+      <div className="overflow-x-auto rounded-lg border border-gray-03">
+        <table className="min-w-full text-sm">
+          <thead className="bg-gray-05/80 text-left text-gray-02">
+            <tr>
+              <th className="px-4 py-2 font-medium">
+                {t("overview.coverage.columns.list")}
+              </th>
+              <th className="px-4 py-2 font-medium">
+                {t("overview.coverage.columns.years")}
+              </th>
+              <th className="px-4 py-2 font-medium">
+                {t("overview.coverage.columns.latestCoverage")}
+              </th>
+              <th className="px-4 py-2 font-medium">
+                {t("overview.coverage.columns.updated")}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {lists.map((list) => {
+              const latestYear = list.years[0];
+              return (
+                <tr
+                  key={list.id}
+                  className="border-t border-gray-03/60 cursor-pointer hover:bg-gray-05/50"
+                  onClick={() => onSelectList(list.id)}
+                >
+                  <td className="px-4 py-2 font-medium text-gray-01">
+                    {list.name}
+                  </td>
+                  <td className="px-4 py-2 text-gray-02">
+                    {list.years.length}
+                  </td>
+                  <td className="px-4 py-2 text-gray-02">
+                    {latestYear
+                      ? t("overview.coverage.latestCoverageCell", {
+                          year: latestYear.year,
+                          percent: latestYear.coveragePercent,
+                          matched: latestYear.matchedCount,
+                          total: latestYear.totalNames,
+                        })
+                      : "—"}
+                  </td>
+                  <td className="px-4 py-2 text-gray-02">
+                    {new Date(list.updatedAt).toLocaleString()}
+                  </td>
+                </tr>
+              );
+            })}
+            {lists.length === 0 ? (
+              <tr>
+                <td colSpan={4} className="px-4 py-8 text-center text-gray-02">
+                  {t("overview.coverage.noLists")}
+                </td>
+              </tr>
+            ) : null}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/tabs/overview/components/CoverageView.tsx
+++ b/src/tabs/overview/components/CoverageView.tsx
@@ -3,6 +3,7 @@ import { Loader2, RefreshCw } from "lucide-react";
 import { useI18n } from "@/contexts/I18nContext";
 import { Button } from "@/ui/button";
 import { Callout } from "@/ui/callout";
+import { ConfirmDialog } from "@/ui/confirm-dialog";
 import { LoadingSpinner } from "@/ui/loading-spinner";
 import {
   useCoverageLists,
@@ -18,13 +19,22 @@ type DialogState =
   | { kind: "addYear"; listId: string }
   | { kind: "editYear"; listId: string; year: number; namesText: string };
 
+type DeleteConfirmState =
+  | { kind: "closed" }
+  | { kind: "year"; listId: string; listName: string; year: number }
+  | { kind: "list"; listId: string; listName: string };
+
 export function CoverageView() {
   const { t } = useI18n();
   const coverage = useCoverageLists();
   const [selectedListId, setSelectedListId] = useState<string | null>(null);
   const [selectedYear, setSelectedYear] = useState<number | null>(null);
   const [dialog, setDialog] = useState<DialogState>({ kind: "closed" });
+  const [deleteConfirm, setDeleteConfirm] = useState<DeleteConfirmState>({
+    kind: "closed",
+  });
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   const selectedList = useMemo(
     () => coverage.lists.find((list) => list.id === selectedListId) ?? null,
@@ -56,6 +66,27 @@ export function CoverageView() {
       setSelectedYear(input.year);
     } finally {
       setIsSubmitting(false);
+    }
+  };
+
+  const handleConfirmDelete = async () => {
+    if (deleteConfirm.kind === "closed") return;
+    setIsDeleting(true);
+    try {
+      if (deleteConfirm.kind === "year") {
+        await coverage.deleteYear(deleteConfirm.listId, deleteConfirm.year);
+        const remaining =
+          selectedList?.years.filter((y) => y.year !== deleteConfirm.year) ??
+          [];
+        setSelectedYear(remaining[0]?.year ?? null);
+      } else {
+        await coverage.deleteList(deleteConfirm.listId);
+        setSelectedListId(null);
+        setSelectedYear(null);
+      }
+      setDeleteConfirm({ kind: "closed" });
+    } finally {
+      setIsDeleting(false);
     }
   };
 
@@ -160,14 +191,12 @@ export function CoverageView() {
                   variant="danger"
                   size="sm"
                   onClick={() =>
-                    void coverage
-                      .deleteYear(selectedList.id, selectedYear)
-                      .then(() => {
-                        const remaining = selectedList.years.filter(
-                          (y) => y.year !== selectedYear,
-                        );
-                        setSelectedYear(remaining[0]?.year ?? null);
-                      })
+                    setDeleteConfirm({
+                      kind: "year",
+                      listId: selectedList.id,
+                      listName: selectedList.name,
+                      year: selectedYear,
+                    })
                   }
                 >
                   {t("overview.coverage.deleteYear")}
@@ -177,9 +206,10 @@ export function CoverageView() {
                 variant="danger"
                 size="sm"
                 onClick={() =>
-                  void coverage.deleteList(selectedList.id).then(() => {
-                    setSelectedListId(null);
-                    setSelectedYear(null);
+                  setDeleteConfirm({
+                    kind: "list",
+                    listId: selectedList.id,
+                    listName: selectedList.name,
                   })
                 }
               >
@@ -274,6 +304,39 @@ export function CoverageView() {
           }
           await handleAddOrEditYear(input);
         }}
+      />
+
+      <ConfirmDialog
+        open={deleteConfirm.kind !== "closed"}
+        onOpenChange={(open) => {
+          if (!open) setDeleteConfirm({ kind: "closed" });
+        }}
+        title={
+          deleteConfirm.kind === "year"
+            ? t("overview.coverage.confirmDeleteYearTitle")
+            : t("overview.coverage.confirmDeleteListTitle")
+        }
+        description={
+          deleteConfirm.kind === "year"
+            ? t("overview.coverage.confirmDeleteYear", {
+                year: deleteConfirm.year,
+                name: deleteConfirm.listName,
+              })
+            : deleteConfirm.kind === "list"
+              ? t("overview.coverage.confirmDeleteList", {
+                  name: deleteConfirm.listName,
+                })
+              : ""
+        }
+        cancelLabel={t("common.cancel")}
+        confirmLabel={
+          deleteConfirm.kind === "year"
+            ? t("overview.coverage.deleteYear")
+            : t("overview.coverage.deleteList")
+        }
+        confirmVariant="danger"
+        onConfirm={handleConfirmDelete}
+        isLoading={isDeleting}
       />
     </div>
   );

--- a/src/tabs/overview/components/CoverageView.tsx
+++ b/src/tabs/overview/components/CoverageView.tsx
@@ -1,0 +1,280 @@
+import { useMemo, useState } from "react";
+import { Loader2, RefreshCw } from "lucide-react";
+import { useI18n } from "@/contexts/I18nContext";
+import { Button } from "@/ui/button";
+import { Callout } from "@/ui/callout";
+import { LoadingSpinner } from "@/ui/loading-spinner";
+import {
+  useCoverageLists,
+  useCoverageYearDetail,
+} from "@/tabs/overview/hooks/useCoverageLists";
+import { CoverageListTable } from "./CoverageListTable";
+import { CoverageYearDetailView } from "./CoverageYearDetail";
+import { CoverageYearFormDialog } from "./CoverageYearFormDialog";
+
+type DialogState =
+  | { kind: "closed" }
+  | { kind: "createList" }
+  | { kind: "addYear"; listId: string }
+  | { kind: "editYear"; listId: string; year: number; namesText: string };
+
+export function CoverageView() {
+  const { t } = useI18n();
+  const coverage = useCoverageLists();
+  const [selectedListId, setSelectedListId] = useState<string | null>(null);
+  const [selectedYear, setSelectedYear] = useState<number | null>(null);
+  const [dialog, setDialog] = useState<DialogState>({ kind: "closed" });
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const selectedList = useMemo(
+    () => coverage.lists.find((list) => list.id === selectedListId) ?? null,
+    [coverage.lists, selectedListId],
+  );
+
+  const yearDetail = useCoverageYearDetail(selectedListId, selectedYear);
+
+  const openList = (listId: string) => {
+    setSelectedListId(listId);
+    const list = coverage.lists.find((item) => item.id === listId);
+    setSelectedYear(list?.years[0]?.year ?? null);
+  };
+
+  const handleCreateList = async (input: {
+    listName?: string;
+    year: number;
+    names: string[];
+  }) => {
+    if (!input.listName) return;
+    setIsSubmitting(true);
+    try {
+      const created = await coverage.createList({
+        name: input.listName,
+        year: input.year,
+        names: input.names,
+      });
+      setSelectedListId(created.id);
+      setSelectedYear(input.year);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleAddOrEditYear = async (input: {
+    listName?: string;
+    year: number;
+    names: string[];
+  }) => {
+    if (dialog.kind === "addYear") {
+      setIsSubmitting(true);
+      try {
+        await coverage.addYear(dialog.listId, {
+          year: input.year,
+          names: input.names,
+        });
+        setSelectedListId(dialog.listId);
+        setSelectedYear(input.year);
+      } finally {
+        setIsSubmitting(false);
+      }
+      return;
+    }
+
+    if (dialog.kind === "editYear") {
+      setIsSubmitting(true);
+      try {
+        await coverage.replaceYearNames(
+          dialog.listId,
+          dialog.year,
+          input.names,
+        );
+        setSelectedListId(dialog.listId);
+        setSelectedYear(dialog.year);
+        await yearDetail.refresh();
+      } finally {
+        setIsSubmitting(false);
+      }
+    }
+  };
+
+  const editNamesText =
+    dialog.kind === "editYear"
+      ? dialog.namesText
+      : (yearDetail.detail?.entries.map((e) => e.name).join("\n") ?? "");
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap gap-2 justify-between items-center">
+        <p className="text-sm text-gray-02 max-w-3xl">
+          {t("overview.subtitleCoverage")}
+        </p>
+        <Button
+          variant="secondary"
+          onClick={() => coverage.refresh()}
+          disabled={coverage.isRefreshing}
+        >
+          {coverage.isRefreshing ? (
+            <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+          ) : (
+            <RefreshCw className="w-4 h-4 mr-2" />
+          )}
+          {t("common.refresh")}
+        </Button>
+      </div>
+
+      {coverage.error ? (
+        <Callout variant="error" title={t("overview.coverage.errorTitle")}>
+          <p className="text-sm">{coverage.error}</p>
+        </Callout>
+      ) : null}
+
+      {coverage.isLoading ? (
+        <div className="py-16 flex justify-center">
+          <LoadingSpinner />
+        </div>
+      ) : selectedList ? (
+        <div className="space-y-4">
+          <div className="rounded-lg border border-gray-03 bg-gray-05/40 p-4 space-y-4">
+            <h3 className="text-lg font-semibold text-gray-01">
+              {selectedList.name}
+            </h3>
+
+            <div className="flex flex-wrap items-center gap-2">
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => setSelectedListId(null)}
+              >
+                {t("overview.coverage.backToLists")}
+              </Button>
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() =>
+                  setDialog({ kind: "addYear", listId: selectedList.id })
+                }
+              >
+                {t("overview.coverage.addYear")}
+              </Button>
+              {selectedYear !== null ? (
+                <Button
+                  variant="danger"
+                  size="sm"
+                  onClick={() =>
+                    void coverage
+                      .deleteYear(selectedList.id, selectedYear)
+                      .then(() => {
+                        const remaining = selectedList.years.filter(
+                          (y) => y.year !== selectedYear,
+                        );
+                        setSelectedYear(remaining[0]?.year ?? null);
+                      })
+                  }
+                >
+                  {t("overview.coverage.deleteYear")}
+                </Button>
+              ) : null}
+              <Button
+                variant="danger"
+                size="sm"
+                onClick={() =>
+                  void coverage.deleteList(selectedList.id).then(() => {
+                    setSelectedListId(null);
+                    setSelectedYear(null);
+                  })
+                }
+              >
+                {t("overview.coverage.deleteList")}
+              </Button>
+            </div>
+
+            <div className="flex flex-wrap gap-2">
+              {selectedList.years.map((yearRow) => (
+                <Button
+                  key={yearRow.year}
+                  variant={
+                    selectedYear === yearRow.year ? "primary" : "secondary"
+                  }
+                  size="sm"
+                  onClick={() => setSelectedYear(yearRow.year)}
+                >
+                  {t("overview.coverage.yearPill", {
+                    year: yearRow.year,
+                    percent: yearRow.coveragePercent,
+                  })}
+                </Button>
+              ))}
+              {selectedList.years.length === 0 ? (
+                <p className="text-sm text-gray-02">
+                  {t("overview.coverage.noYears")}
+                </p>
+              ) : null}
+            </div>
+          </div>
+
+          {selectedYear !== null ? (
+            <div className="space-y-3">
+              {yearDetail.isLoading ? (
+                <div className="py-12 flex justify-center">
+                  <LoadingSpinner />
+                </div>
+              ) : yearDetail.error ? (
+                <Callout
+                  variant="error"
+                  title={t("overview.coverage.errorTitle")}
+                >
+                  <p className="text-sm">{yearDetail.error}</p>
+                </Callout>
+              ) : yearDetail.detail ? (
+                <CoverageYearDetailView
+                  detail={yearDetail.detail}
+                  onEdit={() =>
+                    setDialog({
+                      kind: "editYear",
+                      listId: selectedList.id,
+                      year: selectedYear,
+                      namesText: yearDetail
+                        .detail!.entries.map((e) => e.name)
+                        .join("\n"),
+                    })
+                  }
+                />
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+      ) : (
+        <CoverageListTable
+          lists={coverage.lists}
+          onSelectList={openList}
+          onCreateList={() => setDialog({ kind: "createList" })}
+        />
+      )}
+
+      <CoverageYearFormDialog
+        open={dialog.kind !== "closed"}
+        onOpenChange={(open) => {
+          if (!open) setDialog({ kind: "closed" });
+        }}
+        mode={
+          dialog.kind === "createList"
+            ? "createList"
+            : dialog.kind === "addYear"
+              ? "addYear"
+              : "editYear"
+        }
+        initialYear={
+          dialog.kind === "editYear" ? dialog.year : new Date().getFullYear()
+        }
+        initialNamesText={dialog.kind === "editYear" ? editNamesText : ""}
+        isSubmitting={isSubmitting}
+        onSubmit={async (input) => {
+          if (dialog.kind === "createList") {
+            await handleCreateList(input);
+            return;
+          }
+          await handleAddOrEditYear(input);
+        }}
+      />
+    </div>
+  );
+}

--- a/src/tabs/overview/components/CoverageYearDetail.tsx
+++ b/src/tabs/overview/components/CoverageYearDetail.tsx
@@ -1,15 +1,9 @@
 import { Link } from "react-router-dom";
-
 import { useMemo, useState } from "react";
-
 import { useI18n } from "@/contexts/I18nContext";
-
 import { editorCompanyPath } from "@/tabs/editor/lib/editor-routes";
-
 import { Button } from "@/ui/button";
-
 import { ViewModePills } from "@/ui/view-mode-pills";
-
 import type {
   CoverageEntry,
   CoverageEntryFilter,
@@ -18,19 +12,15 @@ import type {
 
 type CoverageYearDetailProps = {
   detail: CoverageYearDetail;
-
   onEdit: () => void;
 };
 
 export function CoverageYearDetailView({
   detail,
-
   onEdit,
 }: CoverageYearDetailProps) {
   const { t } = useI18n();
-
   const [filter, setFilter] = useState<CoverageEntryFilter>("all");
-
   const [search, setSearch] = useState("");
 
   const missingCount =
@@ -41,19 +31,14 @@ export function CoverageYearDetailView({
 
     return detail.entries.filter((entry) => {
       if (filter !== "all" && entry.status !== filter) return false;
-
       if (!q) return true;
 
       const haystack = [
         entry.name,
-
         entry.matchedCompany?.name ?? "",
-
         entry.matchedCompany?.wikidataId ?? "",
       ]
-
         .join(" ")
-
         .toLocaleLowerCase("sv-SE");
 
       return haystack.includes(q);
@@ -62,11 +47,8 @@ export function CoverageYearDetailView({
 
   const filterOptions: { value: CoverageEntryFilter; label: string }[] = [
     { value: "all", label: t("overview.coverage.filters.all") },
-
     { value: "matched", label: t("overview.coverage.filters.matched") },
-
     { value: "missing", label: t("overview.coverage.filters.missing") },
-
     { value: "ambiguous", label: t("overview.coverage.filters.ambiguous") },
   ];
 
@@ -77,7 +59,6 @@ export function CoverageYearDetailView({
           <h3 className="text-lg font-semibold text-gray-01">
             {detail.listName} — {detail.year}
           </h3>
-
           <Button variant="secondary" size="sm" onClick={onEdit}>
             {t("overview.coverage.editYear")}
           </Button>
@@ -89,25 +70,21 @@ export function CoverageYearDetailView({
             value={detail.totalNames}
             className="border-gray-03/80 bg-gray-04/30 text-gray-01"
           />
-
           <CoverageStatCard
             label={t("overview.coverage.stats.matched")}
             value={detail.matchedCount}
             className="border-green-03/30 bg-green-03/10 text-green-03"
           />
-
           <CoverageStatCard
             label={t("overview.coverage.stats.missing")}
             value={missingCount}
             className="border-orange-03/30 bg-orange-03/10 text-orange-03"
           />
-
           <CoverageStatCard
             label={t("overview.coverage.stats.ambiguous")}
             value={detail.ambiguousCount}
             className="border-yellow-500/30 bg-yellow-500/10 text-yellow-400"
           />
-
           <CoverageStatCard
             label={t("overview.coverage.stats.coverage")}
             value={`${detail.coveragePercent}%`}
@@ -137,22 +114,18 @@ export function CoverageYearDetailView({
               <th className="px-4 py-2 font-medium">
                 {t("overview.coverage.columns.listName")}
               </th>
-
               <th className="px-4 py-2 font-medium">
                 {t("overview.coverage.columns.status")}
               </th>
-
               <th className="px-4 py-2 font-medium">
                 {t("overview.coverage.columns.dbMatch")}
               </th>
             </tr>
           </thead>
-
           <tbody>
             {filteredEntries.map((entry) => (
               <CoverageEntryRow key={entry.id} entry={entry} />
             ))}
-
             {filteredEntries.length === 0 ? (
               <tr>
                 <td colSpan={3} className="px-4 py-8 text-center text-gray-02">
@@ -169,21 +142,16 @@ export function CoverageYearDetailView({
 
 function CoverageStatCard({
   label,
-
   value,
-
   className,
 }: {
   label: string;
-
   value: number | string;
-
   className: string;
 }) {
   return (
     <div className={`rounded-lg border px-3 py-2 ${className}`}>
       <p className="text-[11px] uppercase tracking-wide opacity-80">{label}</p>
-
       <p className="text-xl font-semibold tabular-nums">{value}</p>
     </div>
   );
@@ -209,9 +177,7 @@ function CoverageEntryRow({ entry }: { entry: CoverageEntry }) {
   return (
     <tr className="border-t border-gray-03/60">
       <td className="px-4 py-2 text-gray-01">{entry.name}</td>
-
       <td className={`px-4 py-2 font-medium ${statusClass}`}>{statusLabel}</td>
-
       <td className="px-4 py-2 text-gray-02">
         {entry.matchedCompany ? (
           <Link

--- a/src/tabs/overview/components/CoverageYearDetail.tsx
+++ b/src/tabs/overview/components/CoverageYearDetail.tsx
@@ -1,0 +1,229 @@
+import { Link } from "react-router-dom";
+
+import { useMemo, useState } from "react";
+
+import { useI18n } from "@/contexts/I18nContext";
+
+import { editorCompanyPath } from "@/tabs/editor/lib/editor-routes";
+
+import { Button } from "@/ui/button";
+
+import { ViewModePills } from "@/ui/view-mode-pills";
+
+import type {
+  CoverageEntry,
+  CoverageEntryFilter,
+  CoverageYearDetail,
+} from "@/tabs/overview/lib/coverage-types";
+
+type CoverageYearDetailProps = {
+  detail: CoverageYearDetail;
+
+  onEdit: () => void;
+};
+
+export function CoverageYearDetailView({
+  detail,
+
+  onEdit,
+}: CoverageYearDetailProps) {
+  const { t } = useI18n();
+
+  const [filter, setFilter] = useState<CoverageEntryFilter>("all");
+
+  const [search, setSearch] = useState("");
+
+  const missingCount =
+    detail.totalNames - detail.matchedCount - detail.ambiguousCount;
+
+  const filteredEntries = useMemo(() => {
+    const q = search.trim().toLocaleLowerCase("sv-SE");
+
+    return detail.entries.filter((entry) => {
+      if (filter !== "all" && entry.status !== filter) return false;
+
+      if (!q) return true;
+
+      const haystack = [
+        entry.name,
+
+        entry.matchedCompany?.name ?? "",
+
+        entry.matchedCompany?.wikidataId ?? "",
+      ]
+
+        .join(" ")
+
+        .toLocaleLowerCase("sv-SE");
+
+      return haystack.includes(q);
+    });
+  }, [detail.entries, filter, search]);
+
+  const filterOptions: { value: CoverageEntryFilter; label: string }[] = [
+    { value: "all", label: t("overview.coverage.filters.all") },
+
+    { value: "matched", label: t("overview.coverage.filters.matched") },
+
+    { value: "missing", label: t("overview.coverage.filters.missing") },
+
+    { value: "ambiguous", label: t("overview.coverage.filters.ambiguous") },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-lg border border-gray-03 bg-gray-05/50 p-4 space-y-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <h3 className="text-lg font-semibold text-gray-01">
+            {detail.listName} — {detail.year}
+          </h3>
+
+          <Button variant="secondary" size="sm" onClick={onEdit}>
+            {t("overview.coverage.editYear")}
+          </Button>
+        </div>
+
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
+          <CoverageStatCard
+            label={t("overview.coverage.stats.total")}
+            value={detail.totalNames}
+            className="border-gray-03/80 bg-gray-04/30 text-gray-01"
+          />
+
+          <CoverageStatCard
+            label={t("overview.coverage.stats.matched")}
+            value={detail.matchedCount}
+            className="border-green-03/30 bg-green-03/10 text-green-03"
+          />
+
+          <CoverageStatCard
+            label={t("overview.coverage.stats.missing")}
+            value={missingCount}
+            className="border-orange-03/30 bg-orange-03/10 text-orange-03"
+          />
+
+          <CoverageStatCard
+            label={t("overview.coverage.stats.ambiguous")}
+            value={detail.ambiguousCount}
+            className="border-yellow-500/30 bg-yellow-500/10 text-yellow-400"
+          />
+
+          <CoverageStatCard
+            label={t("overview.coverage.stats.coverage")}
+            value={`${detail.coveragePercent}%`}
+            className="border-blue-03/30 bg-blue-03/10 text-blue-03"
+          />
+        </div>
+      </div>
+
+      <ViewModePills
+        options={filterOptions}
+        value={filter}
+        onValueChange={setFilter}
+        ariaLabel={t("overview.coverage.entryFilterLabel")}
+      />
+
+      <input
+        className="w-full max-w-md rounded-md border border-gray-03 bg-gray-05 px-3 py-2 text-sm"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        placeholder={t("overview.coverage.searchPlaceholder")}
+      />
+
+      <div className="overflow-x-auto rounded-lg border border-gray-03">
+        <table className="min-w-full text-sm">
+          <thead className="bg-gray-05/80 text-left text-gray-02">
+            <tr>
+              <th className="px-4 py-2 font-medium">
+                {t("overview.coverage.columns.listName")}
+              </th>
+
+              <th className="px-4 py-2 font-medium">
+                {t("overview.coverage.columns.status")}
+              </th>
+
+              <th className="px-4 py-2 font-medium">
+                {t("overview.coverage.columns.dbMatch")}
+              </th>
+            </tr>
+          </thead>
+
+          <tbody>
+            {filteredEntries.map((entry) => (
+              <CoverageEntryRow key={entry.id} entry={entry} />
+            ))}
+
+            {filteredEntries.length === 0 ? (
+              <tr>
+                <td colSpan={3} className="px-4 py-8 text-center text-gray-02">
+                  {t("overview.coverage.noEntries")}
+                </td>
+              </tr>
+            ) : null}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function CoverageStatCard({
+  label,
+
+  value,
+
+  className,
+}: {
+  label: string;
+
+  value: number | string;
+
+  className: string;
+}) {
+  return (
+    <div className={`rounded-lg border px-3 py-2 ${className}`}>
+      <p className="text-[11px] uppercase tracking-wide opacity-80">{label}</p>
+
+      <p className="text-xl font-semibold tabular-nums">{value}</p>
+    </div>
+  );
+}
+
+function CoverageEntryRow({ entry }: { entry: CoverageEntry }) {
+  const { t } = useI18n();
+
+  const statusLabel =
+    entry.status === "matched"
+      ? t("overview.coverage.filters.matched")
+      : entry.status === "missing"
+        ? t("overview.coverage.filters.missing")
+        : t("overview.coverage.filters.ambiguous");
+
+  const statusClass =
+    entry.status === "matched"
+      ? "text-green-03"
+      : entry.status === "missing"
+        ? "text-orange-03"
+        : "text-yellow-400";
+
+  return (
+    <tr className="border-t border-gray-03/60">
+      <td className="px-4 py-2 text-gray-01">{entry.name}</td>
+
+      <td className={`px-4 py-2 font-medium ${statusClass}`}>{statusLabel}</td>
+
+      <td className="px-4 py-2 text-gray-02">
+        {entry.matchedCompany ? (
+          <Link
+            to={editorCompanyPath(entry.matchedCompany.wikidataId)}
+            className="text-blue-03 hover:underline"
+          >
+            {entry.matchedCompany.name}
+          </Link>
+        ) : (
+          "—"
+        )}
+      </td>
+    </tr>
+  );
+}

--- a/src/tabs/overview/components/CoverageYearFormDialog.tsx
+++ b/src/tabs/overview/components/CoverageYearFormDialog.tsx
@@ -48,11 +48,18 @@ export function CoverageYearFormDialog({
         ? t("overview.coverage.addYearTitle")
         : t("overview.coverage.editYearTitle");
 
+  const trimmedListName = listName.trim();
+  const parsedYear = Number.parseInt(year, 10);
+  const isValidYear = Number.isFinite(parsedYear);
+  const canSubmit =
+    mode === "createList"
+      ? trimmedListName.length > 0 && isValidYear
+      : isValidYear;
+
   const handleSubmit = async () => {
-    const parsedYear = Number.parseInt(year, 10);
-    if (!Number.isFinite(parsedYear)) return;
+    if (!canSubmit) return;
     await onSubmit({
-      listName: mode === "createList" ? listName.trim() : undefined,
+      listName: mode === "createList" ? trimmedListName : undefined,
       year: parsedYear,
       names: namesFromTextarea(namesText),
     });
@@ -72,7 +79,10 @@ export function CoverageYearFormDialog({
           <Button variant="secondary" onClick={() => onOpenChange(false)}>
             {t("common.cancel")}
           </Button>
-          <Button onClick={() => void handleSubmit()} disabled={isSubmitting}>
+          <Button
+            onClick={() => void handleSubmit()}
+            disabled={!canSubmit || isSubmitting}
+          >
             {t("common.save")}
           </Button>
         </div>

--- a/src/tabs/overview/components/CoverageYearFormDialog.tsx
+++ b/src/tabs/overview/components/CoverageYearFormDialog.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useState } from "react";
+import { useI18n } from "@/contexts/I18nContext";
+import { namesFromTextarea } from "@/tabs/overview/lib/coverage-api";
+import { Button } from "@/ui/button";
+import { Modal } from "@/ui/modal";
+
+type CoverageYearFormDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  mode: "createList" | "addYear" | "editYear";
+  initialListName?: string;
+  initialYear?: number;
+  initialNamesText?: string;
+  onSubmit: (input: {
+    listName?: string;
+    year: number;
+    names: string[];
+  }) => Promise<void>;
+  isSubmitting?: boolean;
+};
+
+export function CoverageYearFormDialog({
+  open,
+  onOpenChange,
+  mode,
+  initialListName = "",
+  initialYear = new Date().getFullYear(),
+  initialNamesText = "",
+  onSubmit,
+  isSubmitting = false,
+}: CoverageYearFormDialogProps) {
+  const { t } = useI18n();
+  const [listName, setListName] = useState(initialListName);
+  const [year, setYear] = useState(String(initialYear));
+  const [namesText, setNamesText] = useState(initialNamesText);
+
+  useEffect(() => {
+    if (!open) return;
+    setListName(initialListName);
+    setYear(String(initialYear));
+    setNamesText(initialNamesText);
+  }, [open, initialListName, initialYear, initialNamesText]);
+
+  const title =
+    mode === "createList"
+      ? t("overview.coverage.createListTitle")
+      : mode === "addYear"
+        ? t("overview.coverage.addYearTitle")
+        : t("overview.coverage.editYearTitle");
+
+  const handleSubmit = async () => {
+    const parsedYear = Number.parseInt(year, 10);
+    if (!Number.isFinite(parsedYear)) return;
+    await onSubmit({
+      listName: mode === "createList" ? listName.trim() : undefined,
+      year: parsedYear,
+      names: namesFromTextarea(namesText),
+    });
+    onOpenChange(false);
+  };
+
+  return (
+    <Modal
+      open={open}
+      onOpenChange={onOpenChange}
+      size="3xl"
+      scrollable
+      title={title}
+      description={t("overview.coverage.formHint")}
+      footer={
+        <div className="flex justify-end gap-2">
+          <Button variant="secondary" onClick={() => onOpenChange(false)}>
+            {t("common.cancel")}
+          </Button>
+          <Button onClick={() => void handleSubmit()} disabled={isSubmitting}>
+            {t("common.save")}
+          </Button>
+        </div>
+      }
+    >
+      <div className="space-y-4">
+        {mode === "createList" ? (
+          <label className="block space-y-1">
+            <span className="text-sm text-gray-02">
+              {t("overview.coverage.listNameLabel")}
+            </span>
+            <input
+              className="w-full rounded-md border border-gray-03 bg-gray-05 px-3 py-2 text-sm"
+              value={listName}
+              onChange={(e) => setListName(e.target.value)}
+              placeholder={t("overview.coverage.listNamePlaceholder")}
+            />
+          </label>
+        ) : null}
+
+        {mode !== "editYear" ? (
+          <label className="block space-y-1">
+            <span className="text-sm text-gray-02">
+              {t("overview.coverage.yearLabel")}
+            </span>
+            <input
+              type="number"
+              className="w-full max-w-[10rem] rounded-md border border-gray-03 bg-gray-05 px-3 py-2 text-sm"
+              value={year}
+              onChange={(e) => setYear(e.target.value)}
+              min={1900}
+              max={2100}
+            />
+          </label>
+        ) : null}
+
+        <label className="block space-y-1">
+          <span className="text-sm text-gray-02">
+            {t("overview.coverage.namesLabel")}
+          </span>
+          <textarea
+            className="w-full min-h-[320px] rounded-md border border-gray-03 bg-gray-05 px-3 py-2 text-sm font-mono"
+            value={namesText}
+            onChange={(e) => setNamesText(e.target.value)}
+            placeholder={t("overview.coverage.namesPlaceholder")}
+          />
+          <p className="text-xs text-gray-02">
+            {t("overview.coverage.namesCount", {
+              count: namesFromTextarea(namesText).length,
+            })}
+          </p>
+        </label>
+      </div>
+    </Modal>
+  );
+}

--- a/src/tabs/overview/hooks/useCoverageLists.ts
+++ b/src/tabs/overview/hooks/useCoverageLists.ts
@@ -1,0 +1,117 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  addCoverageListYear,
+  createCoverageList,
+  deleteCoverageList,
+  deleteCoverageListYear,
+  fetchCoverageLists,
+  fetchCoverageYearDetail,
+  renameCoverageList,
+  replaceCoverageYearNames,
+} from "../lib/coverage-api";
+import type {
+  CoverageListSummary,
+  CoverageYearDetail,
+} from "../lib/coverage-types";
+
+export function useCoverageLists() {
+  const [lists, setLists] = useState<CoverageListSummary[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadLists = useCallback(async (manual = false) => {
+    if (manual) setIsRefreshing(true);
+    else setIsLoading(true);
+    setError(null);
+    try {
+      const response = await fetchCoverageLists();
+      setLists(response.lists);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+      setLists([]);
+    } finally {
+      setIsLoading(false);
+      setIsRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadLists(false);
+  }, [loadLists]);
+
+  return {
+    lists,
+    isLoading,
+    isRefreshing,
+    error,
+    refresh: () => loadLists(true),
+    createList: async (input: {
+      name: string;
+      year?: number;
+      names?: string[];
+    }) => {
+      const created = await createCoverageList(input);
+      await loadLists(true);
+      return created;
+    },
+    addYear: async (
+      listId: string,
+      input: { year: number; names: string[] },
+    ) => {
+      const updated = await addCoverageListYear(listId, input);
+      await loadLists(true);
+      return updated;
+    },
+    renameList: async (listId: string, name: string) => {
+      const updated = await renameCoverageList(listId, name);
+      await loadLists(true);
+      return updated;
+    },
+    replaceYearNames: async (listId: string, year: number, names: string[]) => {
+      const updated = await replaceCoverageYearNames(listId, year, names);
+      await loadLists(true);
+      return updated;
+    },
+    deleteList: async (listId: string) => {
+      await deleteCoverageList(listId);
+      await loadLists(true);
+    },
+    deleteYear: async (listId: string, year: number) => {
+      await deleteCoverageListYear(listId, year);
+      await loadLists(true);
+    },
+  };
+}
+
+export function useCoverageYearDetail(
+  listId: string | null,
+  year: number | null,
+) {
+  const [detail, setDetail] = useState<CoverageYearDetail | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadDetail = useCallback(async () => {
+    if (!listId || year === null) {
+      setDetail(null);
+      return;
+    }
+    setIsLoading(true);
+    setError(null);
+    try {
+      setDetail(await fetchCoverageYearDetail(listId, year));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+      setDetail(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [listId, year]);
+
+  useEffect(() => {
+    void loadDetail();
+  }, [loadDetail]);
+
+  return { detail, isLoading, error, refresh: loadDetail };
+}

--- a/src/tabs/overview/hooks/useOverviewData.ts
+++ b/src/tabs/overview/hooks/useOverviewData.ts
@@ -44,12 +44,14 @@ function overviewViewFromSearchParams(
   const view = searchParams.get(OVERVIEW_VIEW_QUERY);
   if (view === "registry") return "registryReports";
   if (view === "prod-to-stage") return "prodToStage";
+  if (view === "coverage") return "coverage";
   return "companyYears";
 }
 
 function viewModeToQuery(mode: OverviewViewMode): string | null {
   if (mode === "registryReports") return "registry";
   if (mode === "prodToStage") return "prod-to-stage";
+  if (mode === "coverage") return "coverage";
   return null;
 }
 
@@ -119,6 +121,12 @@ export function useOverviewData() {
 
   const loadData = useCallback(
     async (isManualRefresh = false) => {
+      if (viewMode === "coverage") {
+        setIsLoading(false);
+        setIsRefreshing(false);
+        return;
+      }
+
       if (isManualRefresh) setIsRefreshing(true);
       else setIsLoading(true);
 

--- a/src/tabs/overview/lib/coverage-api.ts
+++ b/src/tabs/overview/lib/coverage-api.ts
@@ -1,0 +1,136 @@
+import { getUnearthApiBaseUrl } from "@/config/api-env";
+import { garboAuthFetch, throwIfAuthError } from "@/lib/garbo-auth-fetch";
+import type { CoverageListSummary, CoverageYearDetail } from "./coverage-types";
+
+function coverageUrl(path: string): string {
+  const base = getUnearthApiBaseUrl();
+  const segment = path.replace(/^\//, "").replace(/\/+$/, "");
+  return `${base}/coverage-lists${segment ? `/${segment}` : ""}`.replace(
+    /\/+$/,
+    "",
+  );
+}
+
+async function parseJson<T>(response: Response, url: string): Promise<T> {
+  if (response.ok) {
+    return response.json() as Promise<T>;
+  }
+  throwIfAuthError(response.status);
+  const body = await response.text().catch(() => "");
+  throw new Error(
+    `Coverage request failed (${response.status})${body ? `: ${body.slice(0, 200)}` : ""} (${url})`,
+  );
+}
+
+export async function fetchCoverageLists(): Promise<{
+  lists: CoverageListSummary[];
+}> {
+  const url = coverageUrl("");
+  const response = await garboAuthFetch(url, { cache: "no-store" });
+  return parseJson(response, url);
+}
+
+export async function fetchCoverageList(
+  listId: string,
+): Promise<CoverageListSummary> {
+  const url = coverageUrl(listId);
+  const response = await garboAuthFetch(url, { cache: "no-store" });
+  return parseJson(response, url);
+}
+
+export async function fetchCoverageYearDetail(
+  listId: string,
+  year: number,
+): Promise<CoverageYearDetail> {
+  const url = coverageUrl(`${listId}/years/${year}`);
+  const response = await garboAuthFetch(url, { cache: "no-store" });
+  return parseJson(response, url);
+}
+
+export async function createCoverageList(input: {
+  name: string;
+  year?: number;
+  names?: string[];
+}): Promise<CoverageListSummary> {
+  const url = coverageUrl("");
+  const response = await garboAuthFetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  return parseJson(response, url);
+}
+
+export async function addCoverageListYear(
+  listId: string,
+  input: { year: number; names: string[] },
+): Promise<CoverageListSummary> {
+  const url = coverageUrl(`${listId}/years`);
+  const response = await garboAuthFetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  return parseJson(response, url);
+}
+
+export async function renameCoverageList(
+  listId: string,
+  name: string,
+): Promise<CoverageListSummary> {
+  const url = coverageUrl(listId);
+  const response = await garboAuthFetch(url, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name }),
+  });
+  return parseJson(response, url);
+}
+
+export async function replaceCoverageYearNames(
+  listId: string,
+  year: number,
+  names: string[],
+): Promise<CoverageListSummary> {
+  const url = coverageUrl(`${listId}/years/${year}`);
+  const response = await garboAuthFetch(url, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ names }),
+  });
+  return parseJson(response, url);
+}
+
+export async function deleteCoverageList(listId: string): Promise<void> {
+  const url = coverageUrl(listId);
+  const response = await garboAuthFetch(url, { method: "DELETE" });
+  if (!response.ok) {
+    throwIfAuthError(response.status);
+    const body = await response.text().catch(() => "");
+    throw new Error(
+      `Delete coverage list failed (${response.status})${body ? `: ${body.slice(0, 200)}` : ""}`,
+    );
+  }
+}
+
+export async function deleteCoverageListYear(
+  listId: string,
+  year: number,
+): Promise<void> {
+  const url = coverageUrl(`${listId}/years/${year}`);
+  const response = await garboAuthFetch(url, { method: "DELETE" });
+  if (!response.ok) {
+    throwIfAuthError(response.status);
+    const body = await response.text().catch(() => "");
+    throw new Error(
+      `Delete coverage year failed (${response.status})${body ? `: ${body.slice(0, 200)}` : ""}`,
+    );
+  }
+}
+
+export function namesFromTextarea(text: string): string[] {
+  return text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}

--- a/src/tabs/overview/lib/coverage-api.ts
+++ b/src/tabs/overview/lib/coverage-api.ts
@@ -1,6 +1,12 @@
 import { getUnearthApiBaseUrl } from "@/config/api-env";
 import { garboAuthFetch, throwIfAuthError } from "@/lib/garbo-auth-fetch";
-import type { CoverageListSummary, CoverageYearDetail } from "./coverage-types";
+import {
+  coverageListCollectionSchema,
+  coverageListSummarySchema,
+  coverageYearDetailSchema,
+  type CoverageListSummary,
+  type CoverageYearDetail,
+} from "./coverage-types";
 
 function coverageUrl(path: string): string {
   const base = getUnearthApiBaseUrl();
@@ -11,9 +17,13 @@ function coverageUrl(path: string): string {
   );
 }
 
-async function parseJson<T>(response: Response, url: string): Promise<T> {
+async function parseJson<T>(
+  response: Response,
+  url: string,
+  parse: (data: unknown) => T,
+): Promise<T> {
   if (response.ok) {
-    return response.json() as Promise<T>;
+    return parse(await response.json());
   }
   throwIfAuthError(response.status);
   const body = await response.text().catch(() => "");
@@ -27,7 +37,9 @@ export async function fetchCoverageLists(): Promise<{
 }> {
   const url = coverageUrl("");
   const response = await garboAuthFetch(url, { cache: "no-store" });
-  return parseJson(response, url);
+  return parseJson(response, url, (data) =>
+    coverageListCollectionSchema.parse(data),
+  );
 }
 
 export async function fetchCoverageList(
@@ -35,7 +47,9 @@ export async function fetchCoverageList(
 ): Promise<CoverageListSummary> {
   const url = coverageUrl(listId);
   const response = await garboAuthFetch(url, { cache: "no-store" });
-  return parseJson(response, url);
+  return parseJson(response, url, (data) =>
+    coverageListSummarySchema.parse(data),
+  );
 }
 
 export async function fetchCoverageYearDetail(
@@ -44,7 +58,9 @@ export async function fetchCoverageYearDetail(
 ): Promise<CoverageYearDetail> {
   const url = coverageUrl(`${listId}/years/${year}`);
   const response = await garboAuthFetch(url, { cache: "no-store" });
-  return parseJson(response, url);
+  return parseJson(response, url, (data) =>
+    coverageYearDetailSchema.parse(data),
+  );
 }
 
 export async function createCoverageList(input: {
@@ -58,7 +74,9 @@ export async function createCoverageList(input: {
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(input),
   });
-  return parseJson(response, url);
+  return parseJson(response, url, (data) =>
+    coverageListSummarySchema.parse(data),
+  );
 }
 
 export async function addCoverageListYear(
@@ -71,7 +89,9 @@ export async function addCoverageListYear(
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(input),
   });
-  return parseJson(response, url);
+  return parseJson(response, url, (data) =>
+    coverageListSummarySchema.parse(data),
+  );
 }
 
 export async function renameCoverageList(
@@ -84,7 +104,9 @@ export async function renameCoverageList(
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ name }),
   });
-  return parseJson(response, url);
+  return parseJson(response, url, (data) =>
+    coverageListSummarySchema.parse(data),
+  );
 }
 
 export async function replaceCoverageYearNames(
@@ -98,7 +120,9 @@ export async function replaceCoverageYearNames(
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ names }),
   });
-  return parseJson(response, url);
+  return parseJson(response, url, (data) =>
+    coverageListSummarySchema.parse(data),
+  );
 }
 
 export async function deleteCoverageList(listId: string): Promise<void> {

--- a/src/tabs/overview/lib/coverage-types.ts
+++ b/src/tabs/overview/lib/coverage-types.ts
@@ -1,0 +1,36 @@
+export type CoverageMatchedCompany = {
+  wikidataId: string;
+  name: string;
+};
+
+export type CoverageYearSummary = {
+  year: number;
+  totalNames: number;
+  matchedCount: number;
+  ambiguousCount: number;
+  coveragePercent: number;
+};
+
+export type CoverageListSummary = {
+  id: string;
+  name: string;
+  updatedAt: string;
+  years: CoverageYearSummary[];
+};
+
+export type CoverageEntryStatus = "matched" | "missing" | "ambiguous";
+
+export type CoverageEntry = {
+  id: string;
+  name: string;
+  status: CoverageEntryStatus;
+  matchedCompany?: CoverageMatchedCompany;
+};
+
+export type CoverageYearDetail = CoverageYearSummary & {
+  listId: string;
+  listName: string;
+  entries: CoverageEntry[];
+};
+
+export type CoverageEntryFilter = "all" | CoverageEntryStatus;

--- a/src/tabs/overview/lib/coverage-types.ts
+++ b/src/tabs/overview/lib/coverage-types.ts
@@ -1,36 +1,55 @@
-export type CoverageMatchedCompany = {
-  wikidataId: string;
-  name: string;
-};
+import { z } from "zod";
 
-export type CoverageYearSummary = {
-  year: number;
-  totalNames: number;
-  matchedCount: number;
-  ambiguousCount: number;
-  coveragePercent: number;
-};
+export const coverageMatchedCompanySchema = z.object({
+  wikidataId: z.string(),
+  name: z.string(),
+});
 
-export type CoverageListSummary = {
-  id: string;
-  name: string;
-  updatedAt: string;
-  years: CoverageYearSummary[];
-};
+export const coverageYearSummarySchema = z.object({
+  year: z.number(),
+  totalNames: z.number(),
+  matchedCount: z.number(),
+  ambiguousCount: z.number(),
+  coveragePercent: z.number(),
+});
 
-export type CoverageEntryStatus = "matched" | "missing" | "ambiguous";
+export const coverageListSummarySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  updatedAt: z.string(),
+  years: z.array(coverageYearSummarySchema),
+});
 
-export type CoverageEntry = {
-  id: string;
-  name: string;
-  status: CoverageEntryStatus;
-  matchedCompany?: CoverageMatchedCompany;
-};
+export const coverageEntryStatusSchema = z.enum([
+  "matched",
+  "missing",
+  "ambiguous",
+]);
 
-export type CoverageYearDetail = CoverageYearSummary & {
-  listId: string;
-  listName: string;
-  entries: CoverageEntry[];
-};
+export const coverageEntrySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  status: coverageEntryStatusSchema,
+  matchedCompany: coverageMatchedCompanySchema.optional(),
+});
+
+export const coverageYearDetailSchema = coverageYearSummarySchema.extend({
+  listId: z.string(),
+  listName: z.string(),
+  entries: z.array(coverageEntrySchema),
+});
+
+export const coverageListCollectionSchema = z.object({
+  lists: z.array(coverageListSummarySchema),
+});
+
+export type CoverageMatchedCompany = z.infer<
+  typeof coverageMatchedCompanySchema
+>;
+export type CoverageYearSummary = z.infer<typeof coverageYearSummarySchema>;
+export type CoverageListSummary = z.infer<typeof coverageListSummarySchema>;
+export type CoverageEntryStatus = z.infer<typeof coverageEntryStatusSchema>;
+export type CoverageEntry = z.infer<typeof coverageEntrySchema>;
+export type CoverageYearDetail = z.infer<typeof coverageYearDetailSchema>;
 
 export type CoverageEntryFilter = "all" | CoverageEntryStatus;

--- a/src/tabs/overview/lib/overview-types.ts
+++ b/src/tabs/overview/lib/overview-types.ts
@@ -5,7 +5,8 @@ export const OVERVIEW_YEAR_RANGE_START = 2020;
 export type OverviewViewMode =
   | "companyYears"
   | "registryReports"
-  | "prodToStage";
+  | "prodToStage"
+  | "coverage";
 
 export type OverviewStatusKind =
   | "ok"
@@ -119,6 +120,7 @@ export function defaultFiltersForView(
   viewMode: OverviewViewMode,
 ): OverviewFilters {
   if (viewMode === "registryReports") return defaultRegistryOverviewFilters();
+  if (viewMode === "coverage") return defaultOverviewFilters();
   return defaultOverviewFilters();
 }
 


### PR DESCRIPTION
## Summary
- New Overview subtab (`?view=coverage`) for named index lists with per-year company name editions
- List summary table, year detail with status/DB match columns, and create/edit/delete flows
- API client + hooks wired to `/api/coverage-lists`; en/sv i18n

## Test plan
- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] Open Overview → Coverage; create list, add year, paste names; verify match status updates
- [ ] Confirm short names like `3M` do not false-match unrelated companies

## Deploy order
Requires Garbo migration + Unearth API PR deployed to the target environment.

Made with [Cursor](https://cursor.com)