### PR TITLE
[235] update validate to handle identifiers and wikidataId/companyID changes

### DIFF
--- a/public/climate-plans/measures/jonköping.json
+++ b/public/climate-plans/measures/jonköping.json
@@ -1,8243 +1,7034 @@
 [
-    {
-      "measure_text": "121.Samtliga utsläpp av växthusgaser (scope 1,2 och 3) inom kommunkoncernen ska halveras till år 2030 jämfört med 2020 års utsläppsnivå.",
-      "activity": "none",
-      "activity_shift_score": 1,
-      "activity_shifts": [],
-      "intervention_who": "none",
-      "intervention_when": "none",
-      "intervention_what": "none",
-      "intervention_how": "none",
-      "intervention_score": 1,
-      "intervention_reasoning": "No specific action, responsible actor, timeline, or mechanism is provided.",
-      "intervention_type": "none"
-    },
-    {
-      "measure_text": "122.Den årliga reduktionstakten för kommunkoncernen ska vara 10 procent jämfört med föregående år.",
-      "activity": "none",
-      "activity_shift_score": 1,
-      "activity_shifts": [],
-      "intervention_who": "none",
-      "intervention_when": "none",
-      "intervention_what": "none",
-      "intervention_how": "none",
-      "intervention_score": 1,
-      "intervention_reasoning": "No specific action, responsible actor, timeline, or mechanism is provided.",
-      "intervention_type": "none"
-    },
-    {
-      "measure_text": "123.Kommunkoncernen ska senast år 2030 vara fossilbränslefri avseende el, egna och upphandlade transporter, samt uppvärmning (exkl. fossil del i avfall som eldas på Torsvik).",
-      "activity": "electricity, transport, heating",
-      "activity_shift_score": 6,
-      "activity_shifts": [
-        {
-          "activity": "using electricity",
-          "shift_from": "using fossil fuels for electricity",
-          "shift_to": "using fossil-free sources for electricity",
-          "need": "electricity provision",
-          "type": "Resource Shift",
-          "type_reasoning": "The measure specifies a shift from fossil fuels to fossil-free sources for electricity, which is a change in the resource used.",
-          "score": 6,
-          "reasoning": "Activity, shift_from, shift_to, and need are all identifiable.",
-          "transition_element_matches": [],
-          "transition_element_suggested_new": {
-            "short_label": "shift_to_fossil_free_electricity_generation",
-            "description": "Transition from fossil fuel-based electricity generation to fossil-free sources such as wind, solar, or hydroelectric power."
-          },
-          "transition_element_candidates": [
-            {
-              "stable_id": "shift_to_electricity_in_hydrogen_refinement",
-              "short_label": "T-5B4-TE-5 - Shift to electricity in hydrogen refinement",
-              "description": "Shift to electricity in hydrogen refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within hydrogen refinement, natural gas usage within hydrogen refinement. to: electricity usage within hydrogen refinement. Energy > Energy Transformation > Hydrogen Refinement",
-              "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
-              "acts_on_labels": [
-                "coal usage within hydrogen refinement",
-                "natural gas usage within hydrogen refinement"
-              ],
-              "shifts_to_labels": [
-                "electricity usage within hydrogen refinement"
-              ],
-              "score": 0.5715
-            },
-            {
-              "stable_id": "shift_to_electricity_in_chemical_industries",
-              "short_label": "T-2B9-TE-3 - Shift to electricity in chemical industries",
-              "description": "Shift to electricity in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within chemical industries, natural gas usage within chemical industries. to: electricity usage within chemical industries. Industry > Chemicals > Other",
-              "sector_path": "Industry > Chemicals > Other",
-              "acts_on_labels": [
-                "coal usage within chemical industries",
-                "natural gas usage within chemical industries"
-              ],
-              "shifts_to_labels": [
-                "electricity usage within chemical industries"
-              ],
-              "score": 0.5664
-            },
-            {
-              "stable_id": "shift_to_electricity_in_iron_and_steel_industries",
-              "short_label": "T-2C1-TE-4 - Shift to electricity in iron and steel industries",
-              "description": "Shift to electricity in iron and steel industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within iron and steel industries, natural gas usage within iron and steel industries. to: electricity usage within iron and steel industries. Industry > Metals > Iron Steel",
-              "sector_path": "Industry > Metals > Iron Steel",
-              "acts_on_labels": [
-                "coal usage within iron and steel industries",
-                "natural gas usage within iron and steel industries"
-              ],
-              "shifts_to_labels": [
-                "electricity usage within iron and steel industries"
-              ],
-              "score": 0.5617
-            },
-            {
-              "stable_id": "shift_to_electricity_in_glass_industries",
-              "short_label": "T-2A3-TE-3 - Shift to electricity in glass industries",
-              "description": "Shift to electricity in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within glass industries, oil usage within glass industries, natural gas usage within glass industries. to: electricity usage within glass industries. Industry > Minerals > Glass Production",
-              "sector_path": "Industry > Minerals > Glass Production",
-              "acts_on_labels": [
-                "coal usage within glass industries",
-                "oil usage within glass industries",
-                "natural gas usage within glass industries"
-              ],
-              "shifts_to_labels": [
-                "electricity usage within glass industries"
-              ],
-              "score": 0.5509
-            },
-            {
-              "stable_id": "shift_to_electricity_in_other_industries",
-              "short_label": "T-2D5-TE-3 - Shift to electricity in other industries",
-              "description": "Shift to electricity in other industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: industrial unregulated coal use, industrial unregulated oil use, industrial unregulated gas use. to: industrial unregulated electricity use. Industry > Other > Other",
-              "sector_path": "Industry > Other > Other",
-              "acts_on_labels": [
-                "industrial unregulated coal use",
-                "industrial unregulated oil use",
-                "industrial unregulated gas use"
-              ],
-              "shifts_to_labels": [
-                "industrial unregulated electricity use"
-              ],
-              "score": 0.5502
-            },
-            {
-              "stable_id": "shift_to_electricity_in_magnesium_industries",
-              "short_label": "T-2C4-TE-1 - Shift to electricity in magnesium industries",
-              "description": "Shift to electricity in magnesium industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within magnesium industries, oil usage within magnesium industries, natural gas usage within magnesium industries. to: electricity usage within magnesium industries. Industry > Metals > Magnesium",
-              "sector_path": "Industry > Metals > Magnesium",
-              "acts_on_labels": [
-                "coal usage within magnesium industries",
-                "oil usage within magnesium industries",
-                "natural gas usage within magnesium industries"
-              ],
-              "shifts_to_labels": [
-                "electricity usage within magnesium industries"
-              ],
-              "score": 0.5325
-            },
-            {
-              "stable_id": "electrification_of_production_in_cement_and_concrete_industry",
-              "short_label": "T-2A1-TE-2 - Shift to electricity in cement and mineral industry",
-              "description": "Shift to electricity in cement and mineral industry. Shift kilowatt-hours from cement and mineral processes that uses coal to cement and mineral processes that uses electricity. from: cement mineral industries coal usage. to: cement mineral industries electricity usage. Industry > Minerals > Cement",
-              "sector_path": "Industry > Minerals > Cement",
-              "acts_on_labels": [
-                "cement mineral industries coal usage"
-              ],
-              "shifts_to_labels": [
-                "cement mineral industries electricity usage"
-              ],
-              "score": 0.5322
-            },
-            {
-              "stable_id": "shift_to_biofuel_in_district_heating",
-              "short_label": "T-5A3-TE-7 - Shift to biofuel in district heating",
-              "description": "Shift to biofuel in district heating. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: chp coal, chp natural gas, chp oil. to: chp biofuels. Energy > Energy Supply > Combined Heat Power",
-              "sector_path": "Energy > Energy Supply > Combined Heat Power",
-              "acts_on_labels": [
-                "chp coal",
-                "chp natural gas",
-                "chp oil"
-              ],
-              "shifts_to_labels": [
-                "chp biofuels"
-              ],
-              "score": 0.5306
-            },
-            {
-              "stable_id": "shift_to_electricity_in_pulp_paper_and_print_industries",
-              "short_label": "T-2D1b-TE-3 - Shift to electricity in pulp, paper and print industries",
-              "description": "Shift to electricity in pulp, paper and print industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within pulp paper and print industries, oil usage within pulp paper and print industries, natural gas usage within pulp paper and print industries. to: electricity usage within pulp paper and print industries. Industry > Other > Manufacturing > Pulp Paper Print",
-              "sector_path": "Industry > Other > Manufacturing > Pulp Paper Print",
-              "acts_on_labels": [
-                "coal usage within pulp paper and print industries",
-                "oil usage within pulp paper and print industries",
-                "natural gas usage within pulp paper and print industries"
-              ],
-              "shifts_to_labels": [
-                "electricity usage within pulp paper and print industries"
-              ],
-              "score": 0.5284
-            },
-            {
-              "stable_id": "shift_to_electricity_in_lead_industries",
-              "short_label": "T-2C5-TE-3 - Shift to electricity in lead industries",
-              "description": "Shift to electricity in lead industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within lead industries, oil usage within lead industries, natural gas usage within lead industries. to: electricity usage within lead industries. Industry > Metals > Lead",
-              "sector_path": "Industry > Metals > Lead",
-              "acts_on_labels": [
-                "coal usage within lead industries",
-                "oil usage within lead industries",
-                "natural gas usage within lead industries"
-              ],
-              "shifts_to_labels": [
-                "electricity usage within lead industries"
-              ],
-              "score": 0.5267
-            },
-            {
-              "stable_id": "coal_fired_power_plants",
-              "short_label": "T-5A1-TE-1 - Electricity from coal power plants",
-              "description": "Electricity from coal power plants. Alter the amount of electricity produced by coal fired power plants. from: coal fired power plants. Energy > Energy Supply > Electricity",
-              "sector_path": "Energy > Energy Supply > Electricity",
-              "acts_on_labels": [
-                "coal fired power plants"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.5046
-            },
-            {
-              "stable_id": "oil_fired_power_plants",
-              "short_label": "T-5A1-TE-5 - Electricity from oil power plants",
-              "description": "Electricity from oil power plants. Alter the amount of electricity produced by oil fired power plants. from: oil fired power plants. Energy > Energy Supply > Electricity",
-              "sector_path": "Energy > Energy Supply > Electricity",
-              "acts_on_labels": [
-                "oil fired power plants"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.4965
-            },
-            {
-              "stable_id": "shift_to_electrolysis_of_water_for_hydrogen_production",
-              "short_label": "T-5B4-TE-6 - Shift to electrolysis of water for hydrogen production",
-              "description": "Shift to electrolysis of water for hydrogen production. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: reforming of methane for hydrogen production, gasification of carbon for hydrogen production. to: electrolysis of water for hydrogen production. Energy > Energy Transformation > Hydrogen Refinement",
-              "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
-              "acts_on_labels": [
-                "reforming of methane for hydrogen production",
-                "gasification of carbon for hydrogen production"
-              ],
-              "shifts_to_labels": [
-                "electrolysis of water for hydrogen production"
-              ],
-              "score": 0.4935
-            },
-            {
-              "stable_id": "improved_grid_electricity",
-              "short_label": "T-5A1-TE-3 - Improved Grid Electricity",
-              "description": "Improved Grid Electricity. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: grid current. to: grid future. Energy > Energy Supply > Electricity",
-              "sector_path": "Energy > Energy Supply > Electricity",
-              "acts_on_labels": [
-                "grid current"
-              ],
-              "shifts_to_labels": [
-                "grid future"
-              ],
-              "score": 0.4909
-            },
-            {
-              "stable_id": "biofuel_fired_power_plants",
-              "short_label": "T-5A1-TE-11 - Electricity from biomass power plants",
-              "description": "Electricity from biomass power plants. Alter the amount of electricity produced by biofuel fired power plants. from: biofuel fired powerplants. Energy > Energy Supply > Electricity",
-              "sector_path": "Energy > Energy Supply > Electricity",
-              "acts_on_labels": [
-                "biofuel fired powerplants"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.4846
-            },
-            {
-              "stable_id": "wind_offshore",
-              "short_label": "T-5A1-TE-9 - Electricity from wind offshore",
-              "description": "Electricity from wind offshore. Alter the amount of electricity produced by wind offshore. from: wind offshore. Energy > Energy Supply > Electricity",
-              "sector_path": "Energy > Energy Supply > Electricity",
-              "acts_on_labels": [
-                "wind offshore"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.4835
-            },
-            {
-              "stable_id": "gas_fired_power_plants",
-              "short_label": "T-5A1-TE-2 - Electricity from gas power plants",
-              "description": "Electricity from gas power plants. Alter the amount of electricity produced by gas fired power plants. from: gas fired power plants. Energy > Energy Supply > Electricity",
-              "sector_path": "Energy > Energy Supply > Electricity",
-              "acts_on_labels": [
-                "gas fired power plants"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.4826
-            }
-          ]
+  {
+    "measure_text": "121.Samtliga utsläpp av växthusgaser (scope 1,2 och 3) inom kommunkoncernen ska halveras till år 2030 jämfört med 2020 års utsläppsnivå.",
+    "activity": "none",
+    "activity_shift_score": 1,
+    "activity_shifts": [],
+    "intervention_who": "none",
+    "intervention_when": "none",
+    "intervention_what": "none",
+    "intervention_how": "none",
+    "intervention_score": 1,
+    "intervention_reasoning": "No specific action, responsible actor, timeline, or mechanism is provided.",
+    "intervention_type": "none"
+  },
+  {
+    "measure_text": "122.Den årliga reduktionstakten för kommunkoncernen ska vara 10 procent jämfört med föregående år.",
+    "activity": "none",
+    "activity_shift_score": 1,
+    "activity_shifts": [],
+    "intervention_who": "none",
+    "intervention_when": "none",
+    "intervention_what": "none",
+    "intervention_how": "none",
+    "intervention_score": 1,
+    "intervention_reasoning": "No specific action, responsible actor, timeline, or mechanism is provided.",
+    "intervention_type": "none"
+  },
+  {
+    "measure_text": "123.Kommunkoncernen ska senast år 2030 vara fossilbränslefri avseende el, egna och upphandlade transporter, samt uppvärmning (exkl. fossil del i avfall som eldas på Torsvik).",
+    "activity": "electricity, transport, heating",
+    "activity_shift_score": 6,
+    "activity_shifts": [
+      {
+        "activity": "using electricity",
+        "shift_from": "using fossil fuels for electricity",
+        "shift_to": "using fossil-free sources for electricity",
+        "need": "electricity provision",
+        "type": "Resource Shift",
+        "type_reasoning": "The measure specifies a shift from fossil fuels to fossil-free sources for electricity, which is a change in the resource used.",
+        "score": 6,
+        "reasoning": "Activity, shift_from, shift_to, and need are all identifiable.",
+        "transition_element_matches": [],
+        "transition_element_suggested_new": {
+          "short_label": "shift_to_fossil_free_electricity_generation",
+          "description": "Transition from fossil fuel-based electricity generation to fossil-free sources such as wind, solar, or hydroelectric power."
         },
-        {
-          "activity": "transporting",
-          "shift_from": "using fossil fuels for transport",
-          "shift_to": "using fossil-free sources for transport",
-          "need": "mobility",
-          "type": "Resource Shift",
-          "type_reasoning": "The measure specifies a shift from fossil fuels to fossil-free sources for transport, which is a change in the resource used.",
-          "score": 6,
-          "reasoning": "Activity, shift_from, shift_to, and need are all identifiable.",
-          "transition_element_matches": [
-            {
-              "stable_id": "shift_to_hydrogen_vehicles",
-              "short_label": "T-1A1a-TE-2 - Shift to hydrogen cars",
-              "description": "Shift to hydrogen cars. Shift vehicle kilometer from petrol and diesel vehicles to hydrogen vehicles in vehicle kilometer to fulfill the need of mobility. from: petrol vehicles, diesel vehicles. to: hydrogen vehicles. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles"
-              ],
-              "shifts_to_labels": [
-                "hydrogen vehicles"
-              ],
-              "score": 0.6172,
-              "match_reasoning": "acts_on=yes, shifts_to=yes, confidence=high",
-              "match_confidence": "high"
-            },
-            {
-              "stable_id": "shift_to_gas_vehicles",
-              "short_label": "T-1A1a-TE-19 - Shift to gas cars",
-              "description": "Shift to gas cars. Shift vehicle kilometer from petrol and diesel vehicles to gas vehicles in vehicle kilometer to fulfill the need of mobility. from: petrol vehicles, diesel vehicles. to: gas vehicles. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles"
-              ],
-              "shifts_to_labels": [
-                "gas vehicles"
-              ],
-              "score": 0.6094,
-              "match_reasoning": "acts_on=yes, shifts_to=yes, confidence=high",
-              "match_confidence": "high"
-            },
-            {
-              "stable_id": "shift_to_electric_vehicles",
-              "short_label": "T-1A1a-TE-1 - Shift to electric cars",
-              "description": "Shift to electric cars. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to battery electric vehicles in vehicle kilometer to fulfill the need of mobility. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: battery electric vehicles. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles",
-                "lpg vehicles",
-                "gas vehicles"
-              ],
-              "shifts_to_labels": [
-                "battery electric vehicles"
-              ],
-              "score": 0.6089,
-              "match_reasoning": "acts_on=yes, shifts_to=yes, confidence=high",
-              "match_confidence": "high"
-            },
-            {
-              "stable_id": "increased_proportion_of_public_transport_by_hydrogen_bus",
-              "short_label": "T-1A1a-TE-13 - Shift to travel by hydrogen bus",
-              "description": "Shift to travel by hydrogen bus. Shift vehicle kilometer from petrol and diesel vehicles to hydrogen buses. from: petrol vehicles, diesel vehicles. to: hydrogen buses. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles"
-              ],
-              "shifts_to_labels": [
-                "hydrogen buses"
-              ],
-              "score": 0.5327,
-              "match_reasoning": "acts_on=yes, shifts_to=yes, confidence=mid",
-              "match_confidence": "mid"
-            },
-            {
-              "stable_id": "increased_proportion_of_walking_and_cycling",
-              "short_label": "T-1A1a-TE-10 - Shift to walking and cycling",
-              "description": "Shift to walking and cycling. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to walking cycling. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: walking cycling. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles",
-                "lpg vehicles",
-                "gas vehicles"
-              ],
-              "shifts_to_labels": [
-                "walking cycling"
-              ],
-              "score": 0.5927,
-              "match_reasoning": "acts_on=yes, shifts_to=yes, confidence=mid",
-              "match_confidence": "mid"
-            },
-            {
-              "stable_id": "transfer_from_car_to_railway",
-              "short_label": "T-1A1a-TE-6 - Shift from car to railway",
-              "description": "Shift from car to railway. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to electric rail in person kilometer to fulfill the need of mobility. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: electric rail. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles",
-                "lpg vehicles",
-                "gas vehicles"
-              ],
-              "shifts_to_labels": [
-                "electric rail"
-              ],
-              "score": 0.5435,
-              "match_reasoning": "acts_on=yes, shifts_to=yes, confidence=mid",
-              "match_confidence": "mid"
-            }
-          ],
-          "transition_element_candidates": [
-            {
-              "stable_id": "electrification_of_domestic_sea_passenger_transport",
-              "short_label": "T-1A4-TE-5 - Shift to electric marine passenger transportion",
-              "description": "Shift to electric marine passenger transportion. Shift person kilometer from ship passenger to electric shipping passenger in person kilometer to fulfill the need of mobility. from: ship passenger, gas oil shipping passenger. to: electric shipping passenger. Transport > Mobility > Waterborne",
-              "sector_path": "Transport > Mobility > Waterborne",
-              "acts_on_labels": [
-                "ship passenger",
-                "gas oil shipping passenger"
-              ],
-              "shifts_to_labels": [
-                "electric shipping passenger"
-              ],
-              "score": 0.6205
-            },
-            {
-              "stable_id": "shift_to_hydrogen_vehicles",
-              "short_label": "T-1A1a-TE-2 - Shift to hydrogen cars",
-              "description": "Shift to hydrogen cars. Shift vehicle kilometer from petrol and diesel vehicles to hydrogen vehicles in vehicle kilometer to fulfill the need of mobility. from: petrol vehicles, diesel vehicles. to: hydrogen vehicles. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles"
-              ],
-              "shifts_to_labels": [
-                "hydrogen vehicles"
-              ],
-              "score": 0.6172
-            },
-            {
-              "stable_id": "shift_to_gas_vehicles",
-              "short_label": "T-1A1a-TE-19 - Shift to gas cars",
-              "description": "Shift to gas cars. Shift vehicle kilometer from petrol and diesel vehicles to gas vehicles in vehicle kilometer to fulfill the need of mobility. from: petrol vehicles, diesel vehicles. to: gas vehicles. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles"
-              ],
-              "shifts_to_labels": [
-                "gas vehicles"
-              ],
-              "score": 0.6094
-            },
-            {
-              "stable_id": "shift_to_electric_vehicles",
-              "short_label": "T-1A1a-TE-1 - Shift to electric cars",
-              "description": "Shift to electric cars. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to battery electric vehicles in vehicle kilometer to fulfill the need of mobility. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: battery electric vehicles. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles",
-                "lpg vehicles",
-                "gas vehicles"
-              ],
-              "shifts_to_labels": [
-                "battery electric vehicles"
-              ],
-              "score": 0.6089
-            },
-            {
-              "stable_id": "shift_to_electric_passenger_rail",
-              "short_label": "T-1A2-TE-2 - Shift to travel by electric rail",
-              "description": "Shift to travel by electric rail. Shift person kilometer from diesel passenger rail to electric passenger rail in person kilometer to fulfill the need of mobility. from: diesel passenger rail. to: electric rail. Transport > Mobility > Rail",
-              "sector_path": "Transport > Mobility > Rail",
-              "acts_on_labels": [
-                "diesel passenger rail"
-              ],
-              "shifts_to_labels": [
-                "electric rail"
-              ],
-              "score": 0.606
-            },
-            {
-              "stable_id": "shift_to_hydrogen_passenger_rail",
-              "short_label": "T-1A2-TE-3 - Shift to travel by hydrogen rail",
-              "description": "Shift to travel by hydrogen rail. Shift person kilometer from diesel passenger rail to hydrogen passenger rail in person kilometer to fulfill the need of mobility. from: diesel passenger rail. to: hydrogen passenger rail. Transport > Mobility > Rail",
-              "sector_path": "Transport > Mobility > Rail",
-              "acts_on_labels": [
-                "diesel passenger rail"
-              ],
-              "shifts_to_labels": [
-                "hydrogen passenger rail"
-              ],
-              "score": 0.5996
-            },
-            {
-              "stable_id": "electric_passenger_airplanes",
-              "short_label": "T-1A3-TE-3 - Shift to electric air passenger transport",
-              "description": "Shift to electric air passenger transport. Shift person kilometer from passenger transportation by air to electric passenger transportation by air in person kilometer to fulfill the need of mobility. from: passenger transportation by air. to: electric passenger transportation by air. Transport > Mobility > Aviation",
-              "sector_path": "Transport > Mobility > Aviation",
-              "acts_on_labels": [
-                "passenger transportation by air"
-              ],
-              "shifts_to_labels": [
-                "electric passenger transportation by air"
-              ],
-              "score": 0.598
-            },
-            {
-              "stable_id": "increased_proportion_of_public_transport_by_petrol_bus",
-              "short_label": "T-1A1a-TE-16 - Shift to travel by petrol bus",
-              "description": "Shift to travel by petrol bus. Shift vehicle kilometer from petrol and diesel vehicles to petrol buses. from: petrol vehicles, diesel vehicles. to: petrol buses. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles"
-              ],
-              "shifts_to_labels": [
-                "petrol buses"
-              ],
-              "score": 0.5953
-            },
-            {
-              "stable_id": "shift_from_passenger_air_transport_to_railway",
-              "short_label": "T-1A3-TE-4 - Shift from air travel to railway",
-              "description": "Shift from air travel to railway. Shift person kilometer from passenger transportation by air to electric rail in person kilometer to fulfill the need of mobility. from: passenger transportation by air. to: electric rail. Transport > Mobility > Aviation",
-              "sector_path": "Transport > Mobility > Aviation",
-              "acts_on_labels": [
-                "passenger transportation by air"
-              ],
-              "shifts_to_labels": [
-                "electric rail"
-              ],
-              "score": 0.5936
-            },
-            {
-              "stable_id": "increased_proportion_of_walking_and_cycling",
-              "short_label": "T-1A1a-TE-10 - Shift to walking and cycling",
-              "description": "Shift to walking and cycling. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to walking cycling. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: walking cycling. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles",
-                "lpg vehicles",
-                "gas vehicles"
-              ],
-              "shifts_to_labels": [
-                "walking cycling"
-              ],
-              "score": 0.5927
-            },
-            {
-              "stable_id": "shift_to_lng_fuel_for_sea_passenger_transportation",
-              "short_label": "T-1A4-TE-1 - Shift to LNG fuel for marine passenger transport",
-              "description": "Shift to LNG fuel for marine passenger transport. Shift person kilometer from ship passenger to LNG shipping passenger in person kilometer to fulfill the need of mobility. from: ship passenger, gas oil shipping passenger. to: lng shipping passenger. Transport > Mobility > Waterborne",
-              "sector_path": "Transport > Mobility > Waterborne",
-              "acts_on_labels": [
-                "ship passenger",
-                "gas oil shipping passenger"
-              ],
-              "shifts_to_labels": [
-                "lng shipping passenger"
-              ],
-              "score": 0.5515
-            },
-            {
-              "stable_id": "transfer_from_car_to_railway",
-              "short_label": "T-1A1a-TE-6 - Shift from car to railway",
-              "description": "Shift from car to railway. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to electric rail in person kilometer to fulfill the need of mobility. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: electric rail. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles",
-                "lpg vehicles",
-                "gas vehicles"
-              ],
-              "shifts_to_labels": [
-                "electric rail"
-              ],
-              "score": 0.5435
-            },
-            {
-              "stable_id": "biofuel_for_diesel_rail_passenger",
-              "short_label": "T-1A2-TE-1 - Biofuel for rail passenger transport",
-              "description": "Biofuel for rail passenger transport. Increase the proportion of HVO biodiesel in diesel. from: diesel passenger rail. Transport > Mobility > Rail",
-              "sector_path": "Transport > Mobility > Rail",
-              "acts_on_labels": [
-                "diesel passenger rail"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.5364
-            },
-            {
-              "stable_id": "biofuels_for_sea_passenger_transport",
-              "short_label": "T-1A4-TE-4 - Biofuel for marine passenger transport",
-              "description": "Biofuel for marine passenger transport. Increase the proportion of marine biodiesel in marine diesel. from: ship passenger. Transport > Mobility > Waterborne",
-              "sector_path": "Transport > Mobility > Waterborne",
-              "acts_on_labels": [
-                "ship passenger"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.5362
-            },
-            {
-              "stable_id": "biofuels_for_air_transport",
-              "short_label": "T-1A3-TE-1 - Biofuel for air passenger transport",
-              "description": "Biofuel for air passenger transport. Increase the proportion of aviation biofuel in aviation turbine fuel. from: passenger transportation by air. Transport > Mobility > Aviation",
-              "sector_path": "Transport > Mobility > Aviation",
-              "acts_on_labels": [
-                "passenger transportation by air"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.5357
-            },
-            {
-              "stable_id": "increased_proportion_of_public_transport_by_hydrogen_bus",
-              "short_label": "T-1A1a-TE-13 - Shift to travel by hydrogen bus",
-              "description": "Shift to travel by hydrogen bus. Shift vehicle kilometer from petrol and diesel vehicles to hydrogen buses. from: petrol vehicles, diesel vehicles. to: hydrogen buses. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles"
-              ],
-              "shifts_to_labels": [
-                "hydrogen buses"
-              ],
-              "score": 0.5327
-            }
-          ]
+        "transition_element_candidates": [
+          {
+            "stable_id": "shift_to_electricity_in_hydrogen_refinement",
+            "short_label": "T-5B4-TE-5 - Shift to electricity in hydrogen refinement",
+            "description": "Shift to electricity in hydrogen refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within hydrogen refinement, natural gas usage within hydrogen refinement. to: electricity usage within hydrogen refinement. Energy > Energy Transformation > Hydrogen Refinement",
+            "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
+            "acts_on_labels": [
+              "coal usage within hydrogen refinement",
+              "natural gas usage within hydrogen refinement"
+            ],
+            "shifts_to_labels": [
+              "electricity usage within hydrogen refinement"
+            ],
+            "score": 0.5715
+          },
+          {
+            "stable_id": "shift_to_electricity_in_chemical_industries",
+            "short_label": "T-2B9-TE-3 - Shift to electricity in chemical industries",
+            "description": "Shift to electricity in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within chemical industries, natural gas usage within chemical industries. to: electricity usage within chemical industries. Industry > Chemicals > Other",
+            "sector_path": "Industry > Chemicals > Other",
+            "acts_on_labels": [
+              "coal usage within chemical industries",
+              "natural gas usage within chemical industries"
+            ],
+            "shifts_to_labels": [
+              "electricity usage within chemical industries"
+            ],
+            "score": 0.5664
+          },
+          {
+            "stable_id": "shift_to_electricity_in_iron_and_steel_industries",
+            "short_label": "T-2C1-TE-4 - Shift to electricity in iron and steel industries",
+            "description": "Shift to electricity in iron and steel industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within iron and steel industries, natural gas usage within iron and steel industries. to: electricity usage within iron and steel industries. Industry > Metals > Iron Steel",
+            "sector_path": "Industry > Metals > Iron Steel",
+            "acts_on_labels": [
+              "coal usage within iron and steel industries",
+              "natural gas usage within iron and steel industries"
+            ],
+            "shifts_to_labels": [
+              "electricity usage within iron and steel industries"
+            ],
+            "score": 0.5617
+          },
+          {
+            "stable_id": "shift_to_electricity_in_glass_industries",
+            "short_label": "T-2A3-TE-3 - Shift to electricity in glass industries",
+            "description": "Shift to electricity in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within glass industries, oil usage within glass industries, natural gas usage within glass industries. to: electricity usage within glass industries. Industry > Minerals > Glass Production",
+            "sector_path": "Industry > Minerals > Glass Production",
+            "acts_on_labels": [
+              "coal usage within glass industries",
+              "oil usage within glass industries",
+              "natural gas usage within glass industries"
+            ],
+            "shifts_to_labels": ["electricity usage within glass industries"],
+            "score": 0.5509
+          },
+          {
+            "stable_id": "shift_to_electricity_in_other_industries",
+            "short_label": "T-2D5-TE-3 - Shift to electricity in other industries",
+            "description": "Shift to electricity in other industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: industrial unregulated coal use, industrial unregulated oil use, industrial unregulated gas use. to: industrial unregulated electricity use. Industry > Other > Other",
+            "sector_path": "Industry > Other > Other",
+            "acts_on_labels": [
+              "industrial unregulated coal use",
+              "industrial unregulated oil use",
+              "industrial unregulated gas use"
+            ],
+            "shifts_to_labels": ["industrial unregulated electricity use"],
+            "score": 0.5502
+          },
+          {
+            "stable_id": "shift_to_electricity_in_magnesium_industries",
+            "short_label": "T-2C4-TE-1 - Shift to electricity in magnesium industries",
+            "description": "Shift to electricity in magnesium industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within magnesium industries, oil usage within magnesium industries, natural gas usage within magnesium industries. to: electricity usage within magnesium industries. Industry > Metals > Magnesium",
+            "sector_path": "Industry > Metals > Magnesium",
+            "acts_on_labels": [
+              "coal usage within magnesium industries",
+              "oil usage within magnesium industries",
+              "natural gas usage within magnesium industries"
+            ],
+            "shifts_to_labels": [
+              "electricity usage within magnesium industries"
+            ],
+            "score": 0.5325
+          },
+          {
+            "stable_id": "electrification_of_production_in_cement_and_concrete_industry",
+            "short_label": "T-2A1-TE-2 - Shift to electricity in cement and mineral industry",
+            "description": "Shift to electricity in cement and mineral industry. Shift kilowatt-hours from cement and mineral processes that uses coal to cement and mineral processes that uses electricity. from: cement mineral industries coal usage. to: cement mineral industries electricity usage. Industry > Minerals > Cement",
+            "sector_path": "Industry > Minerals > Cement",
+            "acts_on_labels": ["cement mineral industries coal usage"],
+            "shifts_to_labels": ["cement mineral industries electricity usage"],
+            "score": 0.5322
+          },
+          {
+            "stable_id": "shift_to_biofuel_in_district_heating",
+            "short_label": "T-5A3-TE-7 - Shift to biofuel in district heating",
+            "description": "Shift to biofuel in district heating. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: chp coal, chp natural gas, chp oil. to: chp biofuels. Energy > Energy Supply > Combined Heat Power",
+            "sector_path": "Energy > Energy Supply > Combined Heat Power",
+            "acts_on_labels": ["chp coal", "chp natural gas", "chp oil"],
+            "shifts_to_labels": ["chp biofuels"],
+            "score": 0.5306
+          },
+          {
+            "stable_id": "shift_to_electricity_in_pulp_paper_and_print_industries",
+            "short_label": "T-2D1b-TE-3 - Shift to electricity in pulp, paper and print industries",
+            "description": "Shift to electricity in pulp, paper and print industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within pulp paper and print industries, oil usage within pulp paper and print industries, natural gas usage within pulp paper and print industries. to: electricity usage within pulp paper and print industries. Industry > Other > Manufacturing > Pulp Paper Print",
+            "sector_path": "Industry > Other > Manufacturing > Pulp Paper Print",
+            "acts_on_labels": [
+              "coal usage within pulp paper and print industries",
+              "oil usage within pulp paper and print industries",
+              "natural gas usage within pulp paper and print industries"
+            ],
+            "shifts_to_labels": [
+              "electricity usage within pulp paper and print industries"
+            ],
+            "score": 0.5284
+          },
+          {
+            "stable_id": "shift_to_electricity_in_lead_industries",
+            "short_label": "T-2C5-TE-3 - Shift to electricity in lead industries",
+            "description": "Shift to electricity in lead industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within lead industries, oil usage within lead industries, natural gas usage within lead industries. to: electricity usage within lead industries. Industry > Metals > Lead",
+            "sector_path": "Industry > Metals > Lead",
+            "acts_on_labels": [
+              "coal usage within lead industries",
+              "oil usage within lead industries",
+              "natural gas usage within lead industries"
+            ],
+            "shifts_to_labels": ["electricity usage within lead industries"],
+            "score": 0.5267
+          },
+          {
+            "stable_id": "coal_fired_power_plants",
+            "short_label": "T-5A1-TE-1 - Electricity from coal power plants",
+            "description": "Electricity from coal power plants. Alter the amount of electricity produced by coal fired power plants. from: coal fired power plants. Energy > Energy Supply > Electricity",
+            "sector_path": "Energy > Energy Supply > Electricity",
+            "acts_on_labels": ["coal fired power plants"],
+            "shifts_to_labels": [],
+            "score": 0.5046
+          },
+          {
+            "stable_id": "oil_fired_power_plants",
+            "short_label": "T-5A1-TE-5 - Electricity from oil power plants",
+            "description": "Electricity from oil power plants. Alter the amount of electricity produced by oil fired power plants. from: oil fired power plants. Energy > Energy Supply > Electricity",
+            "sector_path": "Energy > Energy Supply > Electricity",
+            "acts_on_labels": ["oil fired power plants"],
+            "shifts_to_labels": [],
+            "score": 0.4965
+          },
+          {
+            "stable_id": "shift_to_electrolysis_of_water_for_hydrogen_production",
+            "short_label": "T-5B4-TE-6 - Shift to electrolysis of water for hydrogen production",
+            "description": "Shift to electrolysis of water for hydrogen production. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: reforming of methane for hydrogen production, gasification of carbon for hydrogen production. to: electrolysis of water for hydrogen production. Energy > Energy Transformation > Hydrogen Refinement",
+            "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
+            "acts_on_labels": [
+              "reforming of methane for hydrogen production",
+              "gasification of carbon for hydrogen production"
+            ],
+            "shifts_to_labels": [
+              "electrolysis of water for hydrogen production"
+            ],
+            "score": 0.4935
+          },
+          {
+            "stable_id": "improved_grid_electricity",
+            "short_label": "T-5A1-TE-3 - Improved Grid Electricity",
+            "description": "Improved Grid Electricity. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: grid current. to: grid future. Energy > Energy Supply > Electricity",
+            "sector_path": "Energy > Energy Supply > Electricity",
+            "acts_on_labels": ["grid current"],
+            "shifts_to_labels": ["grid future"],
+            "score": 0.4909
+          },
+          {
+            "stable_id": "biofuel_fired_power_plants",
+            "short_label": "T-5A1-TE-11 - Electricity from biomass power plants",
+            "description": "Electricity from biomass power plants. Alter the amount of electricity produced by biofuel fired power plants. from: biofuel fired powerplants. Energy > Energy Supply > Electricity",
+            "sector_path": "Energy > Energy Supply > Electricity",
+            "acts_on_labels": ["biofuel fired powerplants"],
+            "shifts_to_labels": [],
+            "score": 0.4846
+          },
+          {
+            "stable_id": "wind_offshore",
+            "short_label": "T-5A1-TE-9 - Electricity from wind offshore",
+            "description": "Electricity from wind offshore. Alter the amount of electricity produced by wind offshore. from: wind offshore. Energy > Energy Supply > Electricity",
+            "sector_path": "Energy > Energy Supply > Electricity",
+            "acts_on_labels": ["wind offshore"],
+            "shifts_to_labels": [],
+            "score": 0.4835
+          },
+          {
+            "stable_id": "gas_fired_power_plants",
+            "short_label": "T-5A1-TE-2 - Electricity from gas power plants",
+            "description": "Electricity from gas power plants. Alter the amount of electricity produced by gas fired power plants. from: gas fired power plants. Energy > Energy Supply > Electricity",
+            "sector_path": "Energy > Energy Supply > Electricity",
+            "acts_on_labels": ["gas fired power plants"],
+            "shifts_to_labels": [],
+            "score": 0.4826
+          }
+        ]
+      },
+      {
+        "activity": "transporting",
+        "shift_from": "using fossil fuels for transport",
+        "shift_to": "using fossil-free sources for transport",
+        "need": "mobility",
+        "type": "Resource Shift",
+        "type_reasoning": "The measure specifies a shift from fossil fuels to fossil-free sources for transport, which is a change in the resource used.",
+        "score": 6,
+        "reasoning": "Activity, shift_from, shift_to, and need are all identifiable.",
+        "transition_element_matches": [
+          {
+            "stable_id": "shift_to_hydrogen_vehicles",
+            "short_label": "T-1A1a-TE-2 - Shift to hydrogen cars",
+            "description": "Shift to hydrogen cars. Shift vehicle kilometer from petrol and diesel vehicles to hydrogen vehicles in vehicle kilometer to fulfill the need of mobility. from: petrol vehicles, diesel vehicles. to: hydrogen vehicles. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": ["petrol vehicles", "diesel vehicles"],
+            "shifts_to_labels": ["hydrogen vehicles"],
+            "score": 0.6172,
+            "match_reasoning": "acts_on=yes, shifts_to=yes, confidence=high",
+            "match_confidence": "high"
+          },
+          {
+            "stable_id": "shift_to_gas_vehicles",
+            "short_label": "T-1A1a-TE-19 - Shift to gas cars",
+            "description": "Shift to gas cars. Shift vehicle kilometer from petrol and diesel vehicles to gas vehicles in vehicle kilometer to fulfill the need of mobility. from: petrol vehicles, diesel vehicles. to: gas vehicles. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": ["petrol vehicles", "diesel vehicles"],
+            "shifts_to_labels": ["gas vehicles"],
+            "score": 0.6094,
+            "match_reasoning": "acts_on=yes, shifts_to=yes, confidence=high",
+            "match_confidence": "high"
+          },
+          {
+            "stable_id": "shift_to_electric_vehicles",
+            "short_label": "T-1A1a-TE-1 - Shift to electric cars",
+            "description": "Shift to electric cars. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to battery electric vehicles in vehicle kilometer to fulfill the need of mobility. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: battery electric vehicles. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": [
+              "petrol vehicles",
+              "diesel vehicles",
+              "lpg vehicles",
+              "gas vehicles"
+            ],
+            "shifts_to_labels": ["battery electric vehicles"],
+            "score": 0.6089,
+            "match_reasoning": "acts_on=yes, shifts_to=yes, confidence=high",
+            "match_confidence": "high"
+          },
+          {
+            "stable_id": "increased_proportion_of_public_transport_by_hydrogen_bus",
+            "short_label": "T-1A1a-TE-13 - Shift to travel by hydrogen bus",
+            "description": "Shift to travel by hydrogen bus. Shift vehicle kilometer from petrol and diesel vehicles to hydrogen buses. from: petrol vehicles, diesel vehicles. to: hydrogen buses. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": ["petrol vehicles", "diesel vehicles"],
+            "shifts_to_labels": ["hydrogen buses"],
+            "score": 0.5327,
+            "match_reasoning": "acts_on=yes, shifts_to=yes, confidence=mid",
+            "match_confidence": "mid"
+          },
+          {
+            "stable_id": "increased_proportion_of_walking_and_cycling",
+            "short_label": "T-1A1a-TE-10 - Shift to walking and cycling",
+            "description": "Shift to walking and cycling. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to walking cycling. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: walking cycling. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": [
+              "petrol vehicles",
+              "diesel vehicles",
+              "lpg vehicles",
+              "gas vehicles"
+            ],
+            "shifts_to_labels": ["walking cycling"],
+            "score": 0.5927,
+            "match_reasoning": "acts_on=yes, shifts_to=yes, confidence=mid",
+            "match_confidence": "mid"
+          },
+          {
+            "stable_id": "transfer_from_car_to_railway",
+            "short_label": "T-1A1a-TE-6 - Shift from car to railway",
+            "description": "Shift from car to railway. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to electric rail in person kilometer to fulfill the need of mobility. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: electric rail. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": [
+              "petrol vehicles",
+              "diesel vehicles",
+              "lpg vehicles",
+              "gas vehicles"
+            ],
+            "shifts_to_labels": ["electric rail"],
+            "score": 0.5435,
+            "match_reasoning": "acts_on=yes, shifts_to=yes, confidence=mid",
+            "match_confidence": "mid"
+          }
+        ],
+        "transition_element_candidates": [
+          {
+            "stable_id": "electrification_of_domestic_sea_passenger_transport",
+            "short_label": "T-1A4-TE-5 - Shift to electric marine passenger transportion",
+            "description": "Shift to electric marine passenger transportion. Shift person kilometer from ship passenger to electric shipping passenger in person kilometer to fulfill the need of mobility. from: ship passenger, gas oil shipping passenger. to: electric shipping passenger. Transport > Mobility > Waterborne",
+            "sector_path": "Transport > Mobility > Waterborne",
+            "acts_on_labels": ["ship passenger", "gas oil shipping passenger"],
+            "shifts_to_labels": ["electric shipping passenger"],
+            "score": 0.6205
+          },
+          {
+            "stable_id": "shift_to_hydrogen_vehicles",
+            "short_label": "T-1A1a-TE-2 - Shift to hydrogen cars",
+            "description": "Shift to hydrogen cars. Shift vehicle kilometer from petrol and diesel vehicles to hydrogen vehicles in vehicle kilometer to fulfill the need of mobility. from: petrol vehicles, diesel vehicles. to: hydrogen vehicles. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": ["petrol vehicles", "diesel vehicles"],
+            "shifts_to_labels": ["hydrogen vehicles"],
+            "score": 0.6172
+          },
+          {
+            "stable_id": "shift_to_gas_vehicles",
+            "short_label": "T-1A1a-TE-19 - Shift to gas cars",
+            "description": "Shift to gas cars. Shift vehicle kilometer from petrol and diesel vehicles to gas vehicles in vehicle kilometer to fulfill the need of mobility. from: petrol vehicles, diesel vehicles. to: gas vehicles. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": ["petrol vehicles", "diesel vehicles"],
+            "shifts_to_labels": ["gas vehicles"],
+            "score": 0.6094
+          },
+          {
+            "stable_id": "shift_to_electric_vehicles",
+            "short_label": "T-1A1a-TE-1 - Shift to electric cars",
+            "description": "Shift to electric cars. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to battery electric vehicles in vehicle kilometer to fulfill the need of mobility. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: battery electric vehicles. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": [
+              "petrol vehicles",
+              "diesel vehicles",
+              "lpg vehicles",
+              "gas vehicles"
+            ],
+            "shifts_to_labels": ["battery electric vehicles"],
+            "score": 0.6089
+          },
+          {
+            "stable_id": "shift_to_electric_passenger_rail",
+            "short_label": "T-1A2-TE-2 - Shift to travel by electric rail",
+            "description": "Shift to travel by electric rail. Shift person kilometer from diesel passenger rail to electric passenger rail in person kilometer to fulfill the need of mobility. from: diesel passenger rail. to: electric rail. Transport > Mobility > Rail",
+            "sector_path": "Transport > Mobility > Rail",
+            "acts_on_labels": ["diesel passenger rail"],
+            "shifts_to_labels": ["electric rail"],
+            "score": 0.606
+          },
+          {
+            "stable_id": "shift_to_hydrogen_passenger_rail",
+            "short_label": "T-1A2-TE-3 - Shift to travel by hydrogen rail",
+            "description": "Shift to travel by hydrogen rail. Shift person kilometer from diesel passenger rail to hydrogen passenger rail in person kilometer to fulfill the need of mobility. from: diesel passenger rail. to: hydrogen passenger rail. Transport > Mobility > Rail",
+            "sector_path": "Transport > Mobility > Rail",
+            "acts_on_labels": ["diesel passenger rail"],
+            "shifts_to_labels": ["hydrogen passenger rail"],
+            "score": 0.5996
+          },
+          {
+            "stable_id": "electric_passenger_airplanes",
+            "short_label": "T-1A3-TE-3 - Shift to electric air passenger transport",
+            "description": "Shift to electric air passenger transport. Shift person kilometer from passenger transportation by air to electric passenger transportation by air in person kilometer to fulfill the need of mobility. from: passenger transportation by air. to: electric passenger transportation by air. Transport > Mobility > Aviation",
+            "sector_path": "Transport > Mobility > Aviation",
+            "acts_on_labels": ["passenger transportation by air"],
+            "shifts_to_labels": ["electric passenger transportation by air"],
+            "score": 0.598
+          },
+          {
+            "stable_id": "increased_proportion_of_public_transport_by_petrol_bus",
+            "short_label": "T-1A1a-TE-16 - Shift to travel by petrol bus",
+            "description": "Shift to travel by petrol bus. Shift vehicle kilometer from petrol and diesel vehicles to petrol buses. from: petrol vehicles, diesel vehicles. to: petrol buses. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": ["petrol vehicles", "diesel vehicles"],
+            "shifts_to_labels": ["petrol buses"],
+            "score": 0.5953
+          },
+          {
+            "stable_id": "shift_from_passenger_air_transport_to_railway",
+            "short_label": "T-1A3-TE-4 - Shift from air travel to railway",
+            "description": "Shift from air travel to railway. Shift person kilometer from passenger transportation by air to electric rail in person kilometer to fulfill the need of mobility. from: passenger transportation by air. to: electric rail. Transport > Mobility > Aviation",
+            "sector_path": "Transport > Mobility > Aviation",
+            "acts_on_labels": ["passenger transportation by air"],
+            "shifts_to_labels": ["electric rail"],
+            "score": 0.5936
+          },
+          {
+            "stable_id": "increased_proportion_of_walking_and_cycling",
+            "short_label": "T-1A1a-TE-10 - Shift to walking and cycling",
+            "description": "Shift to walking and cycling. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to walking cycling. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: walking cycling. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": [
+              "petrol vehicles",
+              "diesel vehicles",
+              "lpg vehicles",
+              "gas vehicles"
+            ],
+            "shifts_to_labels": ["walking cycling"],
+            "score": 0.5927
+          },
+          {
+            "stable_id": "shift_to_lng_fuel_for_sea_passenger_transportation",
+            "short_label": "T-1A4-TE-1 - Shift to LNG fuel for marine passenger transport",
+            "description": "Shift to LNG fuel for marine passenger transport. Shift person kilometer from ship passenger to LNG shipping passenger in person kilometer to fulfill the need of mobility. from: ship passenger, gas oil shipping passenger. to: lng shipping passenger. Transport > Mobility > Waterborne",
+            "sector_path": "Transport > Mobility > Waterborne",
+            "acts_on_labels": ["ship passenger", "gas oil shipping passenger"],
+            "shifts_to_labels": ["lng shipping passenger"],
+            "score": 0.5515
+          },
+          {
+            "stable_id": "transfer_from_car_to_railway",
+            "short_label": "T-1A1a-TE-6 - Shift from car to railway",
+            "description": "Shift from car to railway. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to electric rail in person kilometer to fulfill the need of mobility. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: electric rail. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": [
+              "petrol vehicles",
+              "diesel vehicles",
+              "lpg vehicles",
+              "gas vehicles"
+            ],
+            "shifts_to_labels": ["electric rail"],
+            "score": 0.5435
+          },
+          {
+            "stable_id": "biofuel_for_diesel_rail_passenger",
+            "short_label": "T-1A2-TE-1 - Biofuel for rail passenger transport",
+            "description": "Biofuel for rail passenger transport. Increase the proportion of HVO biodiesel in diesel. from: diesel passenger rail. Transport > Mobility > Rail",
+            "sector_path": "Transport > Mobility > Rail",
+            "acts_on_labels": ["diesel passenger rail"],
+            "shifts_to_labels": [],
+            "score": 0.5364
+          },
+          {
+            "stable_id": "biofuels_for_sea_passenger_transport",
+            "short_label": "T-1A4-TE-4 - Biofuel for marine passenger transport",
+            "description": "Biofuel for marine passenger transport. Increase the proportion of marine biodiesel in marine diesel. from: ship passenger. Transport > Mobility > Waterborne",
+            "sector_path": "Transport > Mobility > Waterborne",
+            "acts_on_labels": ["ship passenger"],
+            "shifts_to_labels": [],
+            "score": 0.5362
+          },
+          {
+            "stable_id": "biofuels_for_air_transport",
+            "short_label": "T-1A3-TE-1 - Biofuel for air passenger transport",
+            "description": "Biofuel for air passenger transport. Increase the proportion of aviation biofuel in aviation turbine fuel. from: passenger transportation by air. Transport > Mobility > Aviation",
+            "sector_path": "Transport > Mobility > Aviation",
+            "acts_on_labels": ["passenger transportation by air"],
+            "shifts_to_labels": [],
+            "score": 0.5357
+          },
+          {
+            "stable_id": "increased_proportion_of_public_transport_by_hydrogen_bus",
+            "short_label": "T-1A1a-TE-13 - Shift to travel by hydrogen bus",
+            "description": "Shift to travel by hydrogen bus. Shift vehicle kilometer from petrol and diesel vehicles to hydrogen buses. from: petrol vehicles, diesel vehicles. to: hydrogen buses. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": ["petrol vehicles", "diesel vehicles"],
+            "shifts_to_labels": ["hydrogen buses"],
+            "score": 0.5327
+          }
+        ]
+      },
+      {
+        "activity": "heating",
+        "shift_from": "using fossil fuels for heating",
+        "shift_to": "using fossil-free sources for heating",
+        "need": "space heating",
+        "type": "Resource Shift",
+        "type_reasoning": "The measure specifies a shift from fossil fuels to fossil-free sources for heating, which is a change in the resource used.",
+        "score": 6,
+        "reasoning": "Activity, shift_from, shift_to, and need are all identifiable.",
+        "transition_element_matches": [],
+        "transition_element_candidates": [
+          {
+            "stable_id": "heating_non_residential_public_buildings_with_renewable_solid_biofuels",
+            "short_label": "T-4B1b-TE-4 - Shift to biofuel in public buildings",
+            "description": "Shift to biofuel in public buildings. Shift square meter from public buildings heated with oil, gas, direct. from: public building heating with oil, public building heating with gas, public building heating with propane, public building heating with direct electric heaters, public building heating with coal, public building heating with lpg, public building heating with gas oil. to: public building heating with solid biofuels. Buildings > Non Residential > Hvac > Institutional Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
+            "acts_on_labels": [
+              "public building heating with oil",
+              "public building heating with gas",
+              "public building heating with propane",
+              "public building heating with direct electric heaters",
+              "public building heating with coal",
+              "public building heating with lpg",
+              "public building heating with gas oil"
+            ],
+            "shifts_to_labels": ["public building heating with solid biofuels"],
+            "score": 0.6341
+          },
+          {
+            "stable_id": "shift_to_district_heating_in_public_buildings",
+            "short_label": "T-4B1b-TE-1 - Shift to district heating in public buildings",
+            "description": "Shift to district heating in public buildings. Shift square meter from public building heated with oil, gas, direct. from: public building heating with oil, public building heating with gas, public building heating with propane, public building heating with direct electric heaters, public building heating with coal, public building heating with lpg, public building heating with gas oil. to: public building heating with district heating. Buildings > Non Residential > Hvac > Institutional Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
+            "acts_on_labels": [
+              "public building heating with oil",
+              "public building heating with gas",
+              "public building heating with propane",
+              "public building heating with direct electric heaters",
+              "public building heating with coal",
+              "public building heating with lpg",
+              "public building heating with gas oil"
+            ],
+            "shifts_to_labels": [
+              "public building heating with district heating"
+            ],
+            "score": 0.6252
+          },
+          {
+            "stable_id": "shift_to_biofuel_in_district_heating",
+            "short_label": "T-5A3-TE-7 - Shift to biofuel in district heating",
+            "description": "Shift to biofuel in district heating. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: chp coal, chp natural gas, chp oil. to: chp biofuels. Energy > Energy Supply > Combined Heat Power",
+            "sector_path": "Energy > Energy Supply > Combined Heat Power",
+            "acts_on_labels": ["chp coal", "chp natural gas", "chp oil"],
+            "shifts_to_labels": ["chp biofuels"],
+            "score": 0.6197
+          },
+          {
+            "stable_id": "shift_to_heat_pumps_in_district_heating",
+            "short_label": "T-5A2-TE-5 - Shift to heat pumps in district heating",
+            "description": "Shift to heat pumps in district heating. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: chp coal, chp natural gas, chp oil. to: district heating heat pumps. Energy > Energy Supply > Heat",
+            "sector_path": "Energy > Energy Supply > Heat",
+            "acts_on_labels": ["chp coal", "chp natural gas", "chp oil"],
+            "shifts_to_labels": ["district heating heat pumps"],
+            "score": 0.6146
+          },
+          {
+            "stable_id": "heat_pumps_in_non_residential_public_buildings",
+            "short_label": "T-4B1b-TE-3 - Shift to heat pumps in public buildings",
+            "description": "Shift to heat pumps in public buildings. Shift square meter from public buildings heated with oil, gas, direct. from: public building heating with oil, public building heating with gas, public building heating with propane, public building heating with direct electric heaters, public building heating with coal, public building heating with lpg, public building heating with gas oil. to: public building heating with heatpump. Buildings > Non Residential > Hvac > Institutional Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
+            "acts_on_labels": [
+              "public building heating with oil",
+              "public building heating with gas",
+              "public building heating with propane",
+              "public building heating with direct electric heaters",
+              "public building heating with coal",
+              "public building heating with lpg",
+              "public building heating with gas oil"
+            ],
+            "shifts_to_labels": ["public building heating with heatpump"],
+            "score": 0.6145
+          },
+          {
+            "stable_id": "shift_to_solar_thermal_in_public_buildings",
+            "short_label": "T-4B1b-TE-5 - Shift to solar thermal in public buildings",
+            "description": "Shift to solar thermal in public buildings. Shift square meter from public building heated with oil, gas, direct. from: public building heating with oil, public building heating with gas, public building heating with propane, public building heating with direct electric heaters, public building heating with coal, public building heating with lpg, public building heating with gas oil. to: public building heating with solar thermal. Buildings > Non Residential > Hvac > Institutional Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
+            "acts_on_labels": [
+              "public building heating with oil",
+              "public building heating with gas",
+              "public building heating with propane",
+              "public building heating with direct electric heaters",
+              "public building heating with coal",
+              "public building heating with lpg",
+              "public building heating with gas oil"
+            ],
+            "shifts_to_labels": ["public building heating with solar thermal"],
+            "score": 0.6049
+          },
+          {
+            "stable_id": "heating_non_residential_industrial_buildings_with_renewable_solid_biofuels",
+            "short_label": "T-4B1c-TE-4 - Shift to biofuel in industrial buildings",
+            "description": "Shift to biofuel in industrial buildings. Shift square meter from industrial buildings heated with gas, oil and. from: industrial building heating with gas, industrial building heating with oil, industrial building heating with direct electric heaters, industrial building heating with lpg, industrial building heating with coal, industrial building heating with gas oil. to: industrial building heating with solid biofuels. Buildings > Non Residential > Hvac > Other Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Other Hvac",
+            "acts_on_labels": [
+              "industrial building heating with gas",
+              "industrial building heating with oil",
+              "industrial building heating with direct electric heaters",
+              "industrial building heating with lpg",
+              "industrial building heating with coal",
+              "industrial building heating with gas oil"
+            ],
+            "shifts_to_labels": [
+              "industrial building heating with solid biofuels"
+            ],
+            "score": 0.6041
+          },
+          {
+            "stable_id": "shift_to_district_heating_in_single_family_houses",
+            "short_label": "T-4A1b-TE-2 - Shift to district heating in single-family buildings",
+            "description": "Shift to district heating in single-family buildings. Shift square meter from single family building heated with gas, oil,. from: single family building heating with gas, single family building heating with propane, single family building heating with oil, single family building heating with direct electric heaters, single family building heating with coal, single family building heating with lpg. to: single family building heating with district heating. Buildings > Residential > Hvac > Single Family Hvac",
+            "sector_path": "Buildings > Residential > Hvac > Single Family Hvac",
+            "acts_on_labels": [
+              "single family building heating with gas",
+              "single family building heating with propane",
+              "single family building heating with oil",
+              "single family building heating with direct electric heaters",
+              "single family building heating with coal",
+              "single family building heating with lpg"
+            ],
+            "shifts_to_labels": [
+              "single family building heating with district heating"
+            ],
+            "score": 0.601
+          },
+          {
+            "stable_id": "shift_to_district_heating_in_industrial_buildings",
+            "short_label": "T-4B1c-TE-1 - Shift to district heating in industrial buildings",
+            "description": "Shift to district heating in industrial buildings. Shift square meter from industrial building heated with gas, oil and. from: industrial building heating with gas, industrial building heating with oil, industrial building heating with direct electric heaters, industrial building heating with lpg, industrial building heating with coal, industrial building heating with gas oil. to: industrial building heating with district heating. Buildings > Non Residential > Hvac > Other Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Other Hvac",
+            "acts_on_labels": [
+              "industrial building heating with gas",
+              "industrial building heating with oil",
+              "industrial building heating with direct electric heaters",
+              "industrial building heating with lpg",
+              "industrial building heating with coal",
+              "industrial building heating with gas oil"
+            ],
+            "shifts_to_labels": [
+              "industrial building heating with district heating"
+            ],
+            "score": 0.5997
+          },
+          {
+            "stable_id": "heating_non_residential_commercial_buildings_with_renewable_solid_biofuels",
+            "short_label": "T-4B1a-TE-4 - Shift to biofuel in commercial buildings",
+            "description": "Shift to biofuel in commercial buildings. Shift square meter from commercial buildings heated with gas, oil, direct. from: commercial building heating with gas, commercial building heating with propane, commercial building heating with oil, commercial building heating with direct electric heaters, commercial building heating with coal, commercial building heating with lpg, commercial building heating with gas oil. to: commercial building heating with solid biofuels. Buildings > Non Residential > Hvac > Commercial Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Commercial Hvac",
+            "acts_on_labels": [
+              "commercial building heating with gas",
+              "commercial building heating with propane",
+              "commercial building heating with oil",
+              "commercial building heating with direct electric heaters",
+              "commercial building heating with coal",
+              "commercial building heating with lpg",
+              "commercial building heating with gas oil"
+            ],
+            "shifts_to_labels": [
+              "commercial building heating with solid biofuels"
+            ],
+            "score": 0.5936
+          },
+          {
+            "stable_id": "heating_single_family_residential_buildings_with_renewable_solid_biofuels",
+            "short_label": "T-4A1b-TE-5 - Shift to biofuel heating in single-family buildings",
+            "description": "Shift to biofuel heating in single-family buildings. Shift square meter from single-family buildings heated with gas, oil,. from: single family building heating with gas, single family building heating with propane, single family building heating with oil, single family building heating with direct electric heaters, single family building heating with coal, single family building heating with lpg. to: single family building heating with solid biofuels. Buildings > Residential > Hvac > Single Family Hvac",
+            "sector_path": "Buildings > Residential > Hvac > Single Family Hvac",
+            "acts_on_labels": [
+              "single family building heating with gas",
+              "single family building heating with propane",
+              "single family building heating with oil",
+              "single family building heating with direct electric heaters",
+              "single family building heating with coal",
+              "single family building heating with lpg"
+            ],
+            "shifts_to_labels": [
+              "single family building heating with solid biofuels"
+            ],
+            "score": 0.5715
+          },
+          {
+            "stable_id": "shift_to_district_heating_in_commercial_buildings",
+            "short_label": "T-4B1a-TE-1 - Shift to district heating in commercial buildings",
+            "description": "Shift to district heating in commercial buildings. Shift square meter from commercial building heated with gas, oil, direct. from: commercial building heating with gas, commercial building heating with propane, commercial building heating with oil, commercial building heating with direct electric heaters, commercial building heating with coal, commercial building heating with lpg, commercial building heating with gas oil. to: commercial building heating with district heating. Buildings > Non Residential > Hvac > Commercial Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Commercial Hvac",
+            "acts_on_labels": [
+              "commercial building heating with gas",
+              "commercial building heating with propane",
+              "commercial building heating with oil",
+              "commercial building heating with direct electric heaters",
+              "commercial building heating with coal",
+              "commercial building heating with lpg",
+              "commercial building heating with gas oil"
+            ],
+            "shifts_to_labels": [
+              "commercial building heating with district heating"
+            ],
+            "score": 0.5561
+          },
+          {
+            "stable_id": "heat_pumps_in_single_family_residential_buildings",
+            "short_label": "T-4A1b-TE-1 - Shift to heat pumps in single-family buildings",
+            "description": "Shift to heat pumps in single-family buildings. Shift square meter from single-family buildings heated with gas, oil,. from: single family building heating with gas, single family building heating with propane, single family building heating with oil, single family building heating with direct electric heaters, single family building heating with coal, single family building heating with lpg. to: single family building heating with heatpump. Buildings > Residential > Hvac > Single Family Hvac",
+            "sector_path": "Buildings > Residential > Hvac > Single Family Hvac",
+            "acts_on_labels": [
+              "single family building heating with gas",
+              "single family building heating with propane",
+              "single family building heating with oil",
+              "single family building heating with direct electric heaters",
+              "single family building heating with coal",
+              "single family building heating with lpg"
+            ],
+            "shifts_to_labels": [
+              "single family building heating with heatpump"
+            ],
+            "score": 0.5552
+          },
+          {
+            "stable_id": "shift_to_solar_thermal_in_single_family_buildings",
+            "short_label": "T-4A1b-TE-4 - Shift to solar thermal in single-family buildings",
+            "description": "Shift to solar thermal in single-family buildings. Shift square meter from single family building heated with gas, oil,. from: single family building heating with gas, single family building heating with propane, single family building heating with oil, single family building heating with direct electric heaters, single family building heating with coal, single family building heating with lpg. to: single family building heating with solar thermal. Buildings > Residential > Hvac > Single Family Hvac",
+            "sector_path": "Buildings > Residential > Hvac > Single Family Hvac",
+            "acts_on_labels": [
+              "single family building heating with gas",
+              "single family building heating with propane",
+              "single family building heating with oil",
+              "single family building heating with direct electric heaters",
+              "single family building heating with coal",
+              "single family building heating with lpg"
+            ],
+            "shifts_to_labels": [
+              "single family building heating with solar thermal"
+            ],
+            "score": 0.5509
+          },
+          {
+            "stable_id": "energy_efficient_non_residential_public_buildings_retrofitting",
+            "short_label": "T-4B1b-TE-6 - Retrofitting public buildings for efficient heating",
+            "description": "Retrofitting public buildings for efficient heating. Reduce the amount of energy required to heat public building heating. from: public building heating with solid biofuels, public building heating with direct electric heaters, public building heating with gas, public building heating with propane, public building heating with oil, public building heating with heatpump, public building heating with district heating, public building heating with coal, public building heating with solar thermal, public building heating with lpg, public building heating with hydrogen, public building heating with gas oil. Buildings > Non Residential > Hvac > Institutional Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
+            "acts_on_labels": [
+              "public building heating with solid biofuels",
+              "public building heating with direct electric heaters",
+              "public building heating with gas",
+              "public building heating with propane",
+              "public building heating with oil",
+              "public building heating with heatpump",
+              "public building heating with district heating",
+              "public building heating with coal",
+              "public building heating with solar thermal",
+              "public building heating with lpg",
+              "public building heating with hydrogen",
+              "public building heating with gas oil"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.5474
+          }
+        ]
+      }
+    ],
+    "intervention_who": "kommunkoncernen",
+    "intervention_when": "by 2030",
+    "intervention_what": "become fossil fuel-free",
+    "intervention_how": "none",
+    "intervention_score": 4,
+    "intervention_reasoning": "Who, when, and what are present, but how is not specified.",
+    "intervention_type": "direct"
+  },
+  {
+    "measure_text": "124.Utsläppen av växthusgaser i kommunen som geografiskt område ska halveras till år 2030 (basår 2005).",
+    "activity": "none",
+    "activity_shift_score": 1,
+    "activity_shifts": [],
+    "intervention_who": "none",
+    "intervention_when": "by 2030",
+    "intervention_what": "reduce greenhouse gas emissions",
+    "intervention_how": "none",
+    "intervention_score": 2,
+    "intervention_reasoning": "When and what are weakly present, but no specific action or mechanism is provided.",
+    "intervention_type": "none"
+  },
+  {
+    "measure_text": "125.Kommunen ska prioritera platser där åtgärd krävs för att minimera risken för skador på infrastruktur och bebyggelse utifrån Myndigheten för samhällsskydd och beredskaps framtagna kartläggningar.",
+    "activity": "none",
+    "activity_shift_score": 1,
+    "activity_shifts": [],
+    "intervention_who": "kommunen",
+    "intervention_when": "none",
+    "intervention_what": "prioritize locations for action",
+    "intervention_how": "based on MSB's mappings",
+    "intervention_score": 4,
+    "intervention_reasoning": "Who, what, and how are present, but when is not specified.",
+    "intervention_type": "indirect"
+  },
+  {
+    "measure_text": "126.Naturbaserade lösningar ska nyttjas vid samhällsplanering för att ta hand om stora vattenmassor.",
+    "activity": "water management",
+    "activity_shift_score": 3,
+    "activity_shifts": [
+      {
+        "activity": "managing water",
+        "shift_from": "none",
+        "shift_to": "using nature-based solutions for water management",
+        "need": "water management",
+        "type": "Type Shift",
+        "type_reasoning": "The measure suggests a shift to using nature-based solutions, which implies a change in the system or method used for water management.",
+        "score": 3,
+        "reasoning": "Activity and shift_to are identifiable, but shift_from is not clearly specified.",
+        "transition_element_matches": [],
+        "transition_element_suggested_new": {
+          "short_label": "Shift to Nature-Based Water Management",
+          "description": "Implementing nature-based solutions for managing large volumes of water in urban planning."
         },
-        {
-          "activity": "heating",
-          "shift_from": "using fossil fuels for heating",
-          "shift_to": "using fossil-free sources for heating",
-          "need": "space heating",
-          "type": "Resource Shift",
-          "type_reasoning": "The measure specifies a shift from fossil fuels to fossil-free sources for heating, which is a change in the resource used.",
-          "score": 6,
-          "reasoning": "Activity, shift_from, shift_to, and need are all identifiable.",
-          "transition_element_matches": [],
-          "transition_element_candidates": [
-            {
-              "stable_id": "heating_non_residential_public_buildings_with_renewable_solid_biofuels",
-              "short_label": "T-4B1b-TE-4 - Shift to biofuel in public buildings",
-              "description": "Shift to biofuel in public buildings. Shift square meter from public buildings heated with oil, gas, direct. from: public building heating with oil, public building heating with gas, public building heating with propane, public building heating with direct electric heaters, public building heating with coal, public building heating with lpg, public building heating with gas oil. to: public building heating with solid biofuels. Buildings > Non Residential > Hvac > Institutional Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
-              "acts_on_labels": [
-                "public building heating with oil",
-                "public building heating with gas",
-                "public building heating with propane",
-                "public building heating with direct electric heaters",
-                "public building heating with coal",
-                "public building heating with lpg",
-                "public building heating with gas oil"
-              ],
-              "shifts_to_labels": [
-                "public building heating with solid biofuels"
-              ],
-              "score": 0.6341
-            },
-            {
-              "stable_id": "shift_to_district_heating_in_public_buildings",
-              "short_label": "T-4B1b-TE-1 - Shift to district heating in public buildings",
-              "description": "Shift to district heating in public buildings. Shift square meter from public building heated with oil, gas, direct. from: public building heating with oil, public building heating with gas, public building heating with propane, public building heating with direct electric heaters, public building heating with coal, public building heating with lpg, public building heating with gas oil. to: public building heating with district heating. Buildings > Non Residential > Hvac > Institutional Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
-              "acts_on_labels": [
-                "public building heating with oil",
-                "public building heating with gas",
-                "public building heating with propane",
-                "public building heating with direct electric heaters",
-                "public building heating with coal",
-                "public building heating with lpg",
-                "public building heating with gas oil"
-              ],
-              "shifts_to_labels": [
-                "public building heating with district heating"
-              ],
-              "score": 0.6252
-            },
-            {
-              "stable_id": "shift_to_biofuel_in_district_heating",
-              "short_label": "T-5A3-TE-7 - Shift to biofuel in district heating",
-              "description": "Shift to biofuel in district heating. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: chp coal, chp natural gas, chp oil. to: chp biofuels. Energy > Energy Supply > Combined Heat Power",
-              "sector_path": "Energy > Energy Supply > Combined Heat Power",
-              "acts_on_labels": [
-                "chp coal",
-                "chp natural gas",
-                "chp oil"
-              ],
-              "shifts_to_labels": [
-                "chp biofuels"
-              ],
-              "score": 0.6197
-            },
-            {
-              "stable_id": "shift_to_heat_pumps_in_district_heating",
-              "short_label": "T-5A2-TE-5 - Shift to heat pumps in district heating",
-              "description": "Shift to heat pumps in district heating. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: chp coal, chp natural gas, chp oil. to: district heating heat pumps. Energy > Energy Supply > Heat",
-              "sector_path": "Energy > Energy Supply > Heat",
-              "acts_on_labels": [
-                "chp coal",
-                "chp natural gas",
-                "chp oil"
-              ],
-              "shifts_to_labels": [
-                "district heating heat pumps"
-              ],
-              "score": 0.6146
-            },
-            {
-              "stable_id": "heat_pumps_in_non_residential_public_buildings",
-              "short_label": "T-4B1b-TE-3 - Shift to heat pumps in public buildings",
-              "description": "Shift to heat pumps in public buildings. Shift square meter from public buildings heated with oil, gas, direct. from: public building heating with oil, public building heating with gas, public building heating with propane, public building heating with direct electric heaters, public building heating with coal, public building heating with lpg, public building heating with gas oil. to: public building heating with heatpump. Buildings > Non Residential > Hvac > Institutional Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
-              "acts_on_labels": [
-                "public building heating with oil",
-                "public building heating with gas",
-                "public building heating with propane",
-                "public building heating with direct electric heaters",
-                "public building heating with coal",
-                "public building heating with lpg",
-                "public building heating with gas oil"
-              ],
-              "shifts_to_labels": [
-                "public building heating with heatpump"
-              ],
-              "score": 0.6145
-            },
-            {
-              "stable_id": "shift_to_solar_thermal_in_public_buildings",
-              "short_label": "T-4B1b-TE-5 - Shift to solar thermal in public buildings",
-              "description": "Shift to solar thermal in public buildings. Shift square meter from public building heated with oil, gas, direct. from: public building heating with oil, public building heating with gas, public building heating with propane, public building heating with direct electric heaters, public building heating with coal, public building heating with lpg, public building heating with gas oil. to: public building heating with solar thermal. Buildings > Non Residential > Hvac > Institutional Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
-              "acts_on_labels": [
-                "public building heating with oil",
-                "public building heating with gas",
-                "public building heating with propane",
-                "public building heating with direct electric heaters",
-                "public building heating with coal",
-                "public building heating with lpg",
-                "public building heating with gas oil"
-              ],
-              "shifts_to_labels": [
-                "public building heating with solar thermal"
-              ],
-              "score": 0.6049
-            },
-            {
-              "stable_id": "heating_non_residential_industrial_buildings_with_renewable_solid_biofuels",
-              "short_label": "T-4B1c-TE-4 - Shift to biofuel in industrial buildings",
-              "description": "Shift to biofuel in industrial buildings. Shift square meter from industrial buildings heated with gas, oil and. from: industrial building heating with gas, industrial building heating with oil, industrial building heating with direct electric heaters, industrial building heating with lpg, industrial building heating with coal, industrial building heating with gas oil. to: industrial building heating with solid biofuels. Buildings > Non Residential > Hvac > Other Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Other Hvac",
-              "acts_on_labels": [
-                "industrial building heating with gas",
-                "industrial building heating with oil",
-                "industrial building heating with direct electric heaters",
-                "industrial building heating with lpg",
-                "industrial building heating with coal",
-                "industrial building heating with gas oil"
-              ],
-              "shifts_to_labels": [
-                "industrial building heating with solid biofuels"
-              ],
-              "score": 0.6041
-            },
-            {
-              "stable_id": "shift_to_district_heating_in_single_family_houses",
-              "short_label": "T-4A1b-TE-2 - Shift to district heating in single-family buildings",
-              "description": "Shift to district heating in single-family buildings. Shift square meter from single family building heated with gas, oil,. from: single family building heating with gas, single family building heating with propane, single family building heating with oil, single family building heating with direct electric heaters, single family building heating with coal, single family building heating with lpg. to: single family building heating with district heating. Buildings > Residential > Hvac > Single Family Hvac",
-              "sector_path": "Buildings > Residential > Hvac > Single Family Hvac",
-              "acts_on_labels": [
-                "single family building heating with gas",
-                "single family building heating with propane",
-                "single family building heating with oil",
-                "single family building heating with direct electric heaters",
-                "single family building heating with coal",
-                "single family building heating with lpg"
-              ],
-              "shifts_to_labels": [
-                "single family building heating with district heating"
-              ],
-              "score": 0.601
-            },
-            {
-              "stable_id": "shift_to_district_heating_in_industrial_buildings",
-              "short_label": "T-4B1c-TE-1 - Shift to district heating in industrial buildings",
-              "description": "Shift to district heating in industrial buildings. Shift square meter from industrial building heated with gas, oil and. from: industrial building heating with gas, industrial building heating with oil, industrial building heating with direct electric heaters, industrial building heating with lpg, industrial building heating with coal, industrial building heating with gas oil. to: industrial building heating with district heating. Buildings > Non Residential > Hvac > Other Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Other Hvac",
-              "acts_on_labels": [
-                "industrial building heating with gas",
-                "industrial building heating with oil",
-                "industrial building heating with direct electric heaters",
-                "industrial building heating with lpg",
-                "industrial building heating with coal",
-                "industrial building heating with gas oil"
-              ],
-              "shifts_to_labels": [
-                "industrial building heating with district heating"
-              ],
-              "score": 0.5997
-            },
-            {
-              "stable_id": "heating_non_residential_commercial_buildings_with_renewable_solid_biofuels",
-              "short_label": "T-4B1a-TE-4 - Shift to biofuel in commercial buildings",
-              "description": "Shift to biofuel in commercial buildings. Shift square meter from commercial buildings heated with gas, oil, direct. from: commercial building heating with gas, commercial building heating with propane, commercial building heating with oil, commercial building heating with direct electric heaters, commercial building heating with coal, commercial building heating with lpg, commercial building heating with gas oil. to: commercial building heating with solid biofuels. Buildings > Non Residential > Hvac > Commercial Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Commercial Hvac",
-              "acts_on_labels": [
-                "commercial building heating with gas",
-                "commercial building heating with propane",
-                "commercial building heating with oil",
-                "commercial building heating with direct electric heaters",
-                "commercial building heating with coal",
-                "commercial building heating with lpg",
-                "commercial building heating with gas oil"
-              ],
-              "shifts_to_labels": [
-                "commercial building heating with solid biofuels"
-              ],
-              "score": 0.5936
-            },
-            {
-              "stable_id": "heating_single_family_residential_buildings_with_renewable_solid_biofuels",
-              "short_label": "T-4A1b-TE-5 - Shift to biofuel heating in single-family buildings",
-              "description": "Shift to biofuel heating in single-family buildings. Shift square meter from single-family buildings heated with gas, oil,. from: single family building heating with gas, single family building heating with propane, single family building heating with oil, single family building heating with direct electric heaters, single family building heating with coal, single family building heating with lpg. to: single family building heating with solid biofuels. Buildings > Residential > Hvac > Single Family Hvac",
-              "sector_path": "Buildings > Residential > Hvac > Single Family Hvac",
-              "acts_on_labels": [
-                "single family building heating with gas",
-                "single family building heating with propane",
-                "single family building heating with oil",
-                "single family building heating with direct electric heaters",
-                "single family building heating with coal",
-                "single family building heating with lpg"
-              ],
-              "shifts_to_labels": [
-                "single family building heating with solid biofuels"
-              ],
-              "score": 0.5715
-            },
-            {
-              "stable_id": "shift_to_district_heating_in_commercial_buildings",
-              "short_label": "T-4B1a-TE-1 - Shift to district heating in commercial buildings",
-              "description": "Shift to district heating in commercial buildings. Shift square meter from commercial building heated with gas, oil, direct. from: commercial building heating with gas, commercial building heating with propane, commercial building heating with oil, commercial building heating with direct electric heaters, commercial building heating with coal, commercial building heating with lpg, commercial building heating with gas oil. to: commercial building heating with district heating. Buildings > Non Residential > Hvac > Commercial Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Commercial Hvac",
-              "acts_on_labels": [
-                "commercial building heating with gas",
-                "commercial building heating with propane",
-                "commercial building heating with oil",
-                "commercial building heating with direct electric heaters",
-                "commercial building heating with coal",
-                "commercial building heating with lpg",
-                "commercial building heating with gas oil"
-              ],
-              "shifts_to_labels": [
-                "commercial building heating with district heating"
-              ],
-              "score": 0.5561
-            },
-            {
-              "stable_id": "heat_pumps_in_single_family_residential_buildings",
-              "short_label": "T-4A1b-TE-1 - Shift to heat pumps in single-family buildings",
-              "description": "Shift to heat pumps in single-family buildings. Shift square meter from single-family buildings heated with gas, oil,. from: single family building heating with gas, single family building heating with propane, single family building heating with oil, single family building heating with direct electric heaters, single family building heating with coal, single family building heating with lpg. to: single family building heating with heatpump. Buildings > Residential > Hvac > Single Family Hvac",
-              "sector_path": "Buildings > Residential > Hvac > Single Family Hvac",
-              "acts_on_labels": [
-                "single family building heating with gas",
-                "single family building heating with propane",
-                "single family building heating with oil",
-                "single family building heating with direct electric heaters",
-                "single family building heating with coal",
-                "single family building heating with lpg"
-              ],
-              "shifts_to_labels": [
-                "single family building heating with heatpump"
-              ],
-              "score": 0.5552
-            },
-            {
-              "stable_id": "shift_to_solar_thermal_in_single_family_buildings",
-              "short_label": "T-4A1b-TE-4 - Shift to solar thermal in single-family buildings",
-              "description": "Shift to solar thermal in single-family buildings. Shift square meter from single family building heated with gas, oil,. from: single family building heating with gas, single family building heating with propane, single family building heating with oil, single family building heating with direct electric heaters, single family building heating with coal, single family building heating with lpg. to: single family building heating with solar thermal. Buildings > Residential > Hvac > Single Family Hvac",
-              "sector_path": "Buildings > Residential > Hvac > Single Family Hvac",
-              "acts_on_labels": [
-                "single family building heating with gas",
-                "single family building heating with propane",
-                "single family building heating with oil",
-                "single family building heating with direct electric heaters",
-                "single family building heating with coal",
-                "single family building heating with lpg"
-              ],
-              "shifts_to_labels": [
-                "single family building heating with solar thermal"
-              ],
-              "score": 0.5509
-            },
-            {
-              "stable_id": "energy_efficient_non_residential_public_buildings_retrofitting",
-              "short_label": "T-4B1b-TE-6 - Retrofitting public buildings for efficient heating",
-              "description": "Retrofitting public buildings for efficient heating. Reduce the amount of energy required to heat public building heating. from: public building heating with solid biofuels, public building heating with direct electric heaters, public building heating with gas, public building heating with propane, public building heating with oil, public building heating with heatpump, public building heating with district heating, public building heating with coal, public building heating with solar thermal, public building heating with lpg, public building heating with hydrogen, public building heating with gas oil. Buildings > Non Residential > Hvac > Institutional Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
-              "acts_on_labels": [
-                "public building heating with solid biofuels",
-                "public building heating with direct electric heaters",
-                "public building heating with gas",
-                "public building heating with propane",
-                "public building heating with oil",
-                "public building heating with heatpump",
-                "public building heating with district heating",
-                "public building heating with coal",
-                "public building heating with solar thermal",
-                "public building heating with lpg",
-                "public building heating with hydrogen",
-                "public building heating with gas oil"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.5474
-            }
-          ]
-        }
-      ],
-      "intervention_who": "kommunkoncernen",
-      "intervention_when": "by 2030",
-      "intervention_what": "become fossil fuel-free",
-      "intervention_how": "none",
-      "intervention_score": 4,
-      "intervention_reasoning": "Who, when, and what are present, but how is not specified.",
-      "intervention_type": "direct"
-    },
-    {
-      "measure_text": "124.Utsläppen av växthusgaser i kommunen som geografiskt område ska halveras till år 2030 (basår 2005).",
-      "activity": "none",
-      "activity_shift_score": 1,
-      "activity_shifts": [],
-      "intervention_who": "none",
-      "intervention_when": "by 2030",
-      "intervention_what": "reduce greenhouse gas emissions",
-      "intervention_how": "none",
-      "intervention_score": 2,
-      "intervention_reasoning": "When and what are weakly present, but no specific action or mechanism is provided.",
-      "intervention_type": "none"
-    },
-    {
-      "measure_text": "125.Kommunen ska prioritera platser där åtgärd krävs för att minimera risken för skador på infrastruktur och bebyggelse utifrån Myndigheten för samhällsskydd och beredskaps framtagna kartläggningar.",
-      "activity": "none",
-      "activity_shift_score": 1,
-      "activity_shifts": [],
-      "intervention_who": "kommunen",
-      "intervention_when": "none",
-      "intervention_what": "prioritize locations for action",
-      "intervention_how": "based on MSB's mappings",
-      "intervention_score": 4,
-      "intervention_reasoning": "Who, what, and how are present, but when is not specified.",
-      "intervention_type": "indirect"
-    },
-    {
-      "measure_text": "126.Naturbaserade lösningar ska nyttjas vid samhällsplanering för att ta hand om stora vattenmassor.",
-      "activity": "water management",
-      "activity_shift_score": 3,
-      "activity_shifts": [
-        {
-          "activity": "managing water",
-          "shift_from": "none",
-          "shift_to": "using nature-based solutions for water management",
-          "need": "water management",
-          "type": "Type Shift",
-          "type_reasoning": "The measure suggests a shift to using nature-based solutions, which implies a change in the system or method used for water management.",
-          "score": 3,
-          "reasoning": "Activity and shift_to are identifiable, but shift_from is not clearly specified.",
-          "transition_element_matches": [],
-          "transition_element_suggested_new": {
-            "short_label": "Shift to Nature-Based Water Management",
-            "description": "Implementing nature-based solutions for managing large volumes of water in urban planning."
+        "transition_element_candidates": [
+          {
+            "stable_id": "shift_to_sustainable_healthy_diet",
+            "short_label": "T-3A1-TE-1 - Shift to Sustainable Healthy Diets",
+            "description": "Shift to Sustainable Healthy Diets. This Transition Element is the shift from animal based diets to plant based diets.. from: enteric fermentation cattle, enteric fermentation sheep, enteric fermentation swine, enteric fermentation other livestock. Afolu > Livestock > Enteric Fermentation",
+            "sector_path": "Afolu > Livestock > Enteric Fermentation",
+            "acts_on_labels": [
+              "enteric fermentation cattle",
+              "enteric fermentation sheep",
+              "enteric fermentation swine",
+              "enteric fermentation other livestock"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.3779
           },
-          "transition_element_candidates": [
-            {
-              "stable_id": "shift_to_sustainable_healthy_diet",
-              "short_label": "T-3A1-TE-1 - Shift to Sustainable Healthy Diets",
-              "description": "Shift to Sustainable Healthy Diets. This Transition Element is the shift from animal based diets to plant based diets.. from: enteric fermentation cattle, enteric fermentation sheep, enteric fermentation swine, enteric fermentation other livestock. Afolu > Livestock > Enteric Fermentation",
-              "sector_path": "Afolu > Livestock > Enteric Fermentation",
-              "acts_on_labels": [
-                "enteric fermentation cattle",
-                "enteric fermentation sheep",
-                "enteric fermentation swine",
-                "enteric fermentation other livestock"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.3779
-            },
-            {
-              "stable_id": "shift_to_electrolysis_of_water_for_hydrogen_production",
-              "short_label": "T-5B4-TE-6 - Shift to electrolysis of water for hydrogen production",
-              "description": "Shift to electrolysis of water for hydrogen production. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: reforming of methane for hydrogen production, gasification of carbon for hydrogen production. to: electrolysis of water for hydrogen production. Energy > Energy Transformation > Hydrogen Refinement",
-              "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
-              "acts_on_labels": [
-                "reforming of methane for hydrogen production",
-                "gasification of carbon for hydrogen production"
-              ],
-              "shifts_to_labels": [
-                "electrolysis of water for hydrogen production"
-              ],
-              "score": 0.3762
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_chemical_industries",
-              "short_label": "T-2B9-TE-1 - Shift to biogas energy in chemical industries",
-              "description": "Shift to biogas energy in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within chemical industries. to: biogas usage within chemical industries. Industry > Chemicals > Other",
-              "sector_path": "Industry > Chemicals > Other",
-              "acts_on_labels": [
-                "natural gas usage within chemical industries"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within chemical industries"
-              ],
-              "score": 0.3632
-            },
-            {
-              "stable_id": "shift_to_heat_pumps_in_district_heating",
-              "short_label": "T-5A2-TE-5 - Shift to heat pumps in district heating",
-              "description": "Shift to heat pumps in district heating. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: chp coal, chp natural gas, chp oil. to: district heating heat pumps. Energy > Energy Supply > Heat",
-              "sector_path": "Energy > Energy Supply > Heat",
-              "acts_on_labels": [
-                "chp coal",
-                "chp natural gas",
-                "chp oil"
-              ],
-              "shifts_to_labels": [
-                "district heating heat pumps"
-              ],
-              "score": 0.3613
-            },
-            {
-              "stable_id": "shift_to_hydrogen_energy_in_chemical_industries",
-              "short_label": "T-2B9-TE-4 - Shift to hydrogen energy in chemical industries",
-              "description": "Shift to hydrogen energy in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within chemical industries. to: hydrogen usage within chemical industries. Industry > Chemicals > Other",
-              "sector_path": "Industry > Chemicals > Other",
-              "acts_on_labels": [
-                "natural gas usage within chemical industries"
-              ],
-              "shifts_to_labels": [
-                "hydrogen usage within chemical industries"
-              ],
-              "score": 0.3606
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_hydrogen_refinement",
-              "short_label": "T-5B4-TE-3 - Shift to biogas energy in hydrogen refinement",
-              "description": "Shift to biogas energy in hydrogen refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within hydrogen refinement. to: biogas usage within hydrogen refinement. Energy > Energy Transformation > Hydrogen Refinement",
-              "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
-              "acts_on_labels": [
-                "natural gas usage within hydrogen refinement"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within hydrogen refinement"
-              ],
-              "score": 0.3599
-            },
-            {
-              "stable_id": "shift_to_biomass_energy_in_hydrogen_refinement",
-              "short_label": "T-5B4-TE-4 - Shift to biomass energy in hydrogen refinement",
-              "description": "Shift to biomass energy in hydrogen refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within hydrogen refinement. to: biomass usage within hydrogen refinement. Energy > Energy Transformation > Hydrogen Refinement",
-              "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
-              "acts_on_labels": [
-                "coal usage within hydrogen refinement"
-              ],
-              "shifts_to_labels": [
-                "biomass usage within hydrogen refinement"
-              ],
-              "score": 0.3594
-            },
-            {
-              "stable_id": "shift_to_biomass_energy_in_chemical_industries",
-              "short_label": "T-2B9-TE-2 - Shift to biomass energy in chemical industries",
-              "description": "Shift to biomass energy in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within chemical industries. to: biomass usage within chemical industries. Industry > Chemicals > Other",
-              "sector_path": "Industry > Chemicals > Other",
-              "acts_on_labels": [
-                "coal usage within chemical industries"
-              ],
-              "shifts_to_labels": [
-                "biomass usage within chemical industries"
-              ],
-              "score": 0.3575
-            },
-            {
-              "stable_id": "shift_to_biofuel_in_district_heating",
-              "short_label": "T-5A3-TE-7 - Shift to biofuel in district heating",
-              "description": "Shift to biofuel in district heating. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: chp coal, chp natural gas, chp oil. to: chp biofuels. Energy > Energy Supply > Combined Heat Power",
-              "sector_path": "Energy > Energy Supply > Combined Heat Power",
-              "acts_on_labels": [
-                "chp coal",
-                "chp natural gas",
-                "chp oil"
-              ],
-              "shifts_to_labels": [
-                "chp biofuels"
-              ],
-              "score": 0.355
-            },
-            {
-              "stable_id": "electrification_of_domestic_sea_passenger_transport",
-              "short_label": "T-1A4-TE-5 - Shift to electric marine passenger transportion",
-              "description": "Shift to electric marine passenger transportion. Shift person kilometer from ship passenger to electric shipping passenger in person kilometer to fulfill the need of mobility. from: ship passenger, gas oil shipping passenger. to: electric shipping passenger. Transport > Mobility > Waterborne",
-              "sector_path": "Transport > Mobility > Waterborne",
-              "acts_on_labels": [
-                "ship passenger",
-                "gas oil shipping passenger"
-              ],
-              "shifts_to_labels": [
-                "electric shipping passenger"
-              ],
-              "score": 0.3548
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_pulp_paper_and_print_industries",
-              "short_label": "T-2D1b-TE-1 - Shift to biogas energy in pulp, paper and print industries",
-              "description": "Shift to biogas energy in pulp, paper and print industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within pulp paper and print industries. to: biogas usage within pulp paper and print industries. Industry > Other > Manufacturing > Pulp Paper Print",
-              "sector_path": "Industry > Other > Manufacturing > Pulp Paper Print",
-              "acts_on_labels": [
-                "natural gas usage within pulp paper and print industries"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within pulp paper and print industries"
-              ],
-              "score": 0.2577
-            },
-            {
-              "stable_id": "shift_to_hydrogen_energy_in_pulp_paper_and_print_industries",
-              "short_label": "T-2D1b-TE-4 - Shift to hydrogen energy in pulp, paper and print industries",
-              "description": "Shift to hydrogen energy in pulp, paper and print industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within pulp paper and print industries. to: hydrogen usage within pulp paper and print industries. Industry > Other > Manufacturing > Pulp Paper Print",
-              "sector_path": "Industry > Other > Manufacturing > Pulp Paper Print",
-              "acts_on_labels": [
-                "natural gas usage within pulp paper and print industries"
-              ],
-              "shifts_to_labels": [
-                "hydrogen usage within pulp paper and print industries"
-              ],
-              "score": 0.2545
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_glass_industries",
-              "short_label": "T-2A3-TE-1 - Shift to biogas energy in glass industries",
-              "description": "Shift to biogas energy in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within glass industries. to: biogas usage within glass industries. Industry > Minerals > Glass Production",
-              "sector_path": "Industry > Minerals > Glass Production",
-              "acts_on_labels": [
-                "natural gas usage within glass industries"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within glass industries"
-              ],
-              "score": 0.2497
-            },
-            {
-              "stable_id": "energy_efficient_other_agriculture_forestry_fishing_electric_appliances",
-              "short_label": "T-3C6-TE-1 - Energy efficient agriculture, forestry and fishing electrical appliances",
-              "description": "Energy efficient agriculture, forestry and fishing electrical appliances. Reduce the amount of energy required to operate agriculture, forestry and fishing electrical appliances. from: agriculture forestry fishing unregulated electricity use. Afolu > Aggregate Sources Other > Other",
-              "sector_path": "Afolu > Aggregate Sources Other > Other",
-              "acts_on_labels": [
-                "agriculture forestry fishing unregulated electricity use"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.2472
-            },
-            {
-              "stable_id": "shift_to_composting_of_organic_waste",
-              "short_label": "T-6A1-TE-2 - Shift to composting of organic waste",
-              "description": "Shift to composting of organic waste. Shift tonne from solid waste disposal in landfills to composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: composting of organic waste. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc",
-                "incineration and open burning of waste",
-                "open burning of waste",
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "shifts_to_labels": [
-                "composting of organic waste"
-              ],
-              "score": 0.2442
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_lead_industries",
-              "short_label": "T-2C5-TE-1 - Shift to biogas energy in lead industries",
-              "description": "Shift to biogas energy in lead industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within lead industries. to: biogas usage within lead industries. Industry > Metals > Lead",
-              "sector_path": "Industry > Metals > Lead",
-              "acts_on_labels": [
-                "natural gas usage within lead industries"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within lead industries"
-              ],
-              "score": 0.244
-            },
-            {
-              "stable_id": "shift_to_hydrogen_energy_in_glass_industries",
-              "short_label": "T-2A3-TE-4 - Shift to hydrogen energy in glass industries",
-              "description": "Shift to hydrogen energy in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within glass industries. to: hydrogen usage within glass industries. Industry > Minerals > Glass Production",
-              "sector_path": "Industry > Minerals > Glass Production",
-              "acts_on_labels": [
-                "natural gas usage within glass industries"
-              ],
-              "shifts_to_labels": [
-                "hydrogen usage within glass industries"
-              ],
-              "score": 0.2432
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_iron_and_steel_industries",
-              "short_label": "T-2C1-TE-1 - Shift to biogas energy in iron and steel industries",
-              "description": "Shift to biogas energy in iron and steel industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within iron and steel industries. to: biogas usage within iron and steel industries. Industry > Metals > Iron Steel",
-              "sector_path": "Industry > Metals > Iron Steel",
-              "acts_on_labels": [
-                "natural gas usage within iron and steel industries"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within iron and steel industries"
-              ],
-              "score": 0.2431
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_magnesium_industries",
-              "short_label": "T-2C4-TE-2 - Shift to biogas energy in magnesium industries",
-              "description": "Shift to biogas energy in magnesium industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within magnesium industries. to: biogas usage within magnesium industries. Industry > Metals > Magnesium",
-              "sector_path": "Industry > Metals > Magnesium",
-              "acts_on_labels": [
-                "natural gas usage within magnesium industries"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within magnesium industries"
-              ],
-              "score": 0.2429
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_other_industries",
-              "short_label": "T-2D5-TE-2 - Shift to biogas energy in other industries",
-              "description": "Shift to biogas energy in other industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: industrial unregulated gas use. to: industrial unregulated biogas use. Industry > Other > Other",
-              "sector_path": "Industry > Other > Other",
-              "acts_on_labels": [
-                "industrial unregulated gas use"
-              ],
-              "shifts_to_labels": [
-                "industrial unregulated biogas use"
-              ],
-              "score": 0.2404
-            },
-            {
-              "stable_id": "biogas_in_methane_reforming_for_hydrogen_production",
-              "short_label": "T-5B4-TE-1 - Biogas in methane reforming for hydrogen production",
-              "description": "Biogas in methane reforming for hydrogen production. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: reforming of methane for hydrogen production. Energy > Energy Transformation > Hydrogen Refinement",
-              "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
-              "acts_on_labels": [
-                "reforming of methane for hydrogen production"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.2378
-            }
-          ]
-        }
-      ],
-      "intervention_who": "none",
-      "intervention_when": "none",
-      "intervention_what": "utilize nature-based solutions",
-      "intervention_how": "none",
-      "intervention_score": 2,
-      "intervention_reasoning": "What is weakly present, but no specific actor, timeline, or mechanism is provided.",
-      "intervention_type": "indirect"
-    },
-    {
-      "measure_text": "127.Värmeöar i stadsbebyggelsen ska minska genom att öka andelen gröna ytor.",
-      "activity": "urban cooling",
-      "activity_shift_score": 3,
-      "activity_shifts": [
-        {
-          "activity": "cooling urban areas",
-          "shift_from": "none",
-          "shift_to": "increasing green spaces for cooling",
-          "need": "urban cooling",
-          "type": "Type Shift",
-          "type_reasoning": "The measure implies a shift to using green spaces for cooling, which is a change in the method used for urban cooling.",
-          "score": 3,
-          "reasoning": "Activity and shift_to are identifiable, but shift_from is not clearly specified.",
-          "transition_element_matches": [],
-          "transition_element_suggested_new": {
-            "short_label": "Increase Urban Green Spaces for Cooling",
-            "description": "Implement measures to increase the proportion of green areas in urban environments to reduce heat islands and improve urban cooling."
+          {
+            "stable_id": "shift_to_electrolysis_of_water_for_hydrogen_production",
+            "short_label": "T-5B4-TE-6 - Shift to electrolysis of water for hydrogen production",
+            "description": "Shift to electrolysis of water for hydrogen production. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: reforming of methane for hydrogen production, gasification of carbon for hydrogen production. to: electrolysis of water for hydrogen production. Energy > Energy Transformation > Hydrogen Refinement",
+            "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
+            "acts_on_labels": [
+              "reforming of methane for hydrogen production",
+              "gasification of carbon for hydrogen production"
+            ],
+            "shifts_to_labels": [
+              "electrolysis of water for hydrogen production"
+            ],
+            "score": 0.3762
           },
-          "transition_element_candidates": [
-            {
-              "stable_id": "shift_to_district_cooling_in_public_buildings",
-              "short_label": "T-4B1b-TE-2 - Shift to district cooling in public buildings",
-              "description": "Shift to district cooling in public buildings. Shift square meter from industrial building cooling with AC to industrial building cooling with district cooling in square meter to fulfill the need of comfortable premises. from: public building cooling with ac. to: public building cooling with district cooling. Buildings > Non Residential > Hvac > Institutional Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
-              "acts_on_labels": [
-                "public building cooling with ac"
-              ],
-              "shifts_to_labels": [
-                "public building cooling with district cooling"
-              ],
-              "score": 0.5192
-            },
-            {
-              "stable_id": "energy_efficient_non_residential_public_buildings_retrofitting_cooling",
-              "short_label": "T-4B1b-TE-7 - Retrofitting public buildings for efficient cooling",
-              "description": "Retrofitting public buildings for efficient cooling. Reduce the amount of energy required to cool public building with AC and disitrct cooling through retrofitting. from: public building cooling with ac, public building cooling with district cooling. Buildings > Non Residential > Hvac > Institutional Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
-              "acts_on_labels": [
-                "public building cooling with ac",
-                "public building cooling with district cooling"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.5175
-            },
-            {
-              "stable_id": "shift_to_district_cooling_in_industrial_buildings",
-              "short_label": "T-4B1c-TE-2 - Shift to district cooling in industrial buildings",
-              "description": "Shift to district cooling in industrial buildings. Shift square meter from industrial building cooling with AC to industrial building cooling with district cooling in square meter to fulfill the need of comfortable premises. from: industrial building cooling with ac. to: industrial building cooling with district cooling. Buildings > Non Residential > Hvac > Other Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Other Hvac",
-              "acts_on_labels": [
-                "industrial building cooling with ac"
-              ],
-              "shifts_to_labels": [
-                "industrial building cooling with district cooling"
-              ],
-              "score": 0.4944
-            },
-            {
-              "stable_id": "energy_efficient_non_residential_industrial_buildings_retrofitting_cooling",
-              "short_label": "T-4B1c-TE-7 - Retrofitting industrial buildings for efficient cooling",
-              "description": "Retrofitting industrial buildings for efficient cooling. Reduce the amount of energy required to cool industrial building with AC and disitrct cooling through retrofitting. from: industrial building cooling with ac, industrial building cooling with district cooling. Buildings > Non Residential > Hvac > Other Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Other Hvac",
-              "acts_on_labels": [
-                "industrial building cooling with ac",
-                "industrial building cooling with district cooling"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.4941
-            },
-            {
-              "stable_id": "energy_efficient_non_residential_commercial_buildings_retrofitting_cooling",
-              "short_label": "T-4B1a-TE-7 - Retrofitting commerical buildings for efficient cooling",
-              "description": "Retrofitting commerical buildings for efficient cooling. Reduce the amount of energy required to cool commerical  building with AC and disitrct cooling through retrofitting. from: commercial building cooling with ac, commercial building cooling with district cooling. Buildings > Non Residential > Hvac > Commercial Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Commercial Hvac",
-              "acts_on_labels": [
-                "commercial building cooling with ac",
-                "commercial building cooling with district cooling"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.4932
-            },
-            {
-              "stable_id": "shift_to_district_cooling_in_commercial_buildings",
-              "short_label": "T-4B1a-TE-2 - Shift to district cooling in commerical buildings",
-              "description": "Shift to district cooling in commerical buildings. Shift square meter from commerical building cooling with AC to commerical building cooling with district cooling in square meter to fulfill the need of comfortable premises. from: commercial building cooling with ac. to: commercial building cooling with district cooling. Buildings > Non Residential > Hvac > Commercial Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Commercial Hvac",
-              "acts_on_labels": [
-                "commercial building cooling with ac"
-              ],
-              "shifts_to_labels": [
-                "commercial building cooling with district cooling"
-              ],
-              "score": 0.4811
-            },
-            {
-              "stable_id": "shift_to_district_cooling_in_single_family_buildings",
-              "short_label": "T-4A1b-TE-3 - Shift to district cooling in single-family buildings",
-              "description": "Shift to district cooling in single-family buildings. Shift square meter from single family building cooling with AC to single family building cooling with district cooling in square meter to fulfill the need of comfortable premises. from: single family building cooling with ac. to: single family building cooling with district cooling. Buildings > Residential > Hvac > Single Family Hvac",
-              "sector_path": "Buildings > Residential > Hvac > Single Family Hvac",
-              "acts_on_labels": [
-                "single family building cooling with ac"
-              ],
-              "shifts_to_labels": [
-                "single family building cooling with district cooling"
-              ],
-              "score": 0.4692
-            },
-            {
-              "stable_id": "energy_efficient_multi_family_residential_buildings_retrofitting_cooling",
-              "short_label": "T-4A1a-TE-9 - Retrofitting multi-family buildings for efficient cooling",
-              "description": "Retrofitting multi-family buildings for efficient cooling. Reduce the amount of energy required to cool multi family building with AC and disitrct cooling through retrofitting. from: multi family building cooling with ac, multi family building cooling with district cooling. Buildings > Residential > Hvac > Multi Family Hvac",
-              "sector_path": "Buildings > Residential > Hvac > Multi Family Hvac",
-              "acts_on_labels": [
-                "multi family building cooling with ac",
-                "multi family building cooling with district cooling"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.4672
-            },
-            {
-              "stable_id": "energy_efficient_single_family_residential_buildings_retrofitting_cooling",
-              "short_label": "T-4A1b-TE-9 - Retrofitting single-family buildings for efficient cooling",
-              "description": "Retrofitting single-family buildings for efficient cooling. Reduce the amount of energy required to cool single family building with AC and disitrct cooling through retrofitting. from: single family building cooling with ac, single family building cooling with district cooling. Buildings > Residential > Hvac > Single Family Hvac",
-              "sector_path": "Buildings > Residential > Hvac > Single Family Hvac",
-              "acts_on_labels": [
-                "single family building cooling with ac",
-                "single family building cooling with district cooling"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.4656
-            },
-            {
-              "stable_id": "shift_to_district_cooling_in_multi_family_buildings",
-              "short_label": "T-4A1a-TE-3 - Shift to district cooling in multi-family buildings",
-              "description": "Shift to district cooling in multi-family buildings. Shift square meter from multi family building cooling with AC to multi family building cooling with district cooling in square meter to fulfill the need of comfortable premises. from: multi family building cooling with ac. to: multi family building cooling with district cooling. Buildings > Residential > Hvac > Multi Family Hvac",
-              "sector_path": "Buildings > Residential > Hvac > Multi Family Hvac",
-              "acts_on_labels": [
-                "multi family building cooling with ac"
-              ],
-              "shifts_to_labels": [
-                "multi family building cooling with district cooling"
-              ],
-              "score": 0.4619
-            },
-            {
-              "stable_id": "efficient_use_multi_family_residential_buildings_cooling",
-              "short_label": "T-4A1a-TE-7 - Energy efficient use of ACs in multi-family buildings",
-              "description": "Energy efficient use of ACs in multi-family buildings. Reduce the amount of energy required to cool multi family buildings with AC through efficient use of AC units. from: multi family building cooling with ac. Buildings > Residential > Hvac > Multi Family Hvac",
-              "sector_path": "Buildings > Residential > Hvac > Multi Family Hvac",
-              "acts_on_labels": [
-                "multi family building cooling with ac"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.3865
-            },
-            {
-              "stable_id": "energy_efficient_multi_family_residential_buildings_cooling",
-              "short_label": "T-4A1a-TE-8 - Energy efficient AC in multi-family buildings",
-              "description": "Energy efficient AC in multi-family buildings. Reduce the amount of energy required to cool multi family buildings with AC through more efficient AC units. from: multi family building cooling with ac. Buildings > Residential > Hvac > Multi Family Hvac",
-              "sector_path": "Buildings > Residential > Hvac > Multi Family Hvac",
-              "acts_on_labels": [
-                "multi family building cooling with ac"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.3862
-            },
-            {
-              "stable_id": "efficient_use_single_family_residential_buildings_cooling",
-              "short_label": "T-4A1b-TE-7 - Energy efficient use of ACs in single-family buildings",
-              "description": "Energy efficient use of ACs in single-family buildings. Reduce the amount of energy required to cool single family buildings with AC through efficient use of AC units. from: single family building cooling with ac. Buildings > Residential > Hvac > Single Family Hvac",
-              "sector_path": "Buildings > Residential > Hvac > Single Family Hvac",
-              "acts_on_labels": [
-                "single family building cooling with ac"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.3806
-            },
-            {
-              "stable_id": "energy_efficient_single_family_residential_buildings_cooling",
-              "short_label": "T-4A1b-TE-8 - Energy efficient AC in single-family buildings",
-              "description": "Energy efficient AC in single-family buildings. Reduce the amount of energy required to cool single family buildings with AC through more efficient AC units. from: single family building cooling with ac. Buildings > Residential > Hvac > Single Family Hvac",
-              "sector_path": "Buildings > Residential > Hvac > Single Family Hvac",
-              "acts_on_labels": [
-                "single family building cooling with ac"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.38
-            },
-            {
-              "stable_id": "energy_efficient_non_residential_public_buildings_retrofitting",
-              "short_label": "T-4B1b-TE-6 - Retrofitting public buildings for efficient heating",
-              "description": "Retrofitting public buildings for efficient heating. Reduce the amount of energy required to heat public building heating. from: public building heating with solid biofuels, public building heating with direct electric heaters, public building heating with gas, public building heating with propane, public building heating with oil, public building heating with heatpump, public building heating with district heating, public building heating with coal, public building heating with solar thermal, public building heating with lpg, public building heating with hydrogen, public building heating with gas oil. Buildings > Non Residential > Hvac > Institutional Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
-              "acts_on_labels": [
-                "public building heating with solid biofuels",
-                "public building heating with direct electric heaters",
-                "public building heating with gas",
-                "public building heating with propane",
-                "public building heating with oil",
-                "public building heating with heatpump",
-                "public building heating with district heating",
-                "public building heating with coal",
-                "public building heating with solar thermal",
-                "public building heating with lpg",
-                "public building heating with hydrogen",
-                "public building heating with gas oil"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.3433
-            }
-          ]
-        }
-      ],
-      "intervention_who": "none",
-      "intervention_when": "none",
-      "intervention_what": "increase green spaces",
-      "intervention_how": "none",
-      "intervention_score": 2,
-      "intervention_reasoning": "What is weakly present, but no specific actor, timeline, or mechanism is provided.",
-      "intervention_type": "indirect"
-    },
-    {
-      "measure_text": "128.Kommunkoncernen ska vidta energieffektiviseringsåtgärder så att energianvändningen per kvadratmeter i egenägda fastigheter minskar med minst 20 procent från 2020 till 2030.",
-      "activity": "building energy use",
-      "activity_shift_score": 6,
-      "activity_shifts": [
-        {
-          "activity": "using energy in buildings",
-          "shift_from": "high energy use per square meter",
-          "shift_to": "reduced energy use per square meter",
-          "need": "space heating and cooling",
-          "type": "Resource Efficiency Shift",
-          "type_reasoning": "The measure focuses on reducing energy use per square meter, which is a resource efficiency improvement.",
-          "score": 6,
-          "reasoning": "Activity, shift_from, shift_to, and need are all identifiable.",
-          "transition_element_matches": [
-            {
-              "stable_id": "shift_to_district_heating_in_public_buildings",
-              "short_label": "T-4B1b-TE-1 - Shift to district heating in public buildings",
-              "description": "Shift to district heating in public buildings. Shift square meter from public building heated with oil, gas, direct. from: public building heating with oil, public building heating with gas, public building heating with propane, public building heating with direct electric heaters, public building heating with coal, public building heating with lpg, public building heating with gas oil. to: public building heating with district heating. Buildings > Non Residential > Hvac > Institutional Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
-              "acts_on_labels": [
-                "public building heating with oil",
-                "public building heating with gas",
-                "public building heating with propane",
-                "public building heating with direct electric heaters",
-                "public building heating with coal",
-                "public building heating with lpg",
-                "public building heating with gas oil"
-              ],
-              "shifts_to_labels": [
-                "public building heating with district heating"
-              ],
-              "score": 0.5944,
-              "match_reasoning": "acts_on=yes, shifts_to=yes, confidence=mid",
-              "match_confidence": "mid"
-            },
-            {
-              "stable_id": "heat_pumps_in_non_residential_public_buildings",
-              "short_label": "T-4B1b-TE-3 - Shift to heat pumps in public buildings",
-              "description": "Shift to heat pumps in public buildings. Shift square meter from public buildings heated with oil, gas, direct. from: public building heating with oil, public building heating with gas, public building heating with propane, public building heating with direct electric heaters, public building heating with coal, public building heating with lpg, public building heating with gas oil. to: public building heating with heatpump. Buildings > Non Residential > Hvac > Institutional Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
-              "acts_on_labels": [
-                "public building heating with oil",
-                "public building heating with gas",
-                "public building heating with propane",
-                "public building heating with direct electric heaters",
-                "public building heating with coal",
-                "public building heating with lpg",
-                "public building heating with gas oil"
-              ],
-              "shifts_to_labels": [
-                "public building heating with heatpump"
-              ],
-              "score": 0.5889,
-              "match_reasoning": "acts_on=yes, shifts_to=yes, confidence=mid",
-              "match_confidence": "mid"
-            },
-            {
-              "stable_id": "energy_efficient_non_residential_public_buildings_retrofitting",
-              "short_label": "T-4B1b-TE-6 - Retrofitting public buildings for efficient heating",
-              "description": "Retrofitting public buildings for efficient heating. Reduce the amount of energy required to heat public building heating. from: public building heating with solid biofuels, public building heating with direct electric heaters, public building heating with gas, public building heating with propane, public building heating with oil, public building heating with heatpump, public building heating with district heating, public building heating with coal, public building heating with solar thermal, public building heating with lpg, public building heating with hydrogen, public building heating with gas oil. Buildings > Non Residential > Hvac > Institutional Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
-              "acts_on_labels": [
-                "public building heating with solid biofuels",
-                "public building heating with direct electric heaters",
-                "public building heating with gas",
-                "public building heating with propane",
-                "public building heating with oil",
-                "public building heating with heatpump",
-                "public building heating with district heating",
-                "public building heating with coal",
-                "public building heating with solar thermal",
-                "public building heating with lpg",
-                "public building heating with hydrogen",
-                "public building heating with gas oil"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.5853,
-              "match_reasoning": "acts_on=yes, shifts_to=empty, confidence=mid",
-              "match_confidence": "mid"
-            },
-            {
-              "stable_id": "shift_to_solar_thermal_in_public_buildings",
-              "short_label": "T-4B1b-TE-5 - Shift to solar thermal in public buildings",
-              "description": "Shift to solar thermal in public buildings. Shift square meter from public building heated with oil, gas, direct. from: public building heating with oil, public building heating with gas, public building heating with propane, public building heating with direct electric heaters, public building heating with coal, public building heating with lpg, public building heating with gas oil. to: public building heating with solar thermal. Buildings > Non Residential > Hvac > Institutional Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
-              "acts_on_labels": [
-                "public building heating with oil",
-                "public building heating with gas",
-                "public building heating with propane",
-                "public building heating with direct electric heaters",
-                "public building heating with coal",
-                "public building heating with lpg",
-                "public building heating with gas oil"
-              ],
-              "shifts_to_labels": [
-                "public building heating with solar thermal"
-              ],
-              "score": 0.5833,
-              "match_reasoning": "acts_on=yes, shifts_to=yes, confidence=mid",
-              "match_confidence": "mid"
-            },
-            {
-              "stable_id": "heating_non_residential_public_buildings_with_renewable_solid_biofuels",
-              "short_label": "T-4B1b-TE-4 - Shift to biofuel in public buildings",
-              "description": "Shift to biofuel in public buildings. Shift square meter from public buildings heated with oil, gas, direct. from: public building heating with oil, public building heating with gas, public building heating with propane, public building heating with direct electric heaters, public building heating with coal, public building heating with lpg, public building heating with gas oil. to: public building heating with solid biofuels. Buildings > Non Residential > Hvac > Institutional Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
-              "acts_on_labels": [
-                "public building heating with oil",
-                "public building heating with gas",
-                "public building heating with propane",
-                "public building heating with direct electric heaters",
-                "public building heating with coal",
-                "public building heating with lpg",
-                "public building heating with gas oil"
-              ],
-              "shifts_to_labels": [
-                "public building heating with solid biofuels"
-              ],
-              "score": 0.5679,
-              "match_reasoning": "acts_on=yes, shifts_to=yes, confidence=mid",
-              "match_confidence": "mid"
-            }
-          ],
-          "transition_element_candidates": [
-            {
-              "stable_id": "shift_to_district_heating_in_commercial_buildings",
-              "short_label": "T-4B1a-TE-1 - Shift to district heating in commercial buildings",
-              "description": "Shift to district heating in commercial buildings. Shift square meter from commercial building heated with gas, oil, direct. from: commercial building heating with gas, commercial building heating with propane, commercial building heating with oil, commercial building heating with direct electric heaters, commercial building heating with coal, commercial building heating with lpg, commercial building heating with gas oil. to: commercial building heating with district heating. Buildings > Non Residential > Hvac > Commercial Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Commercial Hvac",
-              "acts_on_labels": [
-                "commercial building heating with gas",
-                "commercial building heating with propane",
-                "commercial building heating with oil",
-                "commercial building heating with direct electric heaters",
-                "commercial building heating with coal",
-                "commercial building heating with lpg",
-                "commercial building heating with gas oil"
-              ],
-              "shifts_to_labels": [
-                "commercial building heating with district heating"
-              ],
-              "score": 0.6024
-            },
-            {
-              "stable_id": "shift_to_solar_thermal_in_commercial_buildings",
-              "short_label": "T-4B1a-TE-5 - Shift to solar thermal in commercial buildings",
-              "description": "Shift to solar thermal in commercial buildings. Shift square meter from commercial building heated with gas, oil, direct. from: commercial building heating with gas, commercial building heating with propane, commercial building heating with oil, commercial building heating with direct electric heaters, commercial building heating with coal, commercial building heating with lpg, commercial building heating with gas oil. to: commercial building heating with solar thermal. Buildings > Non Residential > Hvac > Commercial Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Commercial Hvac",
-              "acts_on_labels": [
-                "commercial building heating with gas",
-                "commercial building heating with propane",
-                "commercial building heating with oil",
-                "commercial building heating with direct electric heaters",
-                "commercial building heating with coal",
-                "commercial building heating with lpg",
-                "commercial building heating with gas oil"
-              ],
-              "shifts_to_labels": [
-                "commercial building heating with solar thermal"
-              ],
-              "score": 0.598
-            },
-            {
-              "stable_id": "heat_pumps_in_non_residential_commercial_buildings",
-              "short_label": "T-4B1a-TE-3 - Shift to heat pumps in commerical buildings",
-              "description": "Shift to heat pumps in commerical buildings. Shift square meter from commercial buildings heated with gas, oil, direct. from: commercial building heating with gas, commercial building heating with propane, commercial building heating with oil, commercial building heating with direct electric heaters, commercial building heating with coal, commercial building heating with lpg, commercial building heating with gas oil. to: commercial building heating with heatpump. Buildings > Non Residential > Hvac > Commercial Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Commercial Hvac",
-              "acts_on_labels": [
-                "commercial building heating with gas",
-                "commercial building heating with propane",
-                "commercial building heating with oil",
-                "commercial building heating with direct electric heaters",
-                "commercial building heating with coal",
-                "commercial building heating with lpg",
-                "commercial building heating with gas oil"
-              ],
-              "shifts_to_labels": [
-                "commercial building heating with heatpump"
-              ],
-              "score": 0.5962
-            },
-            {
-              "stable_id": "shift_to_district_heating_in_public_buildings",
-              "short_label": "T-4B1b-TE-1 - Shift to district heating in public buildings",
-              "description": "Shift to district heating in public buildings. Shift square meter from public building heated with oil, gas, direct. from: public building heating with oil, public building heating with gas, public building heating with propane, public building heating with direct electric heaters, public building heating with coal, public building heating with lpg, public building heating with gas oil. to: public building heating with district heating. Buildings > Non Residential > Hvac > Institutional Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
-              "acts_on_labels": [
-                "public building heating with oil",
-                "public building heating with gas",
-                "public building heating with propane",
-                "public building heating with direct electric heaters",
-                "public building heating with coal",
-                "public building heating with lpg",
-                "public building heating with gas oil"
-              ],
-              "shifts_to_labels": [
-                "public building heating with district heating"
-              ],
-              "score": 0.5944
-            },
-            {
-              "stable_id": "shift_to_district_cooling_in_commercial_buildings",
-              "short_label": "T-4B1a-TE-2 - Shift to district cooling in commerical buildings",
-              "description": "Shift to district cooling in commerical buildings. Shift square meter from commerical building cooling with AC to commerical building cooling with district cooling in square meter to fulfill the need of comfortable premises. from: commercial building cooling with ac. to: commercial building cooling with district cooling. Buildings > Non Residential > Hvac > Commercial Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Commercial Hvac",
-              "acts_on_labels": [
-                "commercial building cooling with ac"
-              ],
-              "shifts_to_labels": [
-                "commercial building cooling with district cooling"
-              ],
-              "score": 0.589
-            },
-            {
-              "stable_id": "heat_pumps_in_non_residential_public_buildings",
-              "short_label": "T-4B1b-TE-3 - Shift to heat pumps in public buildings",
-              "description": "Shift to heat pumps in public buildings. Shift square meter from public buildings heated with oil, gas, direct. from: public building heating with oil, public building heating with gas, public building heating with propane, public building heating with direct electric heaters, public building heating with coal, public building heating with lpg, public building heating with gas oil. to: public building heating with heatpump. Buildings > Non Residential > Hvac > Institutional Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
-              "acts_on_labels": [
-                "public building heating with oil",
-                "public building heating with gas",
-                "public building heating with propane",
-                "public building heating with direct electric heaters",
-                "public building heating with coal",
-                "public building heating with lpg",
-                "public building heating with gas oil"
-              ],
-              "shifts_to_labels": [
-                "public building heating with heatpump"
-              ],
-              "score": 0.5889
-            },
-            {
-              "stable_id": "heating_non_residential_commercial_buildings_with_renewable_solid_biofuels",
-              "short_label": "T-4B1a-TE-4 - Shift to biofuel in commercial buildings",
-              "description": "Shift to biofuel in commercial buildings. Shift square meter from commercial buildings heated with gas, oil, direct. from: commercial building heating with gas, commercial building heating with propane, commercial building heating with oil, commercial building heating with direct electric heaters, commercial building heating with coal, commercial building heating with lpg, commercial building heating with gas oil. to: commercial building heating with solid biofuels. Buildings > Non Residential > Hvac > Commercial Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Commercial Hvac",
-              "acts_on_labels": [
-                "commercial building heating with gas",
-                "commercial building heating with propane",
-                "commercial building heating with oil",
-                "commercial building heating with direct electric heaters",
-                "commercial building heating with coal",
-                "commercial building heating with lpg",
-                "commercial building heating with gas oil"
-              ],
-              "shifts_to_labels": [
-                "commercial building heating with solid biofuels"
-              ],
-              "score": 0.5879
-            },
-            {
-              "stable_id": "shift_to_district_cooling_in_public_buildings",
-              "short_label": "T-4B1b-TE-2 - Shift to district cooling in public buildings",
-              "description": "Shift to district cooling in public buildings. Shift square meter from industrial building cooling with AC to industrial building cooling with district cooling in square meter to fulfill the need of comfortable premises. from: public building cooling with ac. to: public building cooling with district cooling. Buildings > Non Residential > Hvac > Institutional Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
-              "acts_on_labels": [
-                "public building cooling with ac"
-              ],
-              "shifts_to_labels": [
-                "public building cooling with district cooling"
-              ],
-              "score": 0.5877
-            },
-            {
-              "stable_id": "energy_efficient_non_residential_public_buildings_retrofitting",
-              "short_label": "T-4B1b-TE-6 - Retrofitting public buildings for efficient heating",
-              "description": "Retrofitting public buildings for efficient heating. Reduce the amount of energy required to heat public building heating. from: public building heating with solid biofuels, public building heating with direct electric heaters, public building heating with gas, public building heating with propane, public building heating with oil, public building heating with heatpump, public building heating with district heating, public building heating with coal, public building heating with solar thermal, public building heating with lpg, public building heating with hydrogen, public building heating with gas oil. Buildings > Non Residential > Hvac > Institutional Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
-              "acts_on_labels": [
-                "public building heating with solid biofuels",
-                "public building heating with direct electric heaters",
-                "public building heating with gas",
-                "public building heating with propane",
-                "public building heating with oil",
-                "public building heating with heatpump",
-                "public building heating with district heating",
-                "public building heating with coal",
-                "public building heating with solar thermal",
-                "public building heating with lpg",
-                "public building heating with hydrogen",
-                "public building heating with gas oil"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.5853
-            },
-            {
-              "stable_id": "shift_to_solar_thermal_in_public_buildings",
-              "short_label": "T-4B1b-TE-5 - Shift to solar thermal in public buildings",
-              "description": "Shift to solar thermal in public buildings. Shift square meter from public building heated with oil, gas, direct. from: public building heating with oil, public building heating with gas, public building heating with propane, public building heating with direct electric heaters, public building heating with coal, public building heating with lpg, public building heating with gas oil. to: public building heating with solar thermal. Buildings > Non Residential > Hvac > Institutional Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
-              "acts_on_labels": [
-                "public building heating with oil",
-                "public building heating with gas",
-                "public building heating with propane",
-                "public building heating with direct electric heaters",
-                "public building heating with coal",
-                "public building heating with lpg",
-                "public building heating with gas oil"
-              ],
-              "shifts_to_labels": [
-                "public building heating with solar thermal"
-              ],
-              "score": 0.5833
-            },
-            {
-              "stable_id": "shift_to_solar_thermal_in_industrial_buildings",
-              "short_label": "T-4B1c-TE-5 - Shift to solar thermal in industrial buildings",
-              "description": "Shift to solar thermal in industrial buildings. Shift square meter from industrial building heated with gas, oil, direct. from: industrial building heating with gas, industrial building heating with oil, industrial building heating with direct electric heaters, industrial building heating with lpg, industrial building heating with coal, industrial building heating with gas oil. to: industrial building heating with solar thermal. Buildings > Non Residential > Hvac > Other Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Other Hvac",
-              "acts_on_labels": [
-                "industrial building heating with gas",
-                "industrial building heating with oil",
-                "industrial building heating with direct electric heaters",
-                "industrial building heating with lpg",
-                "industrial building heating with coal",
-                "industrial building heating with gas oil"
-              ],
-              "shifts_to_labels": [
-                "industrial building heating with solar thermal"
-              ],
-              "score": 0.5832
-            },
-            {
-              "stable_id": "shift_to_district_cooling_in_industrial_buildings",
-              "short_label": "T-4B1c-TE-2 - Shift to district cooling in industrial buildings",
-              "description": "Shift to district cooling in industrial buildings. Shift square meter from industrial building cooling with AC to industrial building cooling with district cooling in square meter to fulfill the need of comfortable premises. from: industrial building cooling with ac. to: industrial building cooling with district cooling. Buildings > Non Residential > Hvac > Other Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Other Hvac",
-              "acts_on_labels": [
-                "industrial building cooling with ac"
-              ],
-              "shifts_to_labels": [
-                "industrial building cooling with district cooling"
-              ],
-              "score": 0.5785
-            },
-            {
-              "stable_id": "shift_to_district_cooling_in_single_family_buildings",
-              "short_label": "T-4A1b-TE-3 - Shift to district cooling in single-family buildings",
-              "description": "Shift to district cooling in single-family buildings. Shift square meter from single family building cooling with AC to single family building cooling with district cooling in square meter to fulfill the need of comfortable premises. from: single family building cooling with ac. to: single family building cooling with district cooling. Buildings > Residential > Hvac > Single Family Hvac",
-              "sector_path": "Buildings > Residential > Hvac > Single Family Hvac",
-              "acts_on_labels": [
-                "single family building cooling with ac"
-              ],
-              "shifts_to_labels": [
-                "single family building cooling with district cooling"
-              ],
-              "score": 0.5781
-            },
-            {
-              "stable_id": "shift_to_district_heating_in_industrial_buildings",
-              "short_label": "T-4B1c-TE-1 - Shift to district heating in industrial buildings",
-              "description": "Shift to district heating in industrial buildings. Shift square meter from industrial building heated with gas, oil and. from: industrial building heating with gas, industrial building heating with oil, industrial building heating with direct electric heaters, industrial building heating with lpg, industrial building heating with coal, industrial building heating with gas oil. to: industrial building heating with district heating. Buildings > Non Residential > Hvac > Other Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Other Hvac",
-              "acts_on_labels": [
-                "industrial building heating with gas",
-                "industrial building heating with oil",
-                "industrial building heating with direct electric heaters",
-                "industrial building heating with lpg",
-                "industrial building heating with coal",
-                "industrial building heating with gas oil"
-              ],
-              "shifts_to_labels": [
-                "industrial building heating with district heating"
-              ],
-              "score": 0.5774
-            },
-            {
-              "stable_id": "shift_to_biogas_heating_of_non_residential_commercial_buildings",
-              "short_label": "T-4B1a-TE-10 - Shift to biogas in commercial buildings",
-              "description": "Shift to biogas in commercial buildings. Shift square meter from commercial building heating with gas to commercial building heating with biogas in square meter to fulfill the need of comfortable premises. from: commercial building heating with gas. to: commercial building heating with biogas. Buildings > Non Residential > Hvac > Commercial Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Commercial Hvac",
-              "acts_on_labels": [
-                "commercial building heating with gas"
-              ],
-              "shifts_to_labels": [
-                "commercial building heating with biogas"
-              ],
-              "score": 0.5758
-            },
-            {
-              "stable_id": "heating_non_residential_public_buildings_with_renewable_solid_biofuels",
-              "short_label": "T-4B1b-TE-4 - Shift to biofuel in public buildings",
-              "description": "Shift to biofuel in public buildings. Shift square meter from public buildings heated with oil, gas, direct. from: public building heating with oil, public building heating with gas, public building heating with propane, public building heating with direct electric heaters, public building heating with coal, public building heating with lpg, public building heating with gas oil. to: public building heating with solid biofuels. Buildings > Non Residential > Hvac > Institutional Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
-              "acts_on_labels": [
-                "public building heating with oil",
-                "public building heating with gas",
-                "public building heating with propane",
-                "public building heating with direct electric heaters",
-                "public building heating with coal",
-                "public building heating with lpg",
-                "public building heating with gas oil"
-              ],
-              "shifts_to_labels": [
-                "public building heating with solid biofuels"
-              ],
-              "score": 0.5679
-            }
-          ]
-        }
-      ],
-      "intervention_who": "kommunkoncernen",
-      "intervention_when": "from 2020 to 2030",
-      "intervention_what": "implement energy efficiency measures",
-      "intervention_how": "none",
-      "intervention_score": 4,
-      "intervention_reasoning": "Who, when, and what are present, but how is not specified.",
-      "intervention_type": "direct"
-    },
-    {
-      "measure_text": "129.Utbyggnaden av förnybara energikällor ska öka inom kommunkoncernen.",
-      "activity": "energy production",
-      "activity_shift_score": 3,
-      "activity_shifts": [
-        {
-          "activity": "producing energy",
-          "shift_from": "none",
-          "shift_to": "increasing renewable energy sources",
-          "need": "electricity provision",
-          "type": "Resource Shift",
-          "type_reasoning": "The measure implies a shift to renewable energy sources, which is a change in the resource used for energy production.",
-          "score": 3,
-          "reasoning": "Activity and shift_to are identifiable, but shift_from is not clearly specified.",
-          "transition_element_matches": [],
-          "transition_element_suggested_new": {
-            "short_label": "Increase Renewable Energy Sources",
-            "description": "Expansion of renewable energy sources within the municipal corporation to increase electricity provision."
+          {
+            "stable_id": "shift_to_biogas_energy_in_chemical_industries",
+            "short_label": "T-2B9-TE-1 - Shift to biogas energy in chemical industries",
+            "description": "Shift to biogas energy in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within chemical industries. to: biogas usage within chemical industries. Industry > Chemicals > Other",
+            "sector_path": "Industry > Chemicals > Other",
+            "acts_on_labels": ["natural gas usage within chemical industries"],
+            "shifts_to_labels": ["biogas usage within chemical industries"],
+            "score": 0.3632
           },
-          "transition_element_candidates": [
-            {
-              "stable_id": "wind_offshore",
-              "short_label": "T-5A1-TE-9 - Electricity from wind offshore",
-              "description": "Electricity from wind offshore. Alter the amount of electricity produced by wind offshore. from: wind offshore. Energy > Energy Supply > Electricity",
-              "sector_path": "Energy > Energy Supply > Electricity",
-              "acts_on_labels": [
-                "wind offshore"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.5344
-            },
-            {
-              "stable_id": "wind_onshore",
-              "short_label": "T-5A1-TE-10 - Electricity from wind onshore",
-              "description": "Electricity from wind onshore. Alter the amount of electricity produced by wind onshore. from: wind onshore. Energy > Energy Supply > Electricity",
-              "sector_path": "Energy > Energy Supply > Electricity",
-              "acts_on_labels": [
-                "wind onshore"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.5319
-            },
-            {
-              "stable_id": "solar_rooftops",
-              "short_label": "T-5A1-TE-8 - Electricity from solar rooftops",
-              "description": "Electricity from solar rooftops. Alter the amount of electricity produced by solar rooftops. from: solar rooftops. Energy > Energy Supply > Electricity",
-              "sector_path": "Energy > Energy Supply > Electricity",
-              "acts_on_labels": [
-                "solar rooftops"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.522
-            },
-            {
-              "stable_id": "shift_to_electricity_in_hydrogen_refinement",
-              "short_label": "T-5B4-TE-5 - Shift to electricity in hydrogen refinement",
-              "description": "Shift to electricity in hydrogen refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within hydrogen refinement, natural gas usage within hydrogen refinement. to: electricity usage within hydrogen refinement. Energy > Energy Transformation > Hydrogen Refinement",
-              "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
-              "acts_on_labels": [
-                "coal usage within hydrogen refinement",
-                "natural gas usage within hydrogen refinement"
-              ],
-              "shifts_to_labels": [
-                "electricity usage within hydrogen refinement"
-              ],
-              "score": 0.5183
-            },
-            {
-              "stable_id": "solar_parks",
-              "short_label": "T-5A1-TE-7 - Electricity from solar parks",
-              "description": "Electricity from solar parks. Alter the amount of electricity produced by solar parks. from: solar parks. Energy > Energy Supply > Electricity",
-              "sector_path": "Energy > Energy Supply > Electricity",
-              "acts_on_labels": [
-                "solar parks"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.514
-            },
-            {
-              "stable_id": "biofuel_fired_power_plants",
-              "short_label": "T-5A1-TE-11 - Electricity from biomass power plants",
-              "description": "Electricity from biomass power plants. Alter the amount of electricity produced by biofuel fired power plants. from: biofuel fired powerplants. Energy > Energy Supply > Electricity",
-              "sector_path": "Energy > Energy Supply > Electricity",
-              "acts_on_labels": [
-                "biofuel fired powerplants"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.5139
-            },
-            {
-              "stable_id": "shift_to_electricity_in_glass_industries",
-              "short_label": "T-2A3-TE-3 - Shift to electricity in glass industries",
-              "description": "Shift to electricity in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within glass industries, oil usage within glass industries, natural gas usage within glass industries. to: electricity usage within glass industries. Industry > Minerals > Glass Production",
-              "sector_path": "Industry > Minerals > Glass Production",
-              "acts_on_labels": [
-                "coal usage within glass industries",
-                "oil usage within glass industries",
-                "natural gas usage within glass industries"
-              ],
-              "shifts_to_labels": [
-                "electricity usage within glass industries"
-              ],
-              "score": 0.5136
-            },
-            {
-              "stable_id": "shift_to_electricity_in_other_industries",
-              "short_label": "T-2D5-TE-3 - Shift to electricity in other industries",
-              "description": "Shift to electricity in other industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: industrial unregulated coal use, industrial unregulated oil use, industrial unregulated gas use. to: industrial unregulated electricity use. Industry > Other > Other",
-              "sector_path": "Industry > Other > Other",
-              "acts_on_labels": [
-                "industrial unregulated coal use",
-                "industrial unregulated oil use",
-                "industrial unregulated gas use"
-              ],
-              "shifts_to_labels": [
-                "industrial unregulated electricity use"
-              ],
-              "score": 0.5131
-            },
-            {
-              "stable_id": "shift_to_electricity_in_chemical_industries",
-              "short_label": "T-2B9-TE-3 - Shift to electricity in chemical industries",
-              "description": "Shift to electricity in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within chemical industries, natural gas usage within chemical industries. to: electricity usage within chemical industries. Industry > Chemicals > Other",
-              "sector_path": "Industry > Chemicals > Other",
-              "acts_on_labels": [
-                "coal usage within chemical industries",
-                "natural gas usage within chemical industries"
-              ],
-              "shifts_to_labels": [
-                "electricity usage within chemical industries"
-              ],
-              "score": 0.5127
-            },
-            {
-              "stable_id": "shift_to_electrolysis_of_water_for_hydrogen_production",
-              "short_label": "T-5B4-TE-6 - Shift to electrolysis of water for hydrogen production",
-              "description": "Shift to electrolysis of water for hydrogen production. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: reforming of methane for hydrogen production, gasification of carbon for hydrogen production. to: electrolysis of water for hydrogen production. Energy > Energy Transformation > Hydrogen Refinement",
-              "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
-              "acts_on_labels": [
-                "reforming of methane for hydrogen production",
-                "gasification of carbon for hydrogen production"
-              ],
-              "shifts_to_labels": [
-                "electrolysis of water for hydrogen production"
-              ],
-              "score": 0.5064
-            },
-            {
-              "stable_id": "improved_grid_electricity",
-              "short_label": "T-5A1-TE-3 - Improved Grid Electricity",
-              "description": "Improved Grid Electricity. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: grid current. to: grid future. Energy > Energy Supply > Electricity",
-              "sector_path": "Energy > Energy Supply > Electricity",
-              "acts_on_labels": [
-                "grid current"
-              ],
-              "shifts_to_labels": [
-                "grid future"
-              ],
-              "score": 0.5042
-            },
-            {
-              "stable_id": "shift_to_residential_electric_cooking_stoves",
-              "short_label": "T-4A2d-TE-2 - Shift to residential electric cooking stoves",
-              "description": "Shift to residential electric cooking stoves. Shift kWh from residential cooking gas stoves to residential electric cooking stoves in kWh to fullfill the need for cooking. from: residential gas cooking stoves. to: residential electric cooking stoves. Buildings > Residential > Other Energy Usage > Unregulated",
-              "sector_path": "Buildings > Residential > Other Energy Usage > Unregulated",
-              "acts_on_labels": [
-                "residential gas cooking stoves"
-              ],
-              "shifts_to_labels": [
-                "residential electric cooking stoves"
-              ],
-              "score": 0.4976
-            },
-            {
-              "stable_id": "shift_to_electricity_in_iron_and_steel_industries",
-              "short_label": "T-2C1-TE-4 - Shift to electricity in iron and steel industries",
-              "description": "Shift to electricity in iron and steel industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within iron and steel industries, natural gas usage within iron and steel industries. to: electricity usage within iron and steel industries. Industry > Metals > Iron Steel",
-              "sector_path": "Industry > Metals > Iron Steel",
-              "acts_on_labels": [
-                "coal usage within iron and steel industries",
-                "natural gas usage within iron and steel industries"
-              ],
-              "shifts_to_labels": [
-                "electricity usage within iron and steel industries"
-              ],
-              "score": 0.4924
-            },
-            {
-              "stable_id": "coal_fired_power_plants",
-              "short_label": "T-5A1-TE-1 - Electricity from coal power plants",
-              "description": "Electricity from coal power plants. Alter the amount of electricity produced by coal fired power plants. from: coal fired power plants. Energy > Energy Supply > Electricity",
-              "sector_path": "Energy > Energy Supply > Electricity",
-              "acts_on_labels": [
-                "coal fired power plants"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.4867
-            },
-            {
-              "stable_id": "hydro_reservoir",
-              "short_label": "T-5A1-TE-6 - Electricity from hydro reservoir",
-              "description": "Electricity from hydro reservoir. Alter the amount of electricity produced by hydro reservoir. from: hydro reservoir. Energy > Energy Supply > Electricity",
-              "sector_path": "Energy > Energy Supply > Electricity",
-              "acts_on_labels": [
-                "hydro reservoir"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.4821
-            },
-            {
-              "stable_id": "gas_fired_power_plants",
-              "short_label": "T-5A1-TE-2 - Electricity from gas power plants",
-              "description": "Electricity from gas power plants. Alter the amount of electricity produced by gas fired power plants. from: gas fired power plants. Energy > Energy Supply > Electricity",
-              "sector_path": "Energy > Energy Supply > Electricity",
-              "acts_on_labels": [
-                "gas fired power plants"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.4792
-            },
-            {
-              "stable_id": "oil_fired_power_plants",
-              "short_label": "T-5A1-TE-5 - Electricity from oil power plants",
-              "description": "Electricity from oil power plants. Alter the amount of electricity produced by oil fired power plants. from: oil fired power plants. Energy > Energy Supply > Electricity",
-              "sector_path": "Energy > Energy Supply > Electricity",
-              "acts_on_labels": [
-                "oil fired power plants"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.4743
-            },
-            {
-              "stable_id": "chp_biofuels",
-              "short_label": "T-5A3-TE-5 - CHP from biomass",
-              "description": "CHP from biomass. Alter the amount of district heat and electricity produced by CHP biofuels. from: chp biofuels. Energy > Energy Supply > Combined Heat Power",
-              "sector_path": "Energy > Energy Supply > Combined Heat Power",
-              "acts_on_labels": [
-                "chp biofuels"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.468
-            },
-            {
-              "stable_id": "increased_energy_recovery_from_waste",
-              "short_label": "T-5A3-TE-6 - Increased energy recovery from waste",
-              "description": "Increased energy recovery from waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to CHP waste incineration in tonne to fulfill the need of warm premisses. from: incineration and open burning of waste. to: chp waste incineration. Energy > Energy Supply > Combined Heat Power",
-              "sector_path": "Energy > Energy Supply > Combined Heat Power",
-              "acts_on_labels": [
-                "incineration and open burning of waste"
-              ],
-              "shifts_to_labels": [
-                "chp waste incineration"
-              ],
-              "score": 0.4648
-            },
-            {
-              "stable_id": "chp_coal",
-              "short_label": "T-5A3-TE-1 - CHP from coal",
-              "description": "CHP from coal. Alter the amount of district heat and electricity produced by CHP coal. from: chp coal. Energy > Energy Supply > Combined Heat Power",
-              "sector_path": "Energy > Energy Supply > Combined Heat Power",
-              "acts_on_labels": [
-                "chp coal"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.4499
-            }
-          ]
-        }
-      ],
-      "intervention_who": "none",
-      "intervention_when": "none",
-      "intervention_what": "increase renewable energy sources",
-      "intervention_how": "none",
-      "intervention_score": 2,
-      "intervention_reasoning": "What is weakly present, but no specific actor, timeline, or mechanism is provided.",
-      "intervention_type": "indirect"
-    },
-    {
-      "measure_text": "130.All el som köps in av kommunkoncernen ska komma från förnybara källor.",
-      "activity": "electricity procurement",
-      "activity_shift_score": 6,
-      "activity_shifts": [
-        {
-          "activity": "procuring electricity",
-          "shift_from": "using non-renewable sources for electricity",
-          "shift_to": "using renewable sources for electricity",
-          "need": "electricity provision",
-          "type": "Resource Shift",
-          "type_reasoning": "The measure specifies a shift to renewable sources for electricity procurement, which is a change in the resource used.",
-          "score": 6,
-          "reasoning": "Activity, shift_from, shift_to, and need are all identifiable.",
-          "transition_element_matches": [],
-          "transition_element_suggested_new": {
-            "short_label": "shift_to_renewable_electricity_in_municipal_operations",
-            "description": "Shift from non-renewable to renewable electricity sources in municipal operations and procurement"
+          {
+            "stable_id": "shift_to_heat_pumps_in_district_heating",
+            "short_label": "T-5A2-TE-5 - Shift to heat pumps in district heating",
+            "description": "Shift to heat pumps in district heating. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: chp coal, chp natural gas, chp oil. to: district heating heat pumps. Energy > Energy Supply > Heat",
+            "sector_path": "Energy > Energy Supply > Heat",
+            "acts_on_labels": ["chp coal", "chp natural gas", "chp oil"],
+            "shifts_to_labels": ["district heating heat pumps"],
+            "score": 0.3613
           },
-          "transition_element_candidates": [
-            {
-              "stable_id": "shift_to_electricity_in_hydrogen_refinement",
-              "short_label": "T-5B4-TE-5 - Shift to electricity in hydrogen refinement",
-              "description": "Shift to electricity in hydrogen refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within hydrogen refinement, natural gas usage within hydrogen refinement. to: electricity usage within hydrogen refinement. Energy > Energy Transformation > Hydrogen Refinement",
-              "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
-              "acts_on_labels": [
-                "coal usage within hydrogen refinement",
-                "natural gas usage within hydrogen refinement"
-              ],
-              "shifts_to_labels": [
-                "electricity usage within hydrogen refinement"
-              ],
-              "score": 0.5552
-            },
-            {
-              "stable_id": "shift_to_electricity_in_chemical_industries",
-              "short_label": "T-2B9-TE-3 - Shift to electricity in chemical industries",
-              "description": "Shift to electricity in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within chemical industries, natural gas usage within chemical industries. to: electricity usage within chemical industries. Industry > Chemicals > Other",
-              "sector_path": "Industry > Chemicals > Other",
-              "acts_on_labels": [
-                "coal usage within chemical industries",
-                "natural gas usage within chemical industries"
-              ],
-              "shifts_to_labels": [
-                "electricity usage within chemical industries"
-              ],
-              "score": 0.5421
-            },
-            {
-              "stable_id": "shift_to_electricity_in_glass_industries",
-              "short_label": "T-2A3-TE-3 - Shift to electricity in glass industries",
-              "description": "Shift to electricity in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within glass industries, oil usage within glass industries, natural gas usage within glass industries. to: electricity usage within glass industries. Industry > Minerals > Glass Production",
-              "sector_path": "Industry > Minerals > Glass Production",
-              "acts_on_labels": [
-                "coal usage within glass industries",
-                "oil usage within glass industries",
-                "natural gas usage within glass industries"
-              ],
-              "shifts_to_labels": [
-                "electricity usage within glass industries"
-              ],
-              "score": 0.537
-            },
-            {
-              "stable_id": "shift_to_electricity_in_other_industries",
-              "short_label": "T-2D5-TE-3 - Shift to electricity in other industries",
-              "description": "Shift to electricity in other industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: industrial unregulated coal use, industrial unregulated oil use, industrial unregulated gas use. to: industrial unregulated electricity use. Industry > Other > Other",
-              "sector_path": "Industry > Other > Other",
-              "acts_on_labels": [
-                "industrial unregulated coal use",
-                "industrial unregulated oil use",
-                "industrial unregulated gas use"
-              ],
-              "shifts_to_labels": [
-                "industrial unregulated electricity use"
-              ],
-              "score": 0.5368
-            },
-            {
-              "stable_id": "shift_to_electricity_in_iron_and_steel_industries",
-              "short_label": "T-2C1-TE-4 - Shift to electricity in iron and steel industries",
-              "description": "Shift to electricity in iron and steel industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within iron and steel industries, natural gas usage within iron and steel industries. to: electricity usage within iron and steel industries. Industry > Metals > Iron Steel",
-              "sector_path": "Industry > Metals > Iron Steel",
-              "acts_on_labels": [
-                "coal usage within iron and steel industries",
-                "natural gas usage within iron and steel industries"
-              ],
-              "shifts_to_labels": [
-                "electricity usage within iron and steel industries"
-              ],
-              "score": 0.5329
-            },
-            {
-              "stable_id": "shift_to_electrolysis_of_water_for_hydrogen_production",
-              "short_label": "T-5B4-TE-6 - Shift to electrolysis of water for hydrogen production",
-              "description": "Shift to electrolysis of water for hydrogen production. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: reforming of methane for hydrogen production, gasification of carbon for hydrogen production. to: electrolysis of water for hydrogen production. Energy > Energy Transformation > Hydrogen Refinement",
-              "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
-              "acts_on_labels": [
-                "reforming of methane for hydrogen production",
-                "gasification of carbon for hydrogen production"
-              ],
-              "shifts_to_labels": [
-                "electrolysis of water for hydrogen production"
-              ],
-              "score": 0.5236
-            },
-            {
-              "stable_id": "shift_to_electric_passenger_rail",
-              "short_label": "T-1A2-TE-2 - Shift to travel by electric rail",
-              "description": "Shift to travel by electric rail. Shift person kilometer from diesel passenger rail to electric passenger rail in person kilometer to fulfill the need of mobility. from: diesel passenger rail. to: electric rail. Transport > Mobility > Rail",
-              "sector_path": "Transport > Mobility > Rail",
-              "acts_on_labels": [
-                "diesel passenger rail"
-              ],
-              "shifts_to_labels": [
-                "electric rail"
-              ],
-              "score": 0.5149
-            },
-            {
-              "stable_id": "shift_to_electricity_in_lead_industries",
-              "short_label": "T-2C5-TE-3 - Shift to electricity in lead industries",
-              "description": "Shift to electricity in lead industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within lead industries, oil usage within lead industries, natural gas usage within lead industries. to: electricity usage within lead industries. Industry > Metals > Lead",
-              "sector_path": "Industry > Metals > Lead",
-              "acts_on_labels": [
-                "coal usage within lead industries",
-                "oil usage within lead industries",
-                "natural gas usage within lead industries"
-              ],
-              "shifts_to_labels": [
-                "electricity usage within lead industries"
-              ],
-              "score": 0.5145
-            },
-            {
-              "stable_id": "shift_to_residential_electric_cooking_stoves",
-              "short_label": "T-4A2d-TE-2 - Shift to residential electric cooking stoves",
-              "description": "Shift to residential electric cooking stoves. Shift kWh from residential cooking gas stoves to residential electric cooking stoves in kWh to fullfill the need for cooking. from: residential gas cooking stoves. to: residential electric cooking stoves. Buildings > Residential > Other Energy Usage > Unregulated",
-              "sector_path": "Buildings > Residential > Other Energy Usage > Unregulated",
-              "acts_on_labels": [
-                "residential gas cooking stoves"
-              ],
-              "shifts_to_labels": [
-                "residential electric cooking stoves"
-              ],
-              "score": 0.5138
-            },
-            {
-              "stable_id": "shift_to_electricity_in_pulp_paper_and_print_industries",
-              "short_label": "T-2D1b-TE-3 - Shift to electricity in pulp, paper and print industries",
-              "description": "Shift to electricity in pulp, paper and print industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within pulp paper and print industries, oil usage within pulp paper and print industries, natural gas usage within pulp paper and print industries. to: electricity usage within pulp paper and print industries. Industry > Other > Manufacturing > Pulp Paper Print",
-              "sector_path": "Industry > Other > Manufacturing > Pulp Paper Print",
-              "acts_on_labels": [
-                "coal usage within pulp paper and print industries",
-                "oil usage within pulp paper and print industries",
-                "natural gas usage within pulp paper and print industries"
-              ],
-              "shifts_to_labels": [
-                "electricity usage within pulp paper and print industries"
-              ],
-              "score": 0.5136
-            },
-            {
-              "stable_id": "solar_rooftops",
-              "short_label": "T-5A1-TE-8 - Electricity from solar rooftops",
-              "description": "Electricity from solar rooftops. Alter the amount of electricity produced by solar rooftops. from: solar rooftops. Energy > Energy Supply > Electricity",
-              "sector_path": "Energy > Energy Supply > Electricity",
-              "acts_on_labels": [
-                "solar rooftops"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.4866
-            },
-            {
-              "stable_id": "improved_grid_electricity",
-              "short_label": "T-5A1-TE-3 - Improved Grid Electricity",
-              "description": "Improved Grid Electricity. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: grid current. to: grid future. Energy > Energy Supply > Electricity",
-              "sector_path": "Energy > Energy Supply > Electricity",
-              "acts_on_labels": [
-                "grid current"
-              ],
-              "shifts_to_labels": [
-                "grid future"
-              ],
-              "score": 0.4847
-            },
-            {
-              "stable_id": "wind_onshore",
-              "short_label": "T-5A1-TE-10 - Electricity from wind onshore",
-              "description": "Electricity from wind onshore. Alter the amount of electricity produced by wind onshore. from: wind onshore. Energy > Energy Supply > Electricity",
-              "sector_path": "Energy > Energy Supply > Electricity",
-              "acts_on_labels": [
-                "wind onshore"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.4835
-            },
-            {
-              "stable_id": "solar_parks",
-              "short_label": "T-5A1-TE-7 - Electricity from solar parks",
-              "description": "Electricity from solar parks. Alter the amount of electricity produced by solar parks. from: solar parks. Energy > Energy Supply > Electricity",
-              "sector_path": "Energy > Energy Supply > Electricity",
-              "acts_on_labels": [
-                "solar parks"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.4814
-            },
-            {
-              "stable_id": "wind_offshore",
-              "short_label": "T-5A1-TE-9 - Electricity from wind offshore",
-              "description": "Electricity from wind offshore. Alter the amount of electricity produced by wind offshore. from: wind offshore. Energy > Energy Supply > Electricity",
-              "sector_path": "Energy > Energy Supply > Electricity",
-              "acts_on_labels": [
-                "wind offshore"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.4759
-            },
-            {
-              "stable_id": "biofuel_fired_power_plants",
-              "short_label": "T-5A1-TE-11 - Electricity from biomass power plants",
-              "description": "Electricity from biomass power plants. Alter the amount of electricity produced by biofuel fired power plants. from: biofuel fired powerplants. Energy > Energy Supply > Electricity",
-              "sector_path": "Energy > Energy Supply > Electricity",
-              "acts_on_labels": [
-                "biofuel fired powerplants"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.4755
-            },
-            {
-              "stable_id": "coal_fired_power_plants",
-              "short_label": "T-5A1-TE-1 - Electricity from coal power plants",
-              "description": "Electricity from coal power plants. Alter the amount of electricity produced by coal fired power plants. from: coal fired power plants. Energy > Energy Supply > Electricity",
-              "sector_path": "Energy > Energy Supply > Electricity",
-              "acts_on_labels": [
-                "coal fired power plants"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.4738
-            },
-            {
-              "stable_id": "gas_fired_power_plants",
-              "short_label": "T-5A1-TE-2 - Electricity from gas power plants",
-              "description": "Electricity from gas power plants. Alter the amount of electricity produced by gas fired power plants. from: gas fired power plants. Energy > Energy Supply > Electricity",
-              "sector_path": "Energy > Energy Supply > Electricity",
-              "acts_on_labels": [
-                "gas fired power plants"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.4646
-            },
-            {
-              "stable_id": "oil_fired_power_plants",
-              "short_label": "T-5A1-TE-5 - Electricity from oil power plants",
-              "description": "Electricity from oil power plants. Alter the amount of electricity produced by oil fired power plants. from: oil fired power plants. Energy > Energy Supply > Electricity",
-              "sector_path": "Energy > Energy Supply > Electricity",
-              "acts_on_labels": [
-                "oil fired power plants"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.4608
-            },
-            {
-              "stable_id": "hydro_reservoir",
-              "short_label": "T-5A1-TE-6 - Electricity from hydro reservoir",
-              "description": "Electricity from hydro reservoir. Alter the amount of electricity produced by hydro reservoir. from: hydro reservoir. Energy > Energy Supply > Electricity",
-              "sector_path": "Energy > Energy Supply > Electricity",
-              "acts_on_labels": [
-                "hydro reservoir"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.4591
-            }
-          ]
-        }
-      ],
-      "intervention_who": "kommunkoncernen",
-      "intervention_when": "none",
-      "intervention_what": "procure renewable electricity",
-      "intervention_how": "none",
-      "intervention_score": 3,
-      "intervention_reasoning": "Who and what are present, but when and how are not specified.",
-      "intervention_type": "direct"
-    },
-    {
-      "measure_text": "131.Användningen av energi, mark, vatten och andra naturresurser ska ske på ett effektivt, resursbesparande och miljöanpassat sätt.",
-      "activity": "resource use",
-      "activity_shift_score": 2,
-      "activity_shifts": [
-        {
-          "activity": "using resources",
-          "shift_from": "none",
-          "shift_to": "using resources efficiently and sustainably",
-          "need": "resource management",
-          "type": "Resource Efficiency Shift",
-          "type_reasoning": "The measure suggests a shift towards more efficient and sustainable use of resources, which is a resource efficiency improvement.",
-          "score": 2,
-          "reasoning": "The shift is faintly implied, but neither shift_from nor shift_to is clearly identifiable.",
-          "transition_element_matches": [
-            {
-              "stable_id": "energy_efficient_other_agriculture_forestry_fishing_electric_appliances",
-              "short_label": "T-3C6-TE-1 - Energy efficient agriculture, forestry and fishing electrical appliances",
-              "description": "Energy efficient agriculture, forestry and fishing electrical appliances. Reduce the amount of energy required to operate agriculture, forestry and fishing electrical appliances. from: agriculture forestry fishing unregulated electricity use. Afolu > Aggregate Sources Other > Other",
-              "sector_path": "Afolu > Aggregate Sources Other > Other",
-              "acts_on_labels": [
-                "agriculture forestry fishing unregulated electricity use"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.3578,
-              "match_reasoning": "acts_on=yes, shifts_to=empty, confidence=mid",
-              "match_confidence": "mid"
-            },
-            {
-              "stable_id": "energy_efficient_other_institutional_electric_appliances",
-              "short_label": "T-4B2c-TE-3 - Energy efficient public electrical appliances",
-              "description": "Energy efficient public electrical appliances. Reduce the amount of energy required to operate institutional electrical appliances. from: institutional unregulated electricity use. Buildings > Non Residential > Other Energy Usage > Other",
-              "sector_path": "Buildings > Non Residential > Other Energy Usage > Other",
-              "acts_on_labels": [
-                "institutional unregulated electricity use"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.3356,
-              "match_reasoning": "acts_on=yes, shifts_to=empty, confidence=mid",
-              "match_confidence": "mid"
-            },
-            {
-              "stable_id": "efficient_use_of_mobile_machinery",
-              "short_label": "T-2D4-TE-3 - Efficient use of mobile machinery",
-              "description": "Efficient use of mobile machinery. Reduce the amount of energy required to operate diesel, petrol, biofuel,. from: mobile machinery biofuel, mobile machinery electricity, mobile machinery diesel, mobile machinery petrol, mobile machinery lpg, mobile machinery cng. Industry > Other > Mobile Machinery",
-              "sector_path": "Industry > Other > Mobile Machinery",
-              "acts_on_labels": [
-                "mobile machinery biofuel",
-                "mobile machinery electricity",
-                "mobile machinery diesel",
-                "mobile machinery petrol",
-                "mobile machinery lpg",
-                "mobile machinery cng"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.3264,
-              "match_reasoning": "acts_on=yes, shifts_to=empty, confidence=mid",
-              "match_confidence": "mid"
-            },
-            {
-              "stable_id": "energy_efficient_other_industrial_electric_appliances",
-              "short_label": "T-4B2c-TE-2 - Energy efficient industrial electrical appliances",
-              "description": "Energy efficient industrial electrical appliances. Reduce the amount of energy required to operate industrial electrical appliances. from: industrial unregulated electricity use. Buildings > Non Residential > Other Energy Usage > Other",
-              "sector_path": "Buildings > Non Residential > Other Energy Usage > Other",
-              "acts_on_labels": [
-                "industrial unregulated electricity use"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.3203,
-              "match_reasoning": "acts_on=yes, shifts_to=empty, confidence=mid",
-              "match_confidence": "mid"
-            }
-          ],
-          "transition_element_suggested_new": {
-            "short_label": "Efficient Resource Use",
-            "description": "Shift to efficient and sustainable use of energy, land, water, and other natural resources."
+          {
+            "stable_id": "shift_to_hydrogen_energy_in_chemical_industries",
+            "short_label": "T-2B9-TE-4 - Shift to hydrogen energy in chemical industries",
+            "description": "Shift to hydrogen energy in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within chemical industries. to: hydrogen usage within chemical industries. Industry > Chemicals > Other",
+            "sector_path": "Industry > Chemicals > Other",
+            "acts_on_labels": ["natural gas usage within chemical industries"],
+            "shifts_to_labels": ["hydrogen usage within chemical industries"],
+            "score": 0.3606
           },
-          "transition_element_candidates": [
-            {
-              "stable_id": "shift_to_sustainable_healthy_diet",
-              "short_label": "T-3A1-TE-1 - Shift to Sustainable Healthy Diets",
-              "description": "Shift to Sustainable Healthy Diets. This Transition Element is the shift from animal based diets to plant based diets.. from: enteric fermentation cattle, enteric fermentation sheep, enteric fermentation swine, enteric fermentation other livestock. Afolu > Livestock > Enteric Fermentation",
-              "sector_path": "Afolu > Livestock > Enteric Fermentation",
-              "acts_on_labels": [
-                "enteric fermentation cattle",
-                "enteric fermentation sheep",
-                "enteric fermentation swine",
-                "enteric fermentation other livestock"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.4938
-            },
-            {
-              "stable_id": "increased_recycling",
-              "short_label": "T-6A1-TE-1 - Shift to recycling of solid waste",
-              "description": "Shift to recycling of solid waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to recycling of solid waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: recycling of solid waste. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc",
-                "incineration and open burning of waste",
-                "open burning of waste",
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "shifts_to_labels": [
-                "recycling of solid waste"
-              ],
-              "score": 0.4488
-            },
-            {
-              "stable_id": "shift_to_biomass_energy_in_hydrogen_refinement",
-              "short_label": "T-5B4-TE-4 - Shift to biomass energy in hydrogen refinement",
-              "description": "Shift to biomass energy in hydrogen refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within hydrogen refinement. to: biomass usage within hydrogen refinement. Energy > Energy Transformation > Hydrogen Refinement",
-              "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
-              "acts_on_labels": [
-                "coal usage within hydrogen refinement"
-              ],
-              "shifts_to_labels": [
-                "biomass usage within hydrogen refinement"
-              ],
-              "score": 0.4388
-            },
-            {
-              "stable_id": "shift_to_biomass_energy_in_lead_industries",
-              "short_label": "T-2C5-TE-2 - Shift to biomass energy in lead industries",
-              "description": "Shift to biomass energy in lead industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within lead industries. to: biomass usage within lead industries. Industry > Metals > Lead",
-              "sector_path": "Industry > Metals > Lead",
-              "acts_on_labels": [
-                "coal usage within lead industries"
-              ],
-              "shifts_to_labels": [
-                "biomass usage within lead industries"
-              ],
-              "score": 0.433
-            },
-            {
-              "stable_id": "shift_to_biomass_energy_in_magnesium_industries",
-              "short_label": "T-2C4-TE-3 - Shift to biomass energy in magnesium industries",
-              "description": "Shift to biomass energy in magnesium industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within magnesium industries. to: biomass usage within magnesium industries. Industry > Metals > Magnesium",
-              "sector_path": "Industry > Metals > Magnesium",
-              "acts_on_labels": [
-                "coal usage within magnesium industries"
-              ],
-              "shifts_to_labels": [
-                "biomass usage within magnesium industries"
-              ],
-              "score": 0.4268
-            },
-            {
-              "stable_id": "shift_to_biomass_energy_in_petroleum_refinement",
-              "short_label": "T-5B1-TE-1 - Shift to biomass energy in petroleum refinement",
-              "description": "Shift to biomass energy in petroleum refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: crude oil usage within petroleum refinement. to: biomass usage within petroleum refinement. Energy > Energy Transformation > Petroleum Refinement",
-              "sector_path": "Energy > Energy Transformation > Petroleum Refinement",
-              "acts_on_labels": [
-                "crude oil usage within petroleum refinement"
-              ],
-              "shifts_to_labels": [
-                "biomass usage within petroleum refinement"
-              ],
-              "score": 0.4252
-            },
-            {
-              "stable_id": "shift_to_biomass_energy_in_glass_industries",
-              "short_label": "T-2A3-TE-2 - Shift to biomass energy in glass industries",
-              "description": "Shift to biomass energy in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within glass industries. to: biomass usage within glass industries. Industry > Minerals > Glass Production",
-              "sector_path": "Industry > Minerals > Glass Production",
-              "acts_on_labels": [
-                "coal usage within glass industries"
-              ],
-              "shifts_to_labels": [
-                "biomass usage within glass industries"
-              ],
-              "score": 0.4223
-            },
-            {
-              "stable_id": "shift_to_biomass_energy_in_chemical_industries",
-              "short_label": "T-2B9-TE-2 - Shift to biomass energy in chemical industries",
-              "description": "Shift to biomass energy in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within chemical industries. to: biomass usage within chemical industries. Industry > Chemicals > Other",
-              "sector_path": "Industry > Chemicals > Other",
-              "acts_on_labels": [
-                "coal usage within chemical industries"
-              ],
-              "shifts_to_labels": [
-                "biomass usage within chemical industries"
-              ],
-              "score": 0.4222
-            },
-            {
-              "stable_id": "biofuels_for_cement_and_mineral_industry",
-              "short_label": "T-2A1-TE-1 - Shift to use biofuel in cement and mineral industry",
-              "description": "Shift to use biofuel in cement and mineral industry. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: cement mineral industries coal usage. to: cement mineral industries biomass usage. Industry > Minerals > Cement",
-              "sector_path": "Industry > Minerals > Cement",
-              "acts_on_labels": [
-                "cement mineral industries coal usage"
-              ],
-              "shifts_to_labels": [
-                "cement mineral industries biomass usage"
-              ],
-              "score": 0.4215
-            },
-            {
-              "stable_id": "shift_to_biomass_energy_in_iron_and_steel_industries",
-              "short_label": "T-2C1-TE-2 - Shift to biomass energy in iron and steel industries",
-              "description": "Shift to biomass energy in iron and steel industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within iron and steel industries. to: biomass usage within iron and steel industries. Industry > Metals > Iron Steel",
-              "sector_path": "Industry > Metals > Iron Steel",
-              "acts_on_labels": [
-                "coal usage within iron and steel industries"
-              ],
-              "shifts_to_labels": [
-                "biomass usage within iron and steel industries"
-              ],
-              "score": 0.4193
-            },
-            {
-              "stable_id": "energy_efficient_other_agriculture_forestry_fishing_electric_appliances",
-              "short_label": "T-3C6-TE-1 - Energy efficient agriculture, forestry and fishing electrical appliances",
-              "description": "Energy efficient agriculture, forestry and fishing electrical appliances. Reduce the amount of energy required to operate agriculture, forestry and fishing electrical appliances. from: agriculture forestry fishing unregulated electricity use. Afolu > Aggregate Sources Other > Other",
-              "sector_path": "Afolu > Aggregate Sources Other > Other",
-              "acts_on_labels": [
-                "agriculture forestry fishing unregulated electricity use"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.3578
-            },
-            {
-              "stable_id": "energy_efficient_other_institutional_electric_appliances",
-              "short_label": "T-4B2c-TE-3 - Energy efficient public electrical appliances",
-              "description": "Energy efficient public electrical appliances. Reduce the amount of energy required to operate institutional electrical appliances. from: institutional unregulated electricity use. Buildings > Non Residential > Other Energy Usage > Other",
-              "sector_path": "Buildings > Non Residential > Other Energy Usage > Other",
-              "acts_on_labels": [
-                "institutional unregulated electricity use"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.3356
-            },
-            {
-              "stable_id": "energy_efficient_new_housing",
-              "short_label": "T-4A1-TE-1 - Energy efficient new Housing",
-              "description": "Energy efficient new Housing. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: heating of new residential single family buildings, heating of new residential multi family buildings. Buildings > Residential > Hvac",
-              "sector_path": "Buildings > Residential > Hvac",
-              "acts_on_labels": [
-                "heating of new residential single family buildings",
-                "heating of new residential multi family buildings"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.3311
-            },
-            {
-              "stable_id": "efficient_use_of_mobile_machinery",
-              "short_label": "T-2D4-TE-3 - Efficient use of mobile machinery",
-              "description": "Efficient use of mobile machinery. Reduce the amount of energy required to operate diesel, petrol, biofuel,. from: mobile machinery biofuel, mobile machinery electricity, mobile machinery diesel, mobile machinery petrol, mobile machinery lpg, mobile machinery cng. Industry > Other > Mobile Machinery",
-              "sector_path": "Industry > Other > Mobile Machinery",
-              "acts_on_labels": [
-                "mobile machinery biofuel",
-                "mobile machinery electricity",
-                "mobile machinery diesel",
-                "mobile machinery petrol",
-                "mobile machinery lpg",
-                "mobile machinery cng"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.3264
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_hydrogen_refinement",
-              "short_label": "T-5B4-TE-3 - Shift to biogas energy in hydrogen refinement",
-              "description": "Shift to biogas energy in hydrogen refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within hydrogen refinement. to: biogas usage within hydrogen refinement. Energy > Energy Transformation > Hydrogen Refinement",
-              "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
-              "acts_on_labels": [
-                "natural gas usage within hydrogen refinement"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within hydrogen refinement"
-              ],
-              "score": 0.3228
-            },
-            {
-              "stable_id": "increased_energy_recovery_from_waste",
-              "short_label": "T-5A3-TE-6 - Increased energy recovery from waste",
-              "description": "Increased energy recovery from waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to CHP waste incineration in tonne to fulfill the need of warm premisses. from: incineration and open burning of waste. to: chp waste incineration. Energy > Energy Supply > Combined Heat Power",
-              "sector_path": "Energy > Energy Supply > Combined Heat Power",
-              "acts_on_labels": [
-                "incineration and open burning of waste"
-              ],
-              "shifts_to_labels": [
-                "chp waste incineration"
-              ],
-              "score": 0.3216
-            },
-            {
-              "stable_id": "energy_efficient_other_industrial_electric_appliances",
-              "short_label": "T-4B2c-TE-2 - Energy efficient industrial electrical appliances",
-              "description": "Energy efficient industrial electrical appliances. Reduce the amount of energy required to operate industrial electrical appliances. from: industrial unregulated electricity use. Buildings > Non Residential > Other Energy Usage > Other",
-              "sector_path": "Buildings > Non Residential > Other Energy Usage > Other",
-              "acts_on_labels": [
-                "industrial unregulated electricity use"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.3203
-            },
-            {
-              "stable_id": "ecodriving_of_cars",
-              "short_label": "T-1A1a-TE-3 - Ecodriving of cars",
-              "description": "Ecodriving of cars. Reduce the amount of energy required to drive petrol, diesel, LPG and natural gas vehicles through ecodriving. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles, hydrogen vehicles. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles",
-                "lpg vehicles",
-                "gas vehicles",
-                "hydrogen vehicles"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.3194
-            }
-          ]
-        }
-      ],
-      "intervention_who": "none",
-      "intervention_when": "none",
-      "intervention_what": "use resources efficiently",
-      "intervention_how": "none",
-      "intervention_score": 1,
-      "intervention_reasoning": "No specific action, responsible actor, timeline, or mechanism is provided.",
-      "intervention_type": "none"
-    },
-    {
-      "measure_text": "132.Förvaltning av tätortsnära natur ska ske genom att värna kommunens ansvarsarter* och hotade arter genom ett nyskapande av deras behov av naturmiljöer vid varje större åtgärd på natur- och parkmark.",
-      "activity": "nature management",
-      "activity_shift_score": 2,
-      "activity_shifts": [
-        {
-          "activity": "managing nature",
-          "shift_from": "none",
-          "shift_to": "protecting species through habitat creation",
-          "need": "biodiversity conservation",
-          "type": "Type Shift",
-          "type_reasoning": "The measure implies a shift towards creating habitats for species, which is a change in the method of nature management.",
-          "score": 2,
-          "reasoning": "The shift is faintly implied, but neither shift_from nor shift_to is clearly identifiable.",
-          "transition_element_matches": [],
-          "transition_element_suggested_new": {
-            "short_label": "Habitat Creation for Biodiversity Conservation",
-            "description": "Managing urban nature by creating habitats to protect species and enhance biodiversity."
+          {
+            "stable_id": "shift_to_biogas_energy_in_hydrogen_refinement",
+            "short_label": "T-5B4-TE-3 - Shift to biogas energy in hydrogen refinement",
+            "description": "Shift to biogas energy in hydrogen refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within hydrogen refinement. to: biogas usage within hydrogen refinement. Energy > Energy Transformation > Hydrogen Refinement",
+            "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
+            "acts_on_labels": ["natural gas usage within hydrogen refinement"],
+            "shifts_to_labels": ["biogas usage within hydrogen refinement"],
+            "score": 0.3599
           },
-          "transition_element_candidates": [
-            {
-              "stable_id": "shift_to_sustainable_healthy_diet",
-              "short_label": "T-3A1-TE-1 - Shift to Sustainable Healthy Diets",
-              "description": "Shift to Sustainable Healthy Diets. This Transition Element is the shift from animal based diets to plant based diets.. from: enteric fermentation cattle, enteric fermentation sheep, enteric fermentation swine, enteric fermentation other livestock. Afolu > Livestock > Enteric Fermentation",
-              "sector_path": "Afolu > Livestock > Enteric Fermentation",
-              "acts_on_labels": [
-                "enteric fermentation cattle",
-                "enteric fermentation sheep",
-                "enteric fermentation swine",
-                "enteric fermentation other livestock"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.3671
-            },
-            {
-              "stable_id": "shift_to_electric_bikes",
-              "short_label": "T-1A1a-TE-11 - Shift to electric bikes",
-              "description": "Shift to electric bikes. Shift vehicle kilometer from petrol,diesel and LPG vehicles to electric bike in vehicle kilometer to fulfill the need of mobility. from: petrol vehicles, diesel vehicles, lpg vehicles. to: electric bikes. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles",
-                "lpg vehicles"
-              ],
-              "shifts_to_labels": [
-                "electric bikes"
-              ],
-              "score": 0.3448
-            },
-            {
-              "stable_id": "increased_proportion_of_walking_and_cycling",
-              "short_label": "T-1A1a-TE-10 - Shift to walking and cycling",
-              "description": "Shift to walking and cycling. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to walking cycling. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: walking cycling. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles",
-                "lpg vehicles",
-                "gas vehicles"
-              ],
-              "shifts_to_labels": [
-                "walking cycling"
-              ],
-              "score": 0.3295
-            },
-            {
-              "stable_id": "increased_proportion_of_public_transport_by_petrol_bus",
-              "short_label": "T-1A1a-TE-16 - Shift to travel by petrol bus",
-              "description": "Shift to travel by petrol bus. Shift vehicle kilometer from petrol and diesel vehicles to petrol buses. from: petrol vehicles, diesel vehicles. to: petrol buses. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles"
-              ],
-              "shifts_to_labels": [
-                "petrol buses"
-              ],
-              "score": 0.3197
-            },
-            {
-              "stable_id": "shift_to_biomass_energy_in_lead_industries",
-              "short_label": "T-2C5-TE-2 - Shift to biomass energy in lead industries",
-              "description": "Shift to biomass energy in lead industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within lead industries. to: biomass usage within lead industries. Industry > Metals > Lead",
-              "sector_path": "Industry > Metals > Lead",
-              "acts_on_labels": [
-                "coal usage within lead industries"
-              ],
-              "shifts_to_labels": [
-                "biomass usage within lead industries"
-              ],
-              "score": 0.3151
-            },
-            {
-              "stable_id": "shift_to_electric_vehicles",
-              "short_label": "T-1A1a-TE-1 - Shift to electric cars",
-              "description": "Shift to electric cars. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to battery electric vehicles in vehicle kilometer to fulfill the need of mobility. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: battery electric vehicles. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles",
-                "lpg vehicles",
-                "gas vehicles"
-              ],
-              "shifts_to_labels": [
-                "battery electric vehicles"
-              ],
-              "score": 0.3085
-            },
-            {
-              "stable_id": "shift_to_hydrogen_vehicles",
-              "short_label": "T-1A1a-TE-2 - Shift to hydrogen cars",
-              "description": "Shift to hydrogen cars. Shift vehicle kilometer from petrol and diesel vehicles to hydrogen vehicles in vehicle kilometer to fulfill the need of mobility. from: petrol vehicles, diesel vehicles. to: hydrogen vehicles. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles"
-              ],
-              "shifts_to_labels": [
-                "hydrogen vehicles"
-              ],
-              "score": 0.3079
-            },
-            {
-              "stable_id": "shift_to_biomass_energy_in_petroleum_refinement",
-              "short_label": "T-5B1-TE-1 - Shift to biomass energy in petroleum refinement",
-              "description": "Shift to biomass energy in petroleum refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: crude oil usage within petroleum refinement. to: biomass usage within petroleum refinement. Energy > Energy Transformation > Petroleum Refinement",
-              "sector_path": "Energy > Energy Transformation > Petroleum Refinement",
-              "acts_on_labels": [
-                "crude oil usage within petroleum refinement"
-              ],
-              "shifts_to_labels": [
-                "biomass usage within petroleum refinement"
-              ],
-              "score": 0.3078
-            },
-            {
-              "stable_id": "increased_proportion_of_commuting_by_electric_bus",
-              "short_label": "T-1A1a-TE-12 - Shift to travel by electric bus",
-              "description": "Shift to travel by electric bus. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to electric bus. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: electric bus. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles",
-                "lpg vehicles",
-                "gas vehicles"
-              ],
-              "shifts_to_labels": [
-                "electric bus"
-              ],
-              "score": 0.307
-            },
-            {
-              "stable_id": "shift_to_biomass_energy_in_hydrogen_refinement",
-              "short_label": "T-5B4-TE-4 - Shift to biomass energy in hydrogen refinement",
-              "description": "Shift to biomass energy in hydrogen refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within hydrogen refinement. to: biomass usage within hydrogen refinement. Energy > Energy Transformation > Hydrogen Refinement",
-              "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
-              "acts_on_labels": [
-                "coal usage within hydrogen refinement"
-              ],
-              "shifts_to_labels": [
-                "biomass usage within hydrogen refinement"
-              ],
-              "score": 0.3064
-            },
-            {
-              "stable_id": "shift_to_composting_of_organic_waste",
-              "short_label": "T-6A1-TE-2 - Shift to composting of organic waste",
-              "description": "Shift to composting of organic waste. Shift tonne from solid waste disposal in landfills to composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: composting of organic waste. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc",
-                "incineration and open burning of waste",
-                "open burning of waste",
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "shifts_to_labels": [
-                "composting of organic waste"
-              ],
-              "score": 0.2161
-            },
-            {
-              "stable_id": "energy_efficient_other_agriculture_forestry_fishing_electric_appliances",
-              "short_label": "T-3C6-TE-1 - Energy efficient agriculture, forestry and fishing electrical appliances",
-              "description": "Energy efficient agriculture, forestry and fishing electrical appliances. Reduce the amount of energy required to operate agriculture, forestry and fishing electrical appliances. from: agriculture forestry fishing unregulated electricity use. Afolu > Aggregate Sources Other > Other",
-              "sector_path": "Afolu > Aggregate Sources Other > Other",
-              "acts_on_labels": [
-                "agriculture forestry fishing unregulated electricity use"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.2147
-            },
-            {
-              "stable_id": "shift_to_biomass_energy_in_glass_industries",
-              "short_label": "T-2A3-TE-2 - Shift to biomass energy in glass industries",
-              "description": "Shift to biomass energy in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within glass industries. to: biomass usage within glass industries. Industry > Minerals > Glass Production",
-              "sector_path": "Industry > Minerals > Glass Production",
-              "acts_on_labels": [
-                "coal usage within glass industries"
-              ],
-              "shifts_to_labels": [
-                "biomass usage within glass industries"
-              ],
-              "score": 0.2136
-            },
-            {
-              "stable_id": "biogas_in_methane_reforming_for_hydrogen_production",
-              "short_label": "T-5B4-TE-1 - Biogas in methane reforming for hydrogen production",
-              "description": "Biogas in methane reforming for hydrogen production. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: reforming of methane for hydrogen production. Energy > Energy Transformation > Hydrogen Refinement",
-              "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
-              "acts_on_labels": [
-                "reforming of methane for hydrogen production"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.2135
-            },
-            {
-              "stable_id": "increased_recycling",
-              "short_label": "T-6A1-TE-1 - Shift to recycling of solid waste",
-              "description": "Shift to recycling of solid waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to recycling of solid waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: recycling of solid waste. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc",
-                "incineration and open burning of waste",
-                "open burning of waste",
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "shifts_to_labels": [
-                "recycling of solid waste"
-              ],
-              "score": 0.2113
-            },
-            {
-              "stable_id": "low_carbon_construction_of_non_residential_commercial_buildings",
-              "short_label": "T-4C1-TE-3 - Low carbon construction of commercial buildings",
-              "description": "Low carbon construction of commercial buildings. Shift square meter from non residential commercial standard construction to non residential commercial low carbon construction in square meter to fulfill the need of housing. from: non residential commercial standard construction. to: non residential commercial low carbon construction. Buildings > Building Stocks > Construction",
-              "sector_path": "Buildings > Building Stocks > Construction",
-              "acts_on_labels": [
-                "non residential commercial standard construction"
-              ],
-              "shifts_to_labels": [
-                "non residential commercial low carbon construction"
-              ],
-              "score": 0.2113
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_hydrogen_refinement",
-              "short_label": "T-5B4-TE-3 - Shift to biogas energy in hydrogen refinement",
-              "description": "Shift to biogas energy in hydrogen refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within hydrogen refinement. to: biogas usage within hydrogen refinement. Energy > Energy Transformation > Hydrogen Refinement",
-              "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
-              "acts_on_labels": [
-                "natural gas usage within hydrogen refinement"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within hydrogen refinement"
-              ],
-              "score": 0.2102
-            },
-            {
-              "stable_id": "biofuels_for_cement_and_mineral_industry",
-              "short_label": "T-2A1-TE-1 - Shift to use biofuel in cement and mineral industry",
-              "description": "Shift to use biofuel in cement and mineral industry. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: cement mineral industries coal usage. to: cement mineral industries biomass usage. Industry > Minerals > Cement",
-              "sector_path": "Industry > Minerals > Cement",
-              "acts_on_labels": [
-                "cement mineral industries coal usage"
-              ],
-              "shifts_to_labels": [
-                "cement mineral industries biomass usage"
-              ],
-              "score": 0.2097
-            },
-            {
-              "stable_id": "energy_efficient_new_housing",
-              "short_label": "T-4A1-TE-1 - Energy efficient new Housing",
-              "description": "Energy efficient new Housing. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: heating of new residential single family buildings, heating of new residential multi family buildings. Buildings > Residential > Hvac",
-              "sector_path": "Buildings > Residential > Hvac",
-              "acts_on_labels": [
-                "heating of new residential single family buildings",
-                "heating of new residential multi family buildings"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.2092
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_glass_industries",
-              "short_label": "T-2A3-TE-1 - Shift to biogas energy in glass industries",
-              "description": "Shift to biogas energy in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within glass industries. to: biogas usage within glass industries. Industry > Minerals > Glass Production",
-              "sector_path": "Industry > Minerals > Glass Production",
-              "acts_on_labels": [
-                "natural gas usage within glass industries"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within glass industries"
-              ],
-              "score": 0.2054
-            },
-            {
-              "stable_id": "shift_to_biomass_energy_in_other_industries",
-              "short_label": "T-2D5-TE-1 - Shift to biomass energy in other industries",
-              "description": "Shift to biomass energy in other industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: industrial unregulated coal use. to: industrial unregulated biomass use. Industry > Other > Other",
-              "sector_path": "Industry > Other > Other",
-              "acts_on_labels": [
-                "industrial unregulated coal use"
-              ],
-              "shifts_to_labels": [
-                "industrial unregulated biomass use"
-              ],
-              "score": 0.2024
-            }
-          ]
-        }
-      ],
-      "intervention_who": "none",
-      "intervention_when": "none",
-      "intervention_what": "protect species through habitat creation",
-      "intervention_how": "none",
-      "intervention_score": 1,
-      "intervention_reasoning": "No specific action, responsible actor, timeline, or mechanism is provided.",
-      "intervention_type": "none"
-    },
-    {
-      "measure_text": "133.Vattenkvaliteten och den fysiska miljön i sjöar och vattendrag behöver förbättras. Det innebär att 85 procent av vattnen i kommunen som omfattas av vattenförvaltningens statusklassning (så kallade ytvattenförekomster*) ska uppnå miljökvalitetsnormerna god status både när det gäller ekologiska och kemiska värden. Vattenanvändningen ska effektiviseras och vattenförsörjningen ska vara klimatanpassad, säker och trygg.",
-      "activity": "water management",
-      "activity_shift_score": 3,
-      "activity_shifts": [
-        {
-          "activity": "managing water",
-          "shift_from": "none",
-          "shift_to": "improving water quality and efficiency",
-          "need": "water management",
-          "type": "Resource Efficiency Shift",
-          "type_reasoning": "The measure suggests improving water quality and efficiency, which is a resource efficiency improvement.",
-          "score": 3,
-          "reasoning": "Activity and shift_to are identifiable, but shift_from is not clearly specified.",
-          "transition_element_matches": [],
-          "transition_element_suggested_new": {
-            "short_label": "Water Quality and Efficiency Improvement",
-            "description": "Focus on improving water quality and efficiency in municipal water management systems."
+          {
+            "stable_id": "shift_to_biomass_energy_in_hydrogen_refinement",
+            "short_label": "T-5B4-TE-4 - Shift to biomass energy in hydrogen refinement",
+            "description": "Shift to biomass energy in hydrogen refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within hydrogen refinement. to: biomass usage within hydrogen refinement. Energy > Energy Transformation > Hydrogen Refinement",
+            "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
+            "acts_on_labels": ["coal usage within hydrogen refinement"],
+            "shifts_to_labels": ["biomass usage within hydrogen refinement"],
+            "score": 0.3594
           },
-          "transition_element_candidates": [
-            {
-              "stable_id": "shift_to_electrolysis_of_water_for_hydrogen_production",
-              "short_label": "T-5B4-TE-6 - Shift to electrolysis of water for hydrogen production",
-              "description": "Shift to electrolysis of water for hydrogen production. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: reforming of methane for hydrogen production, gasification of carbon for hydrogen production. to: electrolysis of water for hydrogen production. Energy > Energy Transformation > Hydrogen Refinement",
-              "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
-              "acts_on_labels": [
-                "reforming of methane for hydrogen production",
-                "gasification of carbon for hydrogen production"
-              ],
-              "shifts_to_labels": [
-                "electrolysis of water for hydrogen production"
-              ],
-              "score": 0.4429
-            },
-            {
-              "stable_id": "shift_to_sustainable_healthy_diet",
-              "short_label": "T-3A1-TE-1 - Shift to Sustainable Healthy Diets",
-              "description": "Shift to Sustainable Healthy Diets. This Transition Element is the shift from animal based diets to plant based diets.. from: enteric fermentation cattle, enteric fermentation sheep, enteric fermentation swine, enteric fermentation other livestock. Afolu > Livestock > Enteric Fermentation",
-              "sector_path": "Afolu > Livestock > Enteric Fermentation",
-              "acts_on_labels": [
-                "enteric fermentation cattle",
-                "enteric fermentation sheep",
-                "enteric fermentation swine",
-                "enteric fermentation other livestock"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.4094
-            },
-            {
-              "stable_id": "increased_recycling",
-              "short_label": "T-6A1-TE-1 - Shift to recycling of solid waste",
-              "description": "Shift to recycling of solid waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to recycling of solid waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: recycling of solid waste. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc",
-                "incineration and open burning of waste",
-                "open burning of waste",
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "shifts_to_labels": [
-                "recycling of solid waste"
-              ],
-              "score": 0.4035
-            },
-            {
-              "stable_id": "shift_to_hydrogen_energy_in_chemical_industries",
-              "short_label": "T-2B9-TE-4 - Shift to hydrogen energy in chemical industries",
-              "description": "Shift to hydrogen energy in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within chemical industries. to: hydrogen usage within chemical industries. Industry > Chemicals > Other",
-              "sector_path": "Industry > Chemicals > Other",
-              "acts_on_labels": [
-                "natural gas usage within chemical industries"
-              ],
-              "shifts_to_labels": [
-                "hydrogen usage within chemical industries"
-              ],
-              "score": 0.399
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_hydrogen_refinement",
-              "short_label": "T-5B4-TE-3 - Shift to biogas energy in hydrogen refinement",
-              "description": "Shift to biogas energy in hydrogen refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within hydrogen refinement. to: biogas usage within hydrogen refinement. Energy > Energy Transformation > Hydrogen Refinement",
-              "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
-              "acts_on_labels": [
-                "natural gas usage within hydrogen refinement"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within hydrogen refinement"
-              ],
-              "score": 0.3964
-            },
-            {
-              "stable_id": "electrification_of_domestic_sea_passenger_transport",
-              "short_label": "T-1A4-TE-5 - Shift to electric marine passenger transportion",
-              "description": "Shift to electric marine passenger transportion. Shift person kilometer from ship passenger to electric shipping passenger in person kilometer to fulfill the need of mobility. from: ship passenger, gas oil shipping passenger. to: electric shipping passenger. Transport > Mobility > Waterborne",
-              "sector_path": "Transport > Mobility > Waterborne",
-              "acts_on_labels": [
-                "ship passenger",
-                "gas oil shipping passenger"
-              ],
-              "shifts_to_labels": [
-                "electric shipping passenger"
-              ],
-              "score": 0.3949
-            },
-            {
-              "stable_id": "shift_to_electricity_in_hydrogen_refinement",
-              "short_label": "T-5B4-TE-5 - Shift to electricity in hydrogen refinement",
-              "description": "Shift to electricity in hydrogen refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within hydrogen refinement, natural gas usage within hydrogen refinement. to: electricity usage within hydrogen refinement. Energy > Energy Transformation > Hydrogen Refinement",
-              "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
-              "acts_on_labels": [
-                "coal usage within hydrogen refinement",
-                "natural gas usage within hydrogen refinement"
-              ],
-              "shifts_to_labels": [
-                "electricity usage within hydrogen refinement"
-              ],
-              "score": 0.3912
-            },
-            {
-              "stable_id": "shift_to_biomass_energy_in_hydrogen_refinement",
-              "short_label": "T-5B4-TE-4 - Shift to biomass energy in hydrogen refinement",
-              "description": "Shift to biomass energy in hydrogen refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within hydrogen refinement. to: biomass usage within hydrogen refinement. Energy > Energy Transformation > Hydrogen Refinement",
-              "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
-              "acts_on_labels": [
-                "coal usage within hydrogen refinement"
-              ],
-              "shifts_to_labels": [
-                "biomass usage within hydrogen refinement"
-              ],
-              "score": 0.3905
-            },
-            {
-              "stable_id": "shift_to_composting_of_organic_waste",
-              "short_label": "T-6A1-TE-2 - Shift to composting of organic waste",
-              "description": "Shift to composting of organic waste. Shift tonne from solid waste disposal in landfills to composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: composting of organic waste. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc",
-                "incineration and open burning of waste",
-                "open burning of waste",
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "shifts_to_labels": [
-                "composting of organic waste"
-              ],
-              "score": 0.3832
-            },
-            {
-              "stable_id": "shift_to_hydrogen_vehicles",
-              "short_label": "T-1A1a-TE-2 - Shift to hydrogen cars",
-              "description": "Shift to hydrogen cars. Shift vehicle kilometer from petrol and diesel vehicles to hydrogen vehicles in vehicle kilometer to fulfill the need of mobility. from: petrol vehicles, diesel vehicles. to: hydrogen vehicles. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles"
-              ],
-              "shifts_to_labels": [
-                "hydrogen vehicles"
-              ],
-              "score": 0.3807
-            },
-            {
-              "stable_id": "energy_efficient_other_agriculture_forestry_fishing_electric_appliances",
-              "short_label": "T-3C6-TE-1 - Energy efficient agriculture, forestry and fishing electrical appliances",
-              "description": "Energy efficient agriculture, forestry and fishing electrical appliances. Reduce the amount of energy required to operate agriculture, forestry and fishing electrical appliances. from: agriculture forestry fishing unregulated electricity use. Afolu > Aggregate Sources Other > Other",
-              "sector_path": "Afolu > Aggregate Sources Other > Other",
-              "acts_on_labels": [
-                "agriculture forestry fishing unregulated electricity use"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.3472
-            },
-            {
-              "stable_id": "energy_efficient_other_institutional_electric_appliances",
-              "short_label": "T-4B2c-TE-3 - Energy efficient public electrical appliances",
-              "description": "Energy efficient public electrical appliances. Reduce the amount of energy required to operate institutional electrical appliances. from: institutional unregulated electricity use. Buildings > Non Residential > Other Energy Usage > Other",
-              "sector_path": "Buildings > Non Residential > Other Energy Usage > Other",
-              "acts_on_labels": [
-                "institutional unregulated electricity use"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.3127
-            },
-            {
-              "stable_id": "energy_efficient_other_industrial_electric_appliances",
-              "short_label": "T-4B2c-TE-2 - Energy efficient industrial electrical appliances",
-              "description": "Energy efficient industrial electrical appliances. Reduce the amount of energy required to operate industrial electrical appliances. from: industrial unregulated electricity use. Buildings > Non Residential > Other Energy Usage > Other",
-              "sector_path": "Buildings > Non Residential > Other Energy Usage > Other",
-              "acts_on_labels": [
-                "industrial unregulated electricity use"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.3081
-            },
-            {
-              "stable_id": "energy_efficient_new_housing",
-              "short_label": "T-4A1-TE-1 - Energy efficient new Housing",
-              "description": "Energy efficient new Housing. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: heating of new residential single family buildings, heating of new residential multi family buildings. Buildings > Residential > Hvac",
-              "sector_path": "Buildings > Residential > Hvac",
-              "acts_on_labels": [
-                "heating of new residential single family buildings",
-                "heating of new residential multi family buildings"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.284
-            },
-            {
-              "stable_id": "energy_efficient_non_residential_public_buildings_retrofitting_cooling",
-              "short_label": "T-4B1b-TE-7 - Retrofitting public buildings for efficient cooling",
-              "description": "Retrofitting public buildings for efficient cooling. Reduce the amount of energy required to cool public building with AC and disitrct cooling through retrofitting. from: public building cooling with ac, public building cooling with district cooling. Buildings > Non Residential > Hvac > Institutional Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
-              "acts_on_labels": [
-                "public building cooling with ac",
-                "public building cooling with district cooling"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.2834
-            },
-            {
-              "stable_id": "efficient_use_multi_family_residential_buildings_cooling",
-              "short_label": "T-4A1a-TE-7 - Energy efficient use of ACs in multi-family buildings",
-              "description": "Energy efficient use of ACs in multi-family buildings. Reduce the amount of energy required to cool multi family buildings with AC through efficient use of AC units. from: multi family building cooling with ac. Buildings > Residential > Hvac > Multi Family Hvac",
-              "sector_path": "Buildings > Residential > Hvac > Multi Family Hvac",
-              "acts_on_labels": [
-                "multi family building cooling with ac"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.2834
-            },
-            {
-              "stable_id": "energy_efficient_street_lighting",
-              "short_label": "T-4B2a-TE-1 - Energy efficient street lighting",
-              "description": "Energy efficient street lighting. Reduce the amount of energy required to operate street lighting. from: institutional electric street lighting. Buildings > Non Residential > Other Energy Usage > Lighting",
-              "sector_path": "Buildings > Non Residential > Other Energy Usage > Lighting",
-              "acts_on_labels": [
-                "institutional electric street lighting"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.2828
-            },
-            {
-              "stable_id": "energy_efficient_multi_family_residential_buildings_cooling",
-              "short_label": "T-4A1a-TE-8 - Energy efficient AC in multi-family buildings",
-              "description": "Energy efficient AC in multi-family buildings. Reduce the amount of energy required to cool multi family buildings with AC through more efficient AC units. from: multi family building cooling with ac. Buildings > Residential > Hvac > Multi Family Hvac",
-              "sector_path": "Buildings > Residential > Hvac > Multi Family Hvac",
-              "acts_on_labels": [
-                "multi family building cooling with ac"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.2783
-            },
-            {
-              "stable_id": "energy_efficient_other_commercial_electric_appliances",
-              "short_label": "T-4B2c-TE-1 - Energy efficient commercial electrical appliances",
-              "description": "Energy efficient commercial electrical appliances. Reduce the amount of energy required to operate commercial electrical appliances. from: commercial unregulated electricity use. Buildings > Non Residential > Other Energy Usage > Other",
-              "sector_path": "Buildings > Non Residential > Other Energy Usage > Other",
-              "acts_on_labels": [
-                "commercial unregulated electricity use"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.2759
-            },
-            {
-              "stable_id": "hydro_reservoir",
-              "short_label": "T-5A1-TE-6 - Electricity from hydro reservoir",
-              "description": "Electricity from hydro reservoir. Alter the amount of electricity produced by hydro reservoir. from: hydro reservoir. Energy > Energy Supply > Electricity",
-              "sector_path": "Energy > Energy Supply > Electricity",
-              "acts_on_labels": [
-                "hydro reservoir"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.2747
-            },
-            {
-              "stable_id": "more_efficient_sea_passenger_transportation",
-              "short_label": "T-1A4-TE-2 - More efficient marine passenger transport",
-              "description": "More efficient marine passenger transport. Reduce the amount of energy required to operate diesel, LNG passenger shipping through more more efficient sea passenger transportation. from: ship passenger, gas oil shipping passenger, electric shipping passenger, lng shipping passenger. Transport > Mobility > Waterborne",
-              "sector_path": "Transport > Mobility > Waterborne",
-              "acts_on_labels": [
-                "ship passenger",
-                "gas oil shipping passenger",
-                "electric shipping passenger",
-                "lng shipping passenger"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.2739
-            },
-            {
-              "stable_id": "biogas_in_methane_reforming_for_hydrogen_production",
-              "short_label": "T-5B4-TE-1 - Biogas in methane reforming for hydrogen production",
-              "description": "Biogas in methane reforming for hydrogen production. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: reforming of methane for hydrogen production. Energy > Energy Transformation > Hydrogen Refinement",
-              "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
-              "acts_on_labels": [
-                "reforming of methane for hydrogen production"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.2717
-            },
-            {
-              "stable_id": "energy_efficient_multi_family_residential_buildings_retrofitting_cooling",
-              "short_label": "T-4A1a-TE-9 - Retrofitting multi-family buildings for efficient cooling",
-              "description": "Retrofitting multi-family buildings for efficient cooling. Reduce the amount of energy required to cool multi family building with AC and disitrct cooling through retrofitting. from: multi family building cooling with ac, multi family building cooling with district cooling. Buildings > Residential > Hvac > Multi Family Hvac",
-              "sector_path": "Buildings > Residential > Hvac > Multi Family Hvac",
-              "acts_on_labels": [
-                "multi family building cooling with ac",
-                "multi family building cooling with district cooling"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.2703
-            }
-          ]
-        }
-      ],
-      "intervention_who": "none",
-      "intervention_when": "none",
-      "intervention_what": "improve water quality and efficiency",
-      "intervention_how": "none",
-      "intervention_score": 2,
-      "intervention_reasoning": "What is weakly present, but no specific actor, timeline, or mechanism is provided.",
-      "intervention_type": "indirect"
-    },
-    {
-      "measure_text": "134.Grundvattenförekomster, både befintliga och de som är utpekade som intressanta för framtiden, ska uppnå en god kemisk och kvalitativ status. Det innebär att vattnet ska ha god kvalitet och vattenmängden ska vara stabil.",
-      "activity": "groundwater management",
-      "activity_shift_score": 3,
-      "activity_shifts": [
-        {
-          "activity": "managing groundwater",
-          "shift_from": "none",
-          "shift_to": "achieving good chemical and qualitative status",
-          "need": "water management",
-          "type": "Resource Efficiency Shift",
-          "type_reasoning": "The measure suggests achieving good status for groundwater, which is a resource efficiency improvement.",
-          "score": 3,
-          "reasoning": "Activity and shift_to are identifiable, but shift_from is not clearly specified.",
-          "transition_element_matches": [],
-          "transition_element_suggested_new": {
-            "short_label": "Shift to sustainable groundwater management",
-            "description": "Implement measures to ensure groundwater achieves good chemical and qualitative status, focusing on water quality and stable water quantity."
+          {
+            "stable_id": "shift_to_biomass_energy_in_chemical_industries",
+            "short_label": "T-2B9-TE-2 - Shift to biomass energy in chemical industries",
+            "description": "Shift to biomass energy in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within chemical industries. to: biomass usage within chemical industries. Industry > Chemicals > Other",
+            "sector_path": "Industry > Chemicals > Other",
+            "acts_on_labels": ["coal usage within chemical industries"],
+            "shifts_to_labels": ["biomass usage within chemical industries"],
+            "score": 0.3575
           },
-          "transition_element_candidates": [
-            {
-              "stable_id": "shift_to_hydrogen_energy_in_chemical_industries",
-              "short_label": "T-2B9-TE-4 - Shift to hydrogen energy in chemical industries",
-              "description": "Shift to hydrogen energy in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within chemical industries. to: hydrogen usage within chemical industries. Industry > Chemicals > Other",
-              "sector_path": "Industry > Chemicals > Other",
-              "acts_on_labels": [
-                "natural gas usage within chemical industries"
-              ],
-              "shifts_to_labels": [
-                "hydrogen usage within chemical industries"
-              ],
-              "score": 0.396
-            },
-            {
-              "stable_id": "shift_to_sustainable_healthy_diet",
-              "short_label": "T-3A1-TE-1 - Shift to Sustainable Healthy Diets",
-              "description": "Shift to Sustainable Healthy Diets. This Transition Element is the shift from animal based diets to plant based diets.. from: enteric fermentation cattle, enteric fermentation sheep, enteric fermentation swine, enteric fermentation other livestock. Afolu > Livestock > Enteric Fermentation",
-              "sector_path": "Afolu > Livestock > Enteric Fermentation",
-              "acts_on_labels": [
-                "enteric fermentation cattle",
-                "enteric fermentation sheep",
-                "enteric fermentation swine",
-                "enteric fermentation other livestock"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.3918
-            },
-            {
-              "stable_id": "shift_to_electricity_in_chemical_industries",
-              "short_label": "T-2B9-TE-3 - Shift to electricity in chemical industries",
-              "description": "Shift to electricity in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within chemical industries, natural gas usage within chemical industries. to: electricity usage within chemical industries. Industry > Chemicals > Other",
-              "sector_path": "Industry > Chemicals > Other",
-              "acts_on_labels": [
-                "coal usage within chemical industries",
-                "natural gas usage within chemical industries"
-              ],
-              "shifts_to_labels": [
-                "electricity usage within chemical industries"
-              ],
-              "score": 0.3859
-            },
-            {
-              "stable_id": "shift_to_biomass_energy_in_chemical_industries",
-              "short_label": "T-2B9-TE-2 - Shift to biomass energy in chemical industries",
-              "description": "Shift to biomass energy in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within chemical industries. to: biomass usage within chemical industries. Industry > Chemicals > Other",
-              "sector_path": "Industry > Chemicals > Other",
-              "acts_on_labels": [
-                "coal usage within chemical industries"
-              ],
-              "shifts_to_labels": [
-                "biomass usage within chemical industries"
-              ],
-              "score": 0.3828
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_chemical_industries",
-              "short_label": "T-2B9-TE-1 - Shift to biogas energy in chemical industries",
-              "description": "Shift to biogas energy in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within chemical industries. to: biogas usage within chemical industries. Industry > Chemicals > Other",
-              "sector_path": "Industry > Chemicals > Other",
-              "acts_on_labels": [
-                "natural gas usage within chemical industries"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within chemical industries"
-              ],
-              "score": 0.3813
-            },
-            {
-              "stable_id": "shift_to_electrolysis_of_water_for_hydrogen_production",
-              "short_label": "T-5B4-TE-6 - Shift to electrolysis of water for hydrogen production",
-              "description": "Shift to electrolysis of water for hydrogen production. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: reforming of methane for hydrogen production, gasification of carbon for hydrogen production. to: electrolysis of water for hydrogen production. Energy > Energy Transformation > Hydrogen Refinement",
-              "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
-              "acts_on_labels": [
-                "reforming of methane for hydrogen production",
-                "gasification of carbon for hydrogen production"
-              ],
-              "shifts_to_labels": [
-                "electrolysis of water for hydrogen production"
-              ],
-              "score": 0.3788
-            },
-            {
-              "stable_id": "electrification_of_domestic_sea_passenger_transport",
-              "short_label": "T-1A4-TE-5 - Shift to electric marine passenger transportion",
-              "description": "Shift to electric marine passenger transportion. Shift person kilometer from ship passenger to electric shipping passenger in person kilometer to fulfill the need of mobility. from: ship passenger, gas oil shipping passenger. to: electric shipping passenger. Transport > Mobility > Waterborne",
-              "sector_path": "Transport > Mobility > Waterborne",
-              "acts_on_labels": [
-                "ship passenger",
-                "gas oil shipping passenger"
-              ],
-              "shifts_to_labels": [
-                "electric shipping passenger"
-              ],
-              "score": 0.3757
-            },
-            {
-              "stable_id": "shift_to_hydrogen_vehicles",
-              "short_label": "T-1A1a-TE-2 - Shift to hydrogen cars",
-              "description": "Shift to hydrogen cars. Shift vehicle kilometer from petrol and diesel vehicles to hydrogen vehicles in vehicle kilometer to fulfill the need of mobility. from: petrol vehicles, diesel vehicles. to: hydrogen vehicles. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles"
-              ],
-              "shifts_to_labels": [
-                "hydrogen vehicles"
-              ],
-              "score": 0.3669
-            },
-            {
-              "stable_id": "increased_proportion_of_walking_and_cycling",
-              "short_label": "T-1A1a-TE-10 - Shift to walking and cycling",
-              "description": "Shift to walking and cycling. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to walking cycling. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: walking cycling. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles",
-                "lpg vehicles",
-                "gas vehicles"
-              ],
-              "shifts_to_labels": [
-                "walking cycling"
-              ],
-              "score": 0.3644
-            },
-            {
-              "stable_id": "increased_recycling",
-              "short_label": "T-6A1-TE-1 - Shift to recycling of solid waste",
-              "description": "Shift to recycling of solid waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to recycling of solid waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: recycling of solid waste. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc",
-                "incineration and open burning of waste",
-                "open burning of waste",
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "shifts_to_labels": [
-                "recycling of solid waste"
-              ],
-              "score": 0.3621
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_hydrogen_refinement",
-              "short_label": "T-5B4-TE-3 - Shift to biogas energy in hydrogen refinement",
-              "description": "Shift to biogas energy in hydrogen refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within hydrogen refinement. to: biogas usage within hydrogen refinement. Energy > Energy Transformation > Hydrogen Refinement",
-              "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
-              "acts_on_labels": [
-                "natural gas usage within hydrogen refinement"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within hydrogen refinement"
-              ],
-              "score": 0.272
-            },
-            {
-              "stable_id": "shift_to_landfill_gas_recovery",
-              "short_label": "T-6A1-TE-4 - Shift to landfill gas recovery",
-              "description": "Shift to landfill gas recovery. Shift tonne from solid waste disposal in landfills without gas recovery to solid waste disposal in landfills with landfill gas recovery in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc. to: solid waste disposal landfill with gas recovery. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc"
-              ],
-              "shifts_to_labels": [
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "score": 0.2673
-            },
-            {
-              "stable_id": "biogas_in_methane_reforming_for_hydrogen_production",
-              "short_label": "T-5B4-TE-1 - Biogas in methane reforming for hydrogen production",
-              "description": "Biogas in methane reforming for hydrogen production. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: reforming of methane for hydrogen production. Energy > Energy Transformation > Hydrogen Refinement",
-              "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
-              "acts_on_labels": [
-                "reforming of methane for hydrogen production"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.2624
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_magnesium_industries",
-              "short_label": "T-2C4-TE-2 - Shift to biogas energy in magnesium industries",
-              "description": "Shift to biogas energy in magnesium industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within magnesium industries. to: biogas usage within magnesium industries. Industry > Metals > Magnesium",
-              "sector_path": "Industry > Metals > Magnesium",
-              "acts_on_labels": [
-                "natural gas usage within magnesium industries"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within magnesium industries"
-              ],
-              "score": 0.2581
-            },
-            {
-              "stable_id": "shift_to_hydrogen_energy_in_glass_industries",
-              "short_label": "T-2A3-TE-4 - Shift to hydrogen energy in glass industries",
-              "description": "Shift to hydrogen energy in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within glass industries. to: hydrogen usage within glass industries. Industry > Minerals > Glass Production",
-              "sector_path": "Industry > Minerals > Glass Production",
-              "acts_on_labels": [
-                "natural gas usage within glass industries"
-              ],
-              "shifts_to_labels": [
-                "hydrogen usage within glass industries"
-              ],
-              "score": 0.254
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_glass_industries",
-              "short_label": "T-2A3-TE-1 - Shift to biogas energy in glass industries",
-              "description": "Shift to biogas energy in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within glass industries. to: biogas usage within glass industries. Industry > Minerals > Glass Production",
-              "sector_path": "Industry > Minerals > Glass Production",
-              "acts_on_labels": [
-                "natural gas usage within glass industries"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within glass industries"
-              ],
-              "score": 0.2524
-            },
-            {
-              "stable_id": "shift_to_composting_of_organic_waste",
-              "short_label": "T-6A1-TE-2 - Shift to composting of organic waste",
-              "description": "Shift to composting of organic waste. Shift tonne from solid waste disposal in landfills to composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: composting of organic waste. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc",
-                "incineration and open burning of waste",
-                "open burning of waste",
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "shifts_to_labels": [
-                "composting of organic waste"
-              ],
-              "score": 0.2503
-            },
-            {
-              "stable_id": "biogas_in_methane_reforming_for_ammonia_production",
-              "short_label": "T-2B1-TE-1 - Biogas in methane reforming for ammonia production",
-              "description": "Biogas in methane reforming for ammonia production. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: reforming of methane for ammonia production. Industry > Chemicals > Ammonia Production",
-              "sector_path": "Industry > Chemicals > Ammonia Production",
-              "acts_on_labels": [
-                "reforming of methane for ammonia production"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.2487
-            },
-            {
-              "stable_id": "shift_to_biomass_energy_in_hydrogen_refinement",
-              "short_label": "T-5B4-TE-4 - Shift to biomass energy in hydrogen refinement",
-              "description": "Shift to biomass energy in hydrogen refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within hydrogen refinement. to: biomass usage within hydrogen refinement. Energy > Energy Transformation > Hydrogen Refinement",
-              "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
-              "acts_on_labels": [
-                "coal usage within hydrogen refinement"
-              ],
-              "shifts_to_labels": [
-                "biomass usage within hydrogen refinement"
-              ],
-              "score": 0.2454
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_lead_industries",
-              "short_label": "T-2C5-TE-1 - Shift to biogas energy in lead industries",
-              "description": "Shift to biogas energy in lead industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within lead industries. to: biogas usage within lead industries. Industry > Metals > Lead",
-              "sector_path": "Industry > Metals > Lead",
-              "acts_on_labels": [
-                "natural gas usage within lead industries"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within lead industries"
-              ],
-              "score": 0.2429
-            }
-          ]
-        }
-      ],
-      "intervention_who": "none",
-      "intervention_when": "none",
-      "intervention_what": "achieve good groundwater status",
-      "intervention_how": "none",
-      "intervention_score": 2,
-      "intervention_reasoning": "What is weakly present, but no specific actor, timeline, or mechanism is provided.",
-      "intervention_type": "indirect"
-    },
-    {
-      "measure_text": "135.Kommunen ska arbeta för att minska utsläpp av kemikalier (bland annat mikroplaster, svårbrytbara kemiska föreningar och läkemedelsrester) för att värna vattnet.",
-      "activity": "chemical emissions management",
-      "activity_shift_score": 3,
-      "activity_shifts": [
-        {
-          "activity": "managing chemical emissions",
-          "shift_from": "none",
-          "shift_to": "reducing chemical emissions",
-          "need": "water protection",
-          "type": "Type Shift",
-          "type_reasoning": "The measure implies a shift towards reducing chemical emissions, which is a change in the method of managing chemical emissions.",
-          "score": 3,
-          "reasoning": "Activity and shift_to are identifiable, but shift_from is not clearly specified.",
-          "transition_element_matches": [],
-          "transition_element_suggested_new": {
-            "short_label": "Reduce Chemical Emissions",
-            "description": "Focus on reducing emissions of microplastics, persistent chemical compounds, and pharmaceutical residues to protect water resources."
+          {
+            "stable_id": "shift_to_biofuel_in_district_heating",
+            "short_label": "T-5A3-TE-7 - Shift to biofuel in district heating",
+            "description": "Shift to biofuel in district heating. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: chp coal, chp natural gas, chp oil. to: chp biofuels. Energy > Energy Supply > Combined Heat Power",
+            "sector_path": "Energy > Energy Supply > Combined Heat Power",
+            "acts_on_labels": ["chp coal", "chp natural gas", "chp oil"],
+            "shifts_to_labels": ["chp biofuels"],
+            "score": 0.355
           },
-          "transition_element_candidates": [
-            {
-              "stable_id": "shift_to_hydrogen_energy_in_chemical_industries",
-              "short_label": "T-2B9-TE-4 - Shift to hydrogen energy in chemical industries",
-              "description": "Shift to hydrogen energy in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within chemical industries. to: hydrogen usage within chemical industries. Industry > Chemicals > Other",
-              "sector_path": "Industry > Chemicals > Other",
-              "acts_on_labels": [
-                "natural gas usage within chemical industries"
-              ],
-              "shifts_to_labels": [
-                "hydrogen usage within chemical industries"
-              ],
-              "score": 0.5344
-            },
-            {
-              "stable_id": "shift_to_electricity_in_chemical_industries",
-              "short_label": "T-2B9-TE-3 - Shift to electricity in chemical industries",
-              "description": "Shift to electricity in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within chemical industries, natural gas usage within chemical industries. to: electricity usage within chemical industries. Industry > Chemicals > Other",
-              "sector_path": "Industry > Chemicals > Other",
-              "acts_on_labels": [
-                "coal usage within chemical industries",
-                "natural gas usage within chemical industries"
-              ],
-              "shifts_to_labels": [
-                "electricity usage within chemical industries"
-              ],
-              "score": 0.5312
-            },
-            {
-              "stable_id": "shift_to_biomass_energy_in_chemical_industries",
-              "short_label": "T-2B9-TE-2 - Shift to biomass energy in chemical industries",
-              "description": "Shift to biomass energy in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within chemical industries. to: biomass usage within chemical industries. Industry > Chemicals > Other",
-              "sector_path": "Industry > Chemicals > Other",
-              "acts_on_labels": [
-                "coal usage within chemical industries"
-              ],
-              "shifts_to_labels": [
-                "biomass usage within chemical industries"
-              ],
-              "score": 0.5074
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_chemical_industries",
-              "short_label": "T-2B9-TE-1 - Shift to biogas energy in chemical industries",
-              "description": "Shift to biogas energy in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within chemical industries. to: biogas usage within chemical industries. Industry > Chemicals > Other",
-              "sector_path": "Industry > Chemicals > Other",
-              "acts_on_labels": [
-                "natural gas usage within chemical industries"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within chemical industries"
-              ],
-              "score": 0.5003
-            },
-            {
-              "stable_id": "shift_to_electrolysis_of_water_for_hydrogen_production",
-              "short_label": "T-5B4-TE-6 - Shift to electrolysis of water for hydrogen production",
-              "description": "Shift to electrolysis of water for hydrogen production. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: reforming of methane for hydrogen production, gasification of carbon for hydrogen production. to: electrolysis of water for hydrogen production. Energy > Energy Transformation > Hydrogen Refinement",
-              "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
-              "acts_on_labels": [
-                "reforming of methane for hydrogen production",
-                "gasification of carbon for hydrogen production"
-              ],
-              "shifts_to_labels": [
-                "electrolysis of water for hydrogen production"
-              ],
-              "score": 0.4825
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_lead_industries",
-              "short_label": "T-2C5-TE-1 - Shift to biogas energy in lead industries",
-              "description": "Shift to biogas energy in lead industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within lead industries. to: biogas usage within lead industries. Industry > Metals > Lead",
-              "sector_path": "Industry > Metals > Lead",
-              "acts_on_labels": [
-                "natural gas usage within lead industries"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within lead industries"
-              ],
-              "score": 0.4539
-            },
-            {
-              "stable_id": "shift_to_hydrogen_energy_in_glass_industries",
-              "short_label": "T-2A3-TE-4 - Shift to hydrogen energy in glass industries",
-              "description": "Shift to hydrogen energy in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within glass industries. to: hydrogen usage within glass industries. Industry > Minerals > Glass Production",
-              "sector_path": "Industry > Minerals > Glass Production",
-              "acts_on_labels": [
-                "natural gas usage within glass industries"
-              ],
-              "shifts_to_labels": [
-                "hydrogen usage within glass industries"
-              ],
-              "score": 0.4461
-            },
-            {
-              "stable_id": "shift_to_sustainable_healthy_diet",
-              "short_label": "T-3A1-TE-1 - Shift to Sustainable Healthy Diets",
-              "description": "Shift to Sustainable Healthy Diets. This Transition Element is the shift from animal based diets to plant based diets.. from: enteric fermentation cattle, enteric fermentation sheep, enteric fermentation swine, enteric fermentation other livestock. Afolu > Livestock > Enteric Fermentation",
-              "sector_path": "Afolu > Livestock > Enteric Fermentation",
-              "acts_on_labels": [
-                "enteric fermentation cattle",
-                "enteric fermentation sheep",
-                "enteric fermentation swine",
-                "enteric fermentation other livestock"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.4427
-            },
-            {
-              "stable_id": "shift_to_hydrogen_energy_in_pulp_paper_and_print_industries",
-              "short_label": "T-2D1b-TE-4 - Shift to hydrogen energy in pulp, paper and print industries",
-              "description": "Shift to hydrogen energy in pulp, paper and print industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within pulp paper and print industries. to: hydrogen usage within pulp paper and print industries. Industry > Other > Manufacturing > Pulp Paper Print",
-              "sector_path": "Industry > Other > Manufacturing > Pulp Paper Print",
-              "acts_on_labels": [
-                "natural gas usage within pulp paper and print industries"
-              ],
-              "shifts_to_labels": [
-                "hydrogen usage within pulp paper and print industries"
-              ],
-              "score": 0.4409
-            },
-            {
-              "stable_id": "shift_to_electricity_in_lead_industries",
-              "short_label": "T-2C5-TE-3 - Shift to electricity in lead industries",
-              "description": "Shift to electricity in lead industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within lead industries, oil usage within lead industries, natural gas usage within lead industries. to: electricity usage within lead industries. Industry > Metals > Lead",
-              "sector_path": "Industry > Metals > Lead",
-              "acts_on_labels": [
-                "coal usage within lead industries",
-                "oil usage within lead industries",
-                "natural gas usage within lead industries"
-              ],
-              "shifts_to_labels": [
-                "electricity usage within lead industries"
-              ],
-              "score": 0.4384
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_glass_industries",
-              "short_label": "T-2A3-TE-1 - Shift to biogas energy in glass industries",
-              "description": "Shift to biogas energy in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within glass industries. to: biogas usage within glass industries. Industry > Minerals > Glass Production",
-              "sector_path": "Industry > Minerals > Glass Production",
-              "acts_on_labels": [
-                "natural gas usage within glass industries"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within glass industries"
-              ],
-              "score": 0.3346
-            },
-            {
-              "stable_id": "biogas_in_methane_reforming_for_ammonia_production",
-              "short_label": "T-2B1-TE-1 - Biogas in methane reforming for ammonia production",
-              "description": "Biogas in methane reforming for ammonia production. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: reforming of methane for ammonia production. Industry > Chemicals > Ammonia Production",
-              "sector_path": "Industry > Chemicals > Ammonia Production",
-              "acts_on_labels": [
-                "reforming of methane for ammonia production"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.332
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_pulp_paper_and_print_industries",
-              "short_label": "T-2D1b-TE-1 - Shift to biogas energy in pulp, paper and print industries",
-              "description": "Shift to biogas energy in pulp, paper and print industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within pulp paper and print industries. to: biogas usage within pulp paper and print industries. Industry > Other > Manufacturing > Pulp Paper Print",
-              "sector_path": "Industry > Other > Manufacturing > Pulp Paper Print",
-              "acts_on_labels": [
-                "natural gas usage within pulp paper and print industries"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within pulp paper and print industries"
-              ],
-              "score": 0.3312
-            },
-            {
-              "stable_id": "shift_to_electricity_in_pulp_paper_and_print_industries",
-              "short_label": "T-2D1b-TE-3 - Shift to electricity in pulp, paper and print industries",
-              "description": "Shift to electricity in pulp, paper and print industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within pulp paper and print industries, oil usage within pulp paper and print industries, natural gas usage within pulp paper and print industries. to: electricity usage within pulp paper and print industries. Industry > Other > Manufacturing > Pulp Paper Print",
-              "sector_path": "Industry > Other > Manufacturing > Pulp Paper Print",
-              "acts_on_labels": [
-                "coal usage within pulp paper and print industries",
-                "oil usage within pulp paper and print industries",
-                "natural gas usage within pulp paper and print industries"
-              ],
-              "shifts_to_labels": [
-                "electricity usage within pulp paper and print industries"
-              ],
-              "score": 0.3289
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_magnesium_industries",
-              "short_label": "T-2C4-TE-2 - Shift to biogas energy in magnesium industries",
-              "description": "Shift to biogas energy in magnesium industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within magnesium industries. to: biogas usage within magnesium industries. Industry > Metals > Magnesium",
-              "sector_path": "Industry > Metals > Magnesium",
-              "acts_on_labels": [
-                "natural gas usage within magnesium industries"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within magnesium industries"
-              ],
-              "score": 0.3282
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_hydrogen_refinement",
-              "short_label": "T-5B4-TE-3 - Shift to biogas energy in hydrogen refinement",
-              "description": "Shift to biogas energy in hydrogen refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within hydrogen refinement. to: biogas usage within hydrogen refinement. Energy > Energy Transformation > Hydrogen Refinement",
-              "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
-              "acts_on_labels": [
-                "natural gas usage within hydrogen refinement"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within hydrogen refinement"
-              ],
-              "score": 0.3255
-            }
-          ]
-        }
-      ],
-      "intervention_who": "kommunen",
-      "intervention_when": "none",
-      "intervention_what": "reduce chemical emissions",
-      "intervention_how": "none",
-      "intervention_score": 3,
-      "intervention_reasoning": "Who and what are present, but when and how are not specified.",
-      "intervention_type": "indirect"
-    },
-    {
-      "measure_text": "136.Förorenade områden är åtgärdade i sådan omfattning att det inte utgör något hot mot människors hälsa eller miljö. De mest förorenade områdena utifrån utförd GIS-analys ska undersökas.",
-      "activity": "none",
-      "activity_shift_score": 1,
-      "activity_shifts": [],
-      "intervention_who": "none",
-      "intervention_when": "none",
-      "intervention_what": "undersöka de mest förorenade områdena",
-      "intervention_how": "none",
-      "intervention_score": 2,
-      "intervention_reasoning": "The measure specifies a 'what' (undersöka de mest förorenade områdena) but lacks a 'who', 'when', and 'how'.",
-      "intervention_type": "none"
-    },
-    {
-      "measure_text": "137.Naturen i Jönköpings kommun behöver bevaras och utvecklas. Det innebär att inga av de områden i kommunens naturvårdsprogram som är mest värdefulla (klass 1 eller 2) eller värdefulla miljöer för rödlistade arter, ska exploateras.",
-      "activity": "none",
-      "activity_shift_score": 1,
-      "activity_shifts": [],
-      "intervention_who": "none",
-      "intervention_when": "none",
-      "intervention_what": "förhindra exploatering av värdefulla områden",
-      "intervention_how": "none",
-      "intervention_score": 2,
-      "intervention_reasoning": "The measure specifies a 'what' (förhindra exploatering av värdefulla områden) but lacks a 'who', 'when', and 'how'.",
-      "intervention_type": "none"
-    },
-    {
-      "measure_text": "138.Rutiner för att arbeta med ekosystemtjänstanalys, kompensation av ekosystemtjänster och gröna stråk i detaljplanearbetet ska finnas och följas.",
-      "activity": "none",
-      "activity_shift_score": 1,
-      "activity_shifts": [],
-      "intervention_who": "none",
-      "intervention_when": "none",
-      "intervention_what": "implementera rutiner för ekosystemtjänstanalys och kompensation",
-      "intervention_how": "none",
-      "intervention_score": 2,
-      "intervention_reasoning": "The measure specifies a 'what' (implementera rutiner för ekosystemtjänstanalys och kompensation) but lacks a 'who', 'when', and 'how'.",
-      "intervention_type": "none"
-    },
-    {
-      "measure_text": "139.Skyddet av värdefull natur behöver stärkas för att långsiktigt säkra naturvärdena. Minst nio naturreservat, biotopskydd eller naturvårdsavtal ska inrättas, varav fem i sjöar eller vattendrag.",
-      "activity": "none",
-      "activity_shift_score": 1,
-      "activity_shifts": [],
-      "intervention_who": "none",
-      "intervention_when": "none",
-      "intervention_what": "inrätta naturreservat, biotopskydd eller naturvårdsavtal",
-      "intervention_how": "none",
-      "intervention_score": 2,
-      "intervention_reasoning": "The measure specifies a 'what' (inrätta naturreservat, biotopskydd eller naturvårdsavtal) but lacks a 'who', 'when', and 'how'.",
-      "intervention_type": "none"
-    },
-    {
-      "measure_text": "140.Kommunens värdefulla våtmarker (de som når upp till klassen mycket höga naturvärden eller klassen höga naturvärden i den nationella våtmarksinventeringen) ska vara restaurerade, både avseende vattenförhållanden och biologisk mångfald.",
-      "activity": "none",
-      "activity_shift_score": 1,
-      "activity_shifts": [],
-      "intervention_who": "none",
-      "intervention_when": "none",
-      "intervention_what": "restaurera värdefulla våtmarker",
-      "intervention_how": "none",
-      "intervention_score": 2,
-      "intervention_reasoning": "The measure specifies a 'what' (restaurera värdefulla våtmarker) but lacks a 'who', 'when', and 'how'.",
-      "intervention_type": "none"
-    },
-    {
-      "measure_text": "141.Alla kommunägda skogar och annan kommunägd naturmark ska fortsatt skötas med naturvårdsinriktad skötsel.",
-      "activity": "none",
-      "activity_shift_score": 1,
-      "activity_shifts": [],
-      "intervention_who": "none",
-      "intervention_when": "none",
-      "intervention_what": "sköta kommunägda skogar med naturvårdsinriktad skötsel",
-      "intervention_how": "none",
-      "intervention_score": 2,
-      "intervention_reasoning": "The measure specifies a 'what' (sköta kommunägda skogar med naturvårdsinriktad skötsel) but lacks a 'who', 'when', and 'how'.",
-      "intervention_type": "none"
-    },
-    {
-      "measure_text": "142.Bäckar och övriga vatten med höga naturvärden ska restaureras i tillräcklig omfattning för att långsiktigt bevara och utveckla de biologiska värdena.",
-      "activity": "none",
-      "activity_shift_score": 1,
-      "activity_shifts": [],
-      "intervention_who": "none",
-      "intervention_when": "none",
-      "intervention_what": "restaurera bäckar och vatten med höga naturvärden",
-      "intervention_how": "none",
-      "intervention_score": 2,
-      "intervention_reasoning": "The measure specifies a 'what' (restaurera bäckar och vatten med höga naturvärden) but lacks a 'who', 'when', and 'how'.",
-      "intervention_type": "none"
-    },
-    {
-      "measure_text": "143.Vägpassager över vattendrag i det kommunala vägnätet ska inte vara ett vandringshinder för vattenlevande arter eller försvåra en säker passage för utter.",
-      "activity": "none",
-      "activity_shift_score": 1,
-      "activity_shifts": [],
-      "intervention_who": "none",
-      "intervention_when": "none",
-      "intervention_what": "säkerställa att vägpassager inte är vandringshinder",
-      "intervention_how": "none",
-      "intervention_score": 2,
-      "intervention_reasoning": "The measure specifies a 'what' (säkerställa att vägpassager inte är vandringshinder) but lacks a 'who', 'when', and 'how'.",
-      "intervention_type": "none"
-    },
-    {
-      "measure_text": "144.Utgångspunkten är att exploatering av brukningsvärd jordbruksmark inte får ske för att klara framtida livsmedelsförsörjning.",
-      "activity": "none",
-      "activity_shift_score": 1,
-      "activity_shifts": [],
-      "intervention_who": "none",
-      "intervention_when": "none",
-      "intervention_what": "förhindra exploatering av jordbruksmark",
-      "intervention_how": "none",
-      "intervention_score": 2,
-      "intervention_reasoning": "The measure specifies a 'what' (förhindra exploatering av jordbruksmark) but lacks a 'who', 'when', and 'how'.",
-      "intervention_type": "none"
-    },
-    {
-      "measure_text": "145.Hanterings- eller åtgärdsplan för samtliga i kommunen förekommande invasiva arter finns och ett aktivt åtgärdsarbete ska bedrivas på kommunägd mark.",
-      "activity": "none",
-      "activity_shift_score": 1,
-      "activity_shifts": [],
-      "intervention_who": "none",
-      "intervention_when": "none",
-      "intervention_what": "bedriva åtgärdsarbete mot invasiva arter",
-      "intervention_how": "none",
-      "intervention_score": 2,
-      "intervention_reasoning": "The measure specifies a 'what' (bedriva åtgärdsarbete mot invasiva arter) but lacks a 'who', 'when', and 'how'.",
-      "intervention_type": "none"
-    },
-    {
-      "measure_text": "146.Kommunen ska arbeta med att informera privata fastighetsägare och privatpersoner om invasiva arter. Entreprenörer ska informeras så att invasiva arter inte sprids vidare.",
-      "activity": "none",
-      "activity_shift_score": 1,
-      "activity_shifts": [],
-      "intervention_who": "Kommunen",
-      "intervention_when": "none",
-      "intervention_what": "informera om invasiva arter",
-      "intervention_how": "none",
-      "intervention_score": 3,
-      "intervention_reasoning": "The measure specifies a 'who' (Kommunen) and a 'what' (informera om invasiva arter) but lacks a 'when' and 'how'.",
-      "intervention_type": "none"
-    },
-    {
-      "measure_text": "149.Kommunen ska arbeta för ett ökat internt delade av resurser, med en fungerande organisation för lager, logistik och beställning av återbrukade produkter.",
-      "activity": "resource sharing",
-      "activity_shift_score": 3,
-      "activity_shifts": [
-        {
-          "activity": "resource sharing",
-          "shift_from": "none",
-          "shift_to": "ökat internt delade av resurser",
-          "need": "none",
-          "type": "Utilisation Shift",
-          "type_reasoning": "The measure implies a shift towards increased sharing of resources within the municipality.",
-          "score": 3,
-          "reasoning": "The activity (resource sharing) and shift_to (ökat internt delade av resurser) are identifiable, but shift_from and need are not clearly defined.",
-          "transition_element_matches": [],
-          "transition_element_suggested_new": {
-            "short_label": "Increased Internal Resource Sharing",
-            "description": "Promote and implement systems for increased sharing and reuse of resources within municipal operations, including logistics and inventory management for reused products."
+          {
+            "stable_id": "electrification_of_domestic_sea_passenger_transport",
+            "short_label": "T-1A4-TE-5 - Shift to electric marine passenger transportion",
+            "description": "Shift to electric marine passenger transportion. Shift person kilometer from ship passenger to electric shipping passenger in person kilometer to fulfill the need of mobility. from: ship passenger, gas oil shipping passenger. to: electric shipping passenger. Transport > Mobility > Waterborne",
+            "sector_path": "Transport > Mobility > Waterborne",
+            "acts_on_labels": ["ship passenger", "gas oil shipping passenger"],
+            "shifts_to_labels": ["electric shipping passenger"],
+            "score": 0.3548
           },
-          "transition_element_candidates": [
-            {
-              "stable_id": "increased_proportion_of_non_travel_meetings_and_services",
-              "short_label": "T-1A1a-TE-7 - Shift to online meetings and services",
-              "description": "Shift to online meetings and services. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to e-meetings in hours to fulfill the need of business trips. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: e meetings. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles",
-                "lpg vehicles",
-                "gas vehicles"
-              ],
-              "shifts_to_labels": [
-                "e meetings"
-              ],
-              "score": 0.3074
-            },
-            {
-              "stable_id": "shift_to_electric_passenger_rail",
-              "short_label": "T-1A2-TE-2 - Shift to travel by electric rail",
-              "description": "Shift to travel by electric rail. Shift person kilometer from diesel passenger rail to electric passenger rail in person kilometer to fulfill the need of mobility. from: diesel passenger rail. to: electric rail. Transport > Mobility > Rail",
-              "sector_path": "Transport > Mobility > Rail",
-              "acts_on_labels": [
-                "diesel passenger rail"
-              ],
-              "shifts_to_labels": [
-                "electric rail"
-              ],
-              "score": 0.2968
-            },
-            {
-              "stable_id": "shift_to_residual_heat_in_district_heating",
-              "short_label": "T-5A2-TE-6 - Shift to Residual Heat in district heating",
-              "description": "Shift to Residual Heat in district heating. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: chp coal, chp natural gas, chp oil. to: district heating residual heat. Energy > Energy Supply > Heat",
-              "sector_path": "Energy > Energy Supply > Heat",
-              "acts_on_labels": [
-                "chp coal",
-                "chp natural gas",
-                "chp oil"
-              ],
-              "shifts_to_labels": [
-                "district heating residual heat"
-              ],
-              "score": 0.2914
-            },
-            {
-              "stable_id": "shift_from_passenger_air_transport_to_railway",
-              "short_label": "T-1A3-TE-4 - Shift from air travel to railway",
-              "description": "Shift from air travel to railway. Shift person kilometer from passenger transportation by air to electric rail in person kilometer to fulfill the need of mobility. from: passenger transportation by air. to: electric rail. Transport > Mobility > Aviation",
-              "sector_path": "Transport > Mobility > Aviation",
-              "acts_on_labels": [
-                "passenger transportation by air"
-              ],
-              "shifts_to_labels": [
-                "electric rail"
-              ],
-              "score": 0.2889
-            },
-            {
-              "stable_id": "transfer_from_car_to_remote_working",
-              "short_label": "T-1A1a-TE-8 - Shift from car to remote working",
-              "description": "Shift from car to remote working. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to remote working. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: remote working. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles",
-                "lpg vehicles",
-                "gas vehicles"
-              ],
-              "shifts_to_labels": [
-                "remote working"
-              ],
-              "score": 0.2839
-            },
-            {
-              "stable_id": "electrification_of_domestic_sea_passenger_transport",
-              "short_label": "T-1A4-TE-5 - Shift to electric marine passenger transportion",
-              "description": "Shift to electric marine passenger transportion. Shift person kilometer from ship passenger to electric shipping passenger in person kilometer to fulfill the need of mobility. from: ship passenger, gas oil shipping passenger. to: electric shipping passenger. Transport > Mobility > Waterborne",
-              "sector_path": "Transport > Mobility > Waterborne",
-              "acts_on_labels": [
-                "ship passenger",
-                "gas oil shipping passenger"
-              ],
-              "shifts_to_labels": [
-                "electric shipping passenger"
-              ],
-              "score": 0.28
-            },
-            {
-              "stable_id": "shift_to_heat_pumps_in_district_heating",
-              "short_label": "T-5A2-TE-5 - Shift to heat pumps in district heating",
-              "description": "Shift to heat pumps in district heating. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: chp coal, chp natural gas, chp oil. to: district heating heat pumps. Energy > Energy Supply > Heat",
-              "sector_path": "Energy > Energy Supply > Heat",
-              "acts_on_labels": [
-                "chp coal",
-                "chp natural gas",
-                "chp oil"
-              ],
-              "shifts_to_labels": [
-                "district heating heat pumps"
-              ],
-              "score": 0.2798
-            },
-            {
-              "stable_id": "shift_to_biofuel_in_district_heating",
-              "short_label": "T-5A3-TE-7 - Shift to biofuel in district heating",
-              "description": "Shift to biofuel in district heating. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: chp coal, chp natural gas, chp oil. to: chp biofuels. Energy > Energy Supply > Combined Heat Power",
-              "sector_path": "Energy > Energy Supply > Combined Heat Power",
-              "acts_on_labels": [
-                "chp coal",
-                "chp natural gas",
-                "chp oil"
-              ],
-              "shifts_to_labels": [
-                "chp biofuels"
-              ],
-              "score": 0.2767
-            },
-            {
-              "stable_id": "increased_energy_recovery_from_waste",
-              "short_label": "T-5A3-TE-6 - Increased energy recovery from waste",
-              "description": "Increased energy recovery from waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to CHP waste incineration in tonne to fulfill the need of warm premisses. from: incineration and open burning of waste. to: chp waste incineration. Energy > Energy Supply > Combined Heat Power",
-              "sector_path": "Energy > Energy Supply > Combined Heat Power",
-              "acts_on_labels": [
-                "incineration and open burning of waste"
-              ],
-              "shifts_to_labels": [
-                "chp waste incineration"
-              ],
-              "score": 0.2731
-            },
-            {
-              "stable_id": "increased_proportion_of_public_transport_by_diesel_bus",
-              "short_label": "T-1A1a-TE-17 - Shift to travel by diesel bus",
-              "description": "Shift to travel by diesel bus. Shift vehicle kilometer from petrol and diesel vehicles to diesel buses. from: petrol vehicles, diesel vehicles. to: diesel buses. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles"
-              ],
-              "shifts_to_labels": [
-                "diesel buses"
-              ],
-              "score": 0.2676
-            },
-            {
-              "stable_id": "district_heating_residual_heat",
-              "short_label": "T-5A2-TE-3 - District heating by residual heat",
-              "description": "District heating by residual heat. Alter the amount of district heat produced by residual heat. from: district heating residual heat. Energy > Energy Supply > Heat",
-              "sector_path": "Energy > Energy Supply > Heat",
-              "acts_on_labels": [
-                "district heating residual heat"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.2645
-            },
-            {
-              "stable_id": "more_efficient_commuting_by_car",
-              "short_label": "T-1A1a-TE-5 - Increase journey sharing",
-              "description": "Increase journey sharing. Reduce the number of vehicle kilometers from petrol, diesel, lpg and natural gas vehicles to fulfill the need of commuting through more efficient commuting by car. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles, battery electric vehicles, hydrogen vehicles. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles",
-                "lpg vehicles",
-                "gas vehicles",
-                "battery electric vehicles",
-                "hydrogen vehicles"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.2532
-            },
-            {
-              "stable_id": "district_heating_heat_pumps",
-              "short_label": "T-5A2-TE-4 - District heating by heat pump",
-              "description": "District heating by heat pump. Alter the amount of district heat produced by heat pumps. from: district heating heat pumps. Energy > Energy Supply > Heat",
-              "sector_path": "Energy > Energy Supply > Heat",
-              "acts_on_labels": [
-                "district heating heat pumps"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.2501
-            },
-            {
-              "stable_id": "biofuel_for_diesel_rail_passenger",
-              "short_label": "T-1A2-TE-1 - Biofuel for rail passenger transport",
-              "description": "Biofuel for rail passenger transport. Increase the proportion of HVO biodiesel in diesel. from: diesel passenger rail. Transport > Mobility > Rail",
-              "sector_path": "Transport > Mobility > Rail",
-              "acts_on_labels": [
-                "diesel passenger rail"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.236
-            },
-            {
-              "stable_id": "biofuel_for_gas_buses",
-              "short_label": "T-1A1c-TE-2 - Biofuel for gas buses",
-              "description": "Biofuel for gas buses. Increase the proportion of biogas in gas mix. from: gas buses. Transport > Mobility > Road > Buses",
-              "sector_path": "Transport > Mobility > Road > Buses",
-              "acts_on_labels": [
-                "gas buses"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.2268
-            },
-            {
-              "stable_id": "shift_to_district_cooling_in_public_buildings",
-              "short_label": "T-4B1b-TE-2 - Shift to district cooling in public buildings",
-              "description": "Shift to district cooling in public buildings. Shift square meter from industrial building cooling with AC to industrial building cooling with district cooling in square meter to fulfill the need of comfortable premises. from: public building cooling with ac. to: public building cooling with district cooling. Buildings > Non Residential > Hvac > Institutional Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
-              "acts_on_labels": [
-                "public building cooling with ac"
-              ],
-              "shifts_to_labels": [
-                "public building cooling with district cooling"
-              ],
-              "score": 0.2219
-            },
-            {
-              "stable_id": "energy_efficient_other_institutional_electric_appliances",
-              "short_label": "T-4B2c-TE-3 - Energy efficient public electrical appliances",
-              "description": "Energy efficient public electrical appliances. Reduce the amount of energy required to operate institutional electrical appliances. from: institutional unregulated electricity use. Buildings > Non Residential > Other Energy Usage > Other",
-              "sector_path": "Buildings > Non Residential > Other Energy Usage > Other",
-              "acts_on_labels": [
-                "institutional unregulated electricity use"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.2214
-            },
-            {
-              "stable_id": "improved_urban_planning",
-              "short_label": "T-1A1a-TE-22 - Improved urban planning",
-              "description": "Improved urban planning. Reduce the amount of vehicle kilometer from cars to fulfill the need of mobility through improved urban planning. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles, lng vehicles, hydrogen vehicles, battery electric vehicles. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles",
-                "lpg vehicles",
-                "gas vehicles",
-                "lng vehicles",
-                "hydrogen vehicles",
-                "battery electric vehicles"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.2095
-            },
-            {
-              "stable_id": "biofuels_for_sea_passenger_transport",
-              "short_label": "T-1A4-TE-4 - Biofuel for marine passenger transport",
-              "description": "Biofuel for marine passenger transport. Increase the proportion of marine biodiesel in marine diesel. from: ship passenger. Transport > Mobility > Waterborne",
-              "sector_path": "Transport > Mobility > Waterborne",
-              "acts_on_labels": [
-                "ship passenger"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.2088
-            }
-          ]
-        }
-      ],
-      "intervention_who": "Kommunen",
-      "intervention_when": "none",
-      "intervention_what": "arbeta för ökat delade av resurser",
-      "intervention_how": "none",
-      "intervention_score": 3,
-      "intervention_reasoning": "The measure specifies a 'who' (Kommunen) and a 'what' (arbeta för ökat delade av resurser) but lacks a 'when' and 'how'.",
-      "intervention_type": "none"
-    },
-    {
-      "measure_text": "150.Verka för fler cirkulära initiativ inom kommunen mot invånarna.",
-      "activity": "none",
-      "activity_shift_score": 1,
-      "activity_shifts": [],
-      "intervention_who": "none",
-      "intervention_when": "none",
-      "intervention_what": "verka för fler cirkulära initiativ",
-      "intervention_how": "none",
-      "intervention_score": 2,
-      "intervention_reasoning": "The measure specifies a 'what' (verka för fler cirkulära initiativ) but lacks a 'who', 'when', and 'how'.",
-      "intervention_type": "none"
-    },
-    {
-      "measure_text": "151.Kommunen ska arbeta för att öka medvetenheten om en hållbar livsstil hos flickor och pojkar och kvinnor och män som lever i eller besöker vår kommun.",
-      "activity": "none",
-      "activity_shift_score": 1,
-      "activity_shifts": [],
-      "intervention_who": "Kommunen",
-      "intervention_when": "none",
-      "intervention_what": "öka medvetenheten om en hållbar livsstil",
-      "intervention_how": "none",
-      "intervention_score": 3,
-      "intervention_reasoning": "The measure specifies a 'who' (Kommunen) and a 'what' (öka medvetenheten om en hållbar livsstil) but lacks a 'when' and 'how'.",
-      "intervention_type": "none"
-    },
-    {
-      "measure_text": "152.Minst 70 procent av maten som köps in till kommunens verksamheter ska ha råvaruland Sverige.",
-      "activity": "food procurement",
-      "activity_shift_score": 3,
-      "activity_shifts": [
-        {
-          "activity": "food procurement",
-          "shift_from": "none",
-          "shift_to": "köpa in mat med råvaruland Sverige",
-          "need": "food provision",
-          "type": "Resource Shift",
-          "type_reasoning": "The measure implies a shift in the source of food resources, focusing on procuring food from Sweden.",
-          "score": 3,
-          "reasoning": "The activity (food procurement) and shift_to (köpa in mat med råvaruland Sverige) are identifiable, but shift_from is not clearly defined, and the need is inferable as food provision.",
-          "transition_element_matches": [],
-          "transition_element_suggested_new": {
-            "short_label": "Shift to Local Food Procurement",
-            "description": "Increase the procurement of food with ingredients sourced from Sweden to at least 70% in municipal operations."
+          {
+            "stable_id": "shift_to_biogas_energy_in_pulp_paper_and_print_industries",
+            "short_label": "T-2D1b-TE-1 - Shift to biogas energy in pulp, paper and print industries",
+            "description": "Shift to biogas energy in pulp, paper and print industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within pulp paper and print industries. to: biogas usage within pulp paper and print industries. Industry > Other > Manufacturing > Pulp Paper Print",
+            "sector_path": "Industry > Other > Manufacturing > Pulp Paper Print",
+            "acts_on_labels": [
+              "natural gas usage within pulp paper and print industries"
+            ],
+            "shifts_to_labels": [
+              "biogas usage within pulp paper and print industries"
+            ],
+            "score": 0.2577
           },
-          "transition_element_candidates": [
-            {
-              "stable_id": "shift_to_sustainable_healthy_diet",
-              "short_label": "T-3A1-TE-1 - Shift to Sustainable Healthy Diets",
-              "description": "Shift to Sustainable Healthy Diets. This Transition Element is the shift from animal based diets to plant based diets.. from: enteric fermentation cattle, enteric fermentation sheep, enteric fermentation swine, enteric fermentation other livestock. Afolu > Livestock > Enteric Fermentation",
-              "sector_path": "Afolu > Livestock > Enteric Fermentation",
-              "acts_on_labels": [
-                "enteric fermentation cattle",
-                "enteric fermentation sheep",
-                "enteric fermentation swine",
-                "enteric fermentation other livestock"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.4118
-            },
-            {
-              "stable_id": "shift_to_electric_cargo_bikes",
-              "short_label": "T-1B1a-TE-10 - Shift to electric cargo bikes",
-              "description": "Shift to electric cargo bikes. Shift vehicle kilometer from diesel and petrol light truck to electric carg bikes in vehicle kilometer to fulfill the need of logistics. from: diesel light trucks, petrol light trucks. to: electric cargo bikes. Transport > Freight > Road > Light Duty Trucks",
-              "sector_path": "Transport > Freight > Road > Light Duty Trucks",
-              "acts_on_labels": [
-                "diesel light trucks",
-                "petrol light trucks"
-              ],
-              "shifts_to_labels": [
-                "electric cargo bikes"
-              ],
-              "score": 0.3506
-            },
-            {
-              "stable_id": "shift_to_biofuel_in_district_heating",
-              "short_label": "T-5A3-TE-7 - Shift to biofuel in district heating",
-              "description": "Shift to biofuel in district heating. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: chp coal, chp natural gas, chp oil. to: chp biofuels. Energy > Energy Supply > Combined Heat Power",
-              "sector_path": "Energy > Energy Supply > Combined Heat Power",
-              "acts_on_labels": [
-                "chp coal",
-                "chp natural gas",
-                "chp oil"
-              ],
-              "shifts_to_labels": [
-                "chp biofuels"
-              ],
-              "score": 0.3433
-            },
-            {
-              "stable_id": "shift_to_gas_vehicles",
-              "short_label": "T-1A1a-TE-19 - Shift to gas cars",
-              "description": "Shift to gas cars. Shift vehicle kilometer from petrol and diesel vehicles to gas vehicles in vehicle kilometer to fulfill the need of mobility. from: petrol vehicles, diesel vehicles. to: gas vehicles. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles"
-              ],
-              "shifts_to_labels": [
-                "gas vehicles"
-              ],
-              "score": 0.3231
-            },
-            {
-              "stable_id": "increased_proportion_of_public_transport_by_diesel_bus",
-              "short_label": "T-1A1a-TE-17 - Shift to travel by diesel bus",
-              "description": "Shift to travel by diesel bus. Shift vehicle kilometer from petrol and diesel vehicles to diesel buses. from: petrol vehicles, diesel vehicles. to: diesel buses. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles"
-              ],
-              "shifts_to_labels": [
-                "diesel buses"
-              ],
-              "score": 0.3163
-            },
-            {
-              "stable_id": "increased_proportion_of_walking_and_cycling",
-              "short_label": "T-1A1a-TE-10 - Shift to walking and cycling",
-              "description": "Shift to walking and cycling. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to walking cycling. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: walking cycling. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles",
-                "lpg vehicles",
-                "gas vehicles"
-              ],
-              "shifts_to_labels": [
-                "walking cycling"
-              ],
-              "score": 0.3162
-            },
-            {
-              "stable_id": "increased_proportion_of_public_transport_by_petrol_bus",
-              "short_label": "T-1A1a-TE-16 - Shift to travel by petrol bus",
-              "description": "Shift to travel by petrol bus. Shift vehicle kilometer from petrol and diesel vehicles to petrol buses. from: petrol vehicles, diesel vehicles. to: petrol buses. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles"
-              ],
-              "shifts_to_labels": [
-                "petrol buses"
-              ],
-              "score": 0.3148
-            },
-            {
-              "stable_id": "shift_to_electric_bikes",
-              "short_label": "T-1A1a-TE-11 - Shift to electric bikes",
-              "description": "Shift to electric bikes. Shift vehicle kilometer from petrol,diesel and LPG vehicles to electric bike in vehicle kilometer to fulfill the need of mobility. from: petrol vehicles, diesel vehicles, lpg vehicles. to: electric bikes. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles",
-                "lpg vehicles"
-              ],
-              "shifts_to_labels": [
-                "electric bikes"
-              ],
-              "score": 0.3142
-            },
-            {
-              "stable_id": "mobile_machinery_using_biofuels",
-              "short_label": "T-2D4-TE-1 - Shift to biofuel for mobile machinery",
-              "description": "Shift to biofuel for mobile machinery. Shift kilowatt-hours from mobile machinery diesel to mobile machinery biofuel in kilowatt-hour to fulfill the need of productivity. from: mobile machinery diesel, mobile machinery petrol. to: mobile machinery biofuel. Industry > Other > Mobile Machinery",
-              "sector_path": "Industry > Other > Mobile Machinery",
-              "acts_on_labels": [
-                "mobile machinery diesel",
-                "mobile machinery petrol"
-              ],
-              "shifts_to_labels": [
-                "mobile machinery biofuel"
-              ],
-              "score": 0.3134
-            },
-            {
-              "stable_id": "gas_light_trucks",
-              "short_label": "T-1B1a-TE-1 - Shift to gas light trucks",
-              "description": "Shift to gas light trucks. Shift vehicle kilometer from diesel light trucks to gas light trucks  in vehicle kilometer to fulfill the need of logistics. from: diesel light trucks, petrol light trucks. to: gas light trucks. Transport > Freight > Road > Light Duty Trucks",
-              "sector_path": "Transport > Freight > Road > Light Duty Trucks",
-              "acts_on_labels": [
-                "diesel light trucks",
-                "petrol light trucks"
-              ],
-              "shifts_to_labels": [
-                "gas light trucks"
-              ],
-              "score": 0.313
-            },
-            {
-              "stable_id": "biofuels_for_sea_freight_transport",
-              "short_label": "T-1B4b-TE-4 - Biofuel for marine freight transport",
-              "description": "Biofuel for marine freight transport. Increase the proportion of marine biodiesel in marine diesel. from: ship freight. Transport > Freight > Shipping > Navigation",
-              "sector_path": "Transport > Freight > Shipping > Navigation",
-              "acts_on_labels": [
-                "ship freight"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.2817
-            },
-            {
-              "stable_id": "biofuel_for_diesel_rail_passenger",
-              "short_label": "T-1A2-TE-1 - Biofuel for rail passenger transport",
-              "description": "Biofuel for rail passenger transport. Increase the proportion of HVO biodiesel in diesel. from: diesel passenger rail. Transport > Mobility > Rail",
-              "sector_path": "Transport > Mobility > Rail",
-              "acts_on_labels": [
-                "diesel passenger rail"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.28
-            },
-            {
-              "stable_id": "biofuel_for_heavy_trucks",
-              "short_label": "T-1B1b-TE-2 - Biofuel for diesel heavy trucks",
-              "description": "Biofuel for diesel heavy trucks. Increase the proportion of HVO biodiesel in diesel. from: diesel heavy trucks. Transport > Freight > Road > Heavy Duty Trucks",
-              "sector_path": "Transport > Freight > Road > Heavy Duty Trucks",
-              "acts_on_labels": [
-                "diesel heavy trucks"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.2791
-            },
-            {
-              "stable_id": "energy_efficient_other_agriculture_forestry_fishing_electric_appliances",
-              "short_label": "T-3C6-TE-1 - Energy efficient agriculture, forestry and fishing electrical appliances",
-              "description": "Energy efficient agriculture, forestry and fishing electrical appliances. Reduce the amount of energy required to operate agriculture, forestry and fishing electrical appliances. from: agriculture forestry fishing unregulated electricity use. Afolu > Aggregate Sources Other > Other",
-              "sector_path": "Afolu > Aggregate Sources Other > Other",
-              "acts_on_labels": [
-                "agriculture forestry fishing unregulated electricity use"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.2776
-            },
-            {
-              "stable_id": "biofuels_for_freight_air_transport",
-              "short_label": "T-1B3-TE-1 - Biofuel for kerosene air freight transport",
-              "description": "Biofuel for kerosene air freight transport. Increase the proportion of aviation biofuel in aviation turbine fuel. from: freight transportation by air. Transport > Freight > Aviation",
-              "sector_path": "Transport > Freight > Aviation",
-              "acts_on_labels": [
-                "freight transportation by air"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.272
-            },
-            {
-              "stable_id": "biofuel_for_diesel_rail_freight",
-              "short_label": "T-1B2-TE-1 - Biofuel for rail freight transport",
-              "description": "Biofuel for rail freight transport. Increase the proportion of HVO biodiesel in diesel. from: diesel rail freight. Transport > Freight > Rail",
-              "sector_path": "Transport > Freight > Rail",
-              "acts_on_labels": [
-                "diesel rail freight"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.2717
-            },
-            {
-              "stable_id": "biofuel_for_light_trucks",
-              "short_label": "T-1B1a-TE-2 - Biofuel for diesel light trucks",
-              "description": "Biofuel for diesel light trucks. Increase the proportion of HVO biodiesel in diesel. from: diesel light trucks. Transport > Freight > Road > Light Duty Trucks",
-              "sector_path": "Transport > Freight > Road > Light Duty Trucks",
-              "acts_on_labels": [
-                "diesel light trucks"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.2682
-            },
-            {
-              "stable_id": "shift_to_exported_composting_of_organic_waste",
-              "short_label": "T-6A1-TE-3 - Shift to exported composting of organic waste",
-              "description": "Shift to exported composting of organic waste. Shift tonne from solid waste disposal in landfills to exported composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: waste exported for composting. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc",
-                "incineration and open burning of waste",
-                "open burning of waste",
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "shifts_to_labels": [
-                "waste exported for composting"
-              ],
-              "score": 0.2547
-            },
-            {
-              "stable_id": "biofuel_for_gas_buses",
-              "short_label": "T-1A1c-TE-2 - Biofuel for gas buses",
-              "description": "Biofuel for gas buses. Increase the proportion of biogas in gas mix. from: gas buses. Transport > Mobility > Road > Buses",
-              "sector_path": "Transport > Mobility > Road > Buses",
-              "acts_on_labels": [
-                "gas buses"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.2519
-            },
-            {
-              "stable_id": "biofuels_for_sea_passenger_transport",
-              "short_label": "T-1A4-TE-4 - Biofuel for marine passenger transport",
-              "description": "Biofuel for marine passenger transport. Increase the proportion of marine biodiesel in marine diesel. from: ship passenger. Transport > Mobility > Waterborne",
-              "sector_path": "Transport > Mobility > Waterborne",
-              "acts_on_labels": [
-                "ship passenger"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.2508
-            },
-            {
-              "stable_id": "biofuels_for_air_transport",
-              "short_label": "T-1A3-TE-1 - Biofuel for air passenger transport",
-              "description": "Biofuel for air passenger transport. Increase the proportion of aviation biofuel in aviation turbine fuel. from: passenger transportation by air. Transport > Mobility > Aviation",
-              "sector_path": "Transport > Mobility > Aviation",
-              "acts_on_labels": [
-                "passenger transportation by air"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.2482
-            },
-            {
-              "stable_id": "imported_grid_district_heat",
-              "short_label": "T-5A2-TE-1 - District heat from imported grid",
-              "description": "District heat from imported grid. Alter the amount of district heat produced by imported grid district heat. from: imported grid district heat. Energy > Energy Supply > Heat",
-              "sector_path": "Energy > Energy Supply > Heat",
-              "acts_on_labels": [
-                "imported grid district heat"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.2467
-            },
-            {
-              "stable_id": "increase_renewable_proportion_in_diesel",
-              "short_label": "T-1A1a-TE-21 - Biofuel for diesel cars",
-              "description": "Biofuel for diesel cars. Increase the proportion of HVO biodiesel in diesel. from: diesel vehicles. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "diesel vehicles"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.2447
-            }
-          ]
-        }
-      ],
-      "intervention_who": "none",
-      "intervention_when": "none",
-      "intervention_what": "köpa in mat med råvaruland Sverige",
-      "intervention_how": "none",
-      "intervention_score": 2,
-      "intervention_reasoning": "The measure specifies a 'what' (köpa in mat med råvaruland Sverige) but lacks a 'who', 'when', and 'how'.",
-      "intervention_type": "none"
-    },
-    {
-      "measure_text": "153.Minst 80 procent av maten som köps in till kommunens verksamheter ska vara tillverkad i Sverige.",
-      "activity": "food procurement",
-      "activity_shift_score": 1,
-      "activity_shifts": [],
-      "intervention_who": "kommunens verksamheter",
-      "intervention_when": "none",
-      "intervention_what": "purchase food produced in Sweden",
-      "intervention_how": "none",
-      "intervention_score": 3,
-      "intervention_reasoning": "WHO and WHAT are present. The measure specifies that 80% of food should be produced in Sweden, but lacks a clear HOW or WHEN.",
-      "intervention_type": "indirect"
-    },
-    {
-      "measure_text": "154.Sträva efter att 60 procent av livsmedlen som serveras i kommunal verksamhet ska vara ekologiska.",
-      "activity": "food procurement",
-      "activity_shift_score": 1,
-      "activity_shifts": [],
-      "intervention_who": "kommunal verksamhet",
-      "intervention_when": "none",
-      "intervention_what": "aim for 60% of food to be organic",
-      "intervention_how": "none",
-      "intervention_score": 3,
-      "intervention_reasoning": "WHO and WHAT are present. The measure aims for 60% of food to be organic but lacks a clear HOW or WHEN.",
-      "intervention_type": "indirect"
-    },
-    {
-      "measure_text": "155.Klimatpåverkan från livsmedel som används i kommunal verksamhet ska minska. Målet är att klimatbelastningen ska vara max 1,25 kg CO2-ekv. per",
-      "activity": "food consumption",
-      "activity_shift_score": 2,
-      "activity_shifts": [
-        {
-          "activity": "consuming food",
-          "shift_from": "none",
-          "shift_to": "none",
-          "need": "food provision",
-          "type": "Resource Efficiency Shift",
-          "type_reasoning": "The measure aims to reduce the climate impact of food consumption, implying more efficient use of resources to achieve the same nutritional outcome.",
-          "score": 2,
-          "reasoning": "The measure implies a shift towards more efficient food consumption with lower climate impact, but FROM and TO are not clearly identifiable.",
-          "transition_element_matches": [],
-          "transition_element_suggested_new": {
-            "short_label": "Shift to Low-Carbon Food Provision",
-            "description": "This measure focuses on reducing the climate impact of food used in municipal operations by targeting a maximum of 1.25 kg CO2-equivalent per unit, promoting sustainable and low-carbon food choices."
+          {
+            "stable_id": "shift_to_hydrogen_energy_in_pulp_paper_and_print_industries",
+            "short_label": "T-2D1b-TE-4 - Shift to hydrogen energy in pulp, paper and print industries",
+            "description": "Shift to hydrogen energy in pulp, paper and print industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within pulp paper and print industries. to: hydrogen usage within pulp paper and print industries. Industry > Other > Manufacturing > Pulp Paper Print",
+            "sector_path": "Industry > Other > Manufacturing > Pulp Paper Print",
+            "acts_on_labels": [
+              "natural gas usage within pulp paper and print industries"
+            ],
+            "shifts_to_labels": [
+              "hydrogen usage within pulp paper and print industries"
+            ],
+            "score": 0.2545
           },
-          "transition_element_candidates": [
-            {
-              "stable_id": "shift_to_sustainable_healthy_diet",
-              "short_label": "T-3A1-TE-1 - Shift to Sustainable Healthy Diets",
-              "description": "Shift to Sustainable Healthy Diets. This Transition Element is the shift from animal based diets to plant based diets.. from: enteric fermentation cattle, enteric fermentation sheep, enteric fermentation swine, enteric fermentation other livestock. Afolu > Livestock > Enteric Fermentation",
-              "sector_path": "Afolu > Livestock > Enteric Fermentation",
-              "acts_on_labels": [
-                "enteric fermentation cattle",
-                "enteric fermentation sheep",
-                "enteric fermentation swine",
-                "enteric fermentation other livestock"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.3506
-            },
-            {
-              "stable_id": "energy_efficient_other_agriculture_forestry_fishing_electric_appliances",
-              "short_label": "T-3C6-TE-1 - Energy efficient agriculture, forestry and fishing electrical appliances",
-              "description": "Energy efficient agriculture, forestry and fishing electrical appliances. Reduce the amount of energy required to operate agriculture, forestry and fishing electrical appliances. from: agriculture forestry fishing unregulated electricity use. Afolu > Aggregate Sources Other > Other",
-              "sector_path": "Afolu > Aggregate Sources Other > Other",
-              "acts_on_labels": [
-                "agriculture forestry fishing unregulated electricity use"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.2722
-            },
-            {
-              "stable_id": "shift_to_biomass_energy_in_petroleum_refinement",
-              "short_label": "T-5B1-TE-1 - Shift to biomass energy in petroleum refinement",
-              "description": "Shift to biomass energy in petroleum refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: crude oil usage within petroleum refinement. to: biomass usage within petroleum refinement. Energy > Energy Transformation > Petroleum Refinement",
-              "sector_path": "Energy > Energy Transformation > Petroleum Refinement",
-              "acts_on_labels": [
-                "crude oil usage within petroleum refinement"
-              ],
-              "shifts_to_labels": [
-                "biomass usage within petroleum refinement"
-              ],
-              "score": 0.251
-            },
-            {
-              "stable_id": "shift_to_residential_electric_cooking_stoves",
-              "short_label": "T-4A2d-TE-2 - Shift to residential electric cooking stoves",
-              "description": "Shift to residential electric cooking stoves. Shift kWh from residential cooking gas stoves to residential electric cooking stoves in kWh to fullfill the need for cooking. from: residential gas cooking stoves. to: residential electric cooking stoves. Buildings > Residential > Other Energy Usage > Unregulated",
-              "sector_path": "Buildings > Residential > Other Energy Usage > Unregulated",
-              "acts_on_labels": [
-                "residential gas cooking stoves"
-              ],
-              "shifts_to_labels": [
-                "residential electric cooking stoves"
-              ],
-              "score": 0.2438
-            },
-            {
-              "stable_id": "shift_to_commercial_electric_cooking_stoves",
-              "short_label": "T-4B2b-TE-1 - Shift to commercial electric cooking stoves",
-              "description": "Shift to commercial electric cooking stoves. Shift kWh from commercial cooking gas stoves to commercial electric cooking stoves in kWh to fullfill the need for cooking. from: commercial gas cooking stoves. to: commercial electric cooking stoves. Buildings > Non Residential > Other Energy Usage > Equipment Appliances",
-              "sector_path": "Buildings > Non Residential > Other Energy Usage > Equipment Appliances",
-              "acts_on_labels": [
-                "commercial gas cooking stoves"
-              ],
-              "shifts_to_labels": [
-                "commercial electric cooking stoves"
-              ],
-              "score": 0.2401
-            },
-            {
-              "stable_id": "shift_to_biomass_energy_in_hydrogen_refinement",
-              "short_label": "T-5B4-TE-4 - Shift to biomass energy in hydrogen refinement",
-              "description": "Shift to biomass energy in hydrogen refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within hydrogen refinement. to: biomass usage within hydrogen refinement. Energy > Energy Transformation > Hydrogen Refinement",
-              "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
-              "acts_on_labels": [
-                "coal usage within hydrogen refinement"
-              ],
-              "shifts_to_labels": [
-                "biomass usage within hydrogen refinement"
-              ],
-              "score": 0.239
-            },
-            {
-              "stable_id": "shift_to_biomass_energy_in_other_industries",
-              "short_label": "T-2D5-TE-1 - Shift to biomass energy in other industries",
-              "description": "Shift to biomass energy in other industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: industrial unregulated coal use. to: industrial unregulated biomass use. Industry > Other > Other",
-              "sector_path": "Industry > Other > Other",
-              "acts_on_labels": [
-                "industrial unregulated coal use"
-              ],
-              "shifts_to_labels": [
-                "industrial unregulated biomass use"
-              ],
-              "score": 0.2351
-            },
-            {
-              "stable_id": "biogas_in_methane_reforming_for_hydrogen_production",
-              "short_label": "T-5B4-TE-1 - Biogas in methane reforming for hydrogen production",
-              "description": "Biogas in methane reforming for hydrogen production. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: reforming of methane for hydrogen production. Energy > Energy Transformation > Hydrogen Refinement",
-              "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
-              "acts_on_labels": [
-                "reforming of methane for hydrogen production"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.2348
-            },
-            {
-              "stable_id": "shift_to_composting_of_organic_waste",
-              "short_label": "T-6A1-TE-2 - Shift to composting of organic waste",
-              "description": "Shift to composting of organic waste. Shift tonne from solid waste disposal in landfills to composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: composting of organic waste. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc",
-                "incineration and open burning of waste",
-                "open burning of waste",
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "shifts_to_labels": [
-                "composting of organic waste"
-              ],
-              "score": 0.2337
-            },
-            {
-              "stable_id": "biomass_in_carbon_gasification_for_hydrogen_production",
-              "short_label": "T-5B4-TE-2 - Biomass in carbon gasification for hydrogen production",
-              "description": "Biomass in carbon gasification for hydrogen production. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: gasification of carbon for hydrogen production. Energy > Energy Transformation > Hydrogen Refinement",
-              "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
-              "acts_on_labels": [
-                "gasification of carbon for hydrogen production"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.2324
-            },
-            {
-              "stable_id": "biofuels_for_air_transport",
-              "short_label": "T-1A3-TE-1 - Biofuel for air passenger transport",
-              "description": "Biofuel for air passenger transport. Increase the proportion of aviation biofuel in aviation turbine fuel. from: passenger transportation by air. Transport > Mobility > Aviation",
-              "sector_path": "Transport > Mobility > Aviation",
-              "acts_on_labels": [
-                "passenger transportation by air"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.2307
-            },
-            {
-              "stable_id": "biogas_in_methane_reforming_for_ammonia_production",
-              "short_label": "T-2B1-TE-1 - Biogas in methane reforming for ammonia production",
-              "description": "Biogas in methane reforming for ammonia production. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: reforming of methane for ammonia production. Industry > Chemicals > Ammonia Production",
-              "sector_path": "Industry > Chemicals > Ammonia Production",
-              "acts_on_labels": [
-                "reforming of methane for ammonia production"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.227
-            },
-            {
-              "stable_id": "biofuels_for_freight_air_transport",
-              "short_label": "T-1B3-TE-1 - Biofuel for kerosene air freight transport",
-              "description": "Biofuel for kerosene air freight transport. Increase the proportion of aviation biofuel in aviation turbine fuel. from: freight transportation by air. Transport > Freight > Aviation",
-              "sector_path": "Transport > Freight > Aviation",
-              "acts_on_labels": [
-                "freight transportation by air"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.2269
-            },
-            {
-              "stable_id": "biofuels_for_cement_and_mineral_industry",
-              "short_label": "T-2A1-TE-1 - Shift to use biofuel in cement and mineral industry",
-              "description": "Shift to use biofuel in cement and mineral industry. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: cement mineral industries coal usage. to: cement mineral industries biomass usage. Industry > Minerals > Cement",
-              "sector_path": "Industry > Minerals > Cement",
-              "acts_on_labels": [
-                "cement mineral industries coal usage"
-              ],
-              "shifts_to_labels": [
-                "cement mineral industries biomass usage"
-              ],
-              "score": 0.2262
-            },
-            {
-              "stable_id": "shift_to_biomass_energy_in_iron_and_steel_industries",
-              "short_label": "T-2C1-TE-2 - Shift to biomass energy in iron and steel industries",
-              "description": "Shift to biomass energy in iron and steel industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within iron and steel industries. to: biomass usage within iron and steel industries. Industry > Metals > Iron Steel",
-              "sector_path": "Industry > Metals > Iron Steel",
-              "acts_on_labels": [
-                "coal usage within iron and steel industries"
-              ],
-              "shifts_to_labels": [
-                "biomass usage within iron and steel industries"
-              ],
-              "score": 0.226
-            }
-          ]
-        }
-      ],
-      "intervention_who": "kommunal verksamhet",
-      "intervention_when": "none",
-      "intervention_what": "reduce climate impact of food",
-      "intervention_how": "none",
-      "intervention_score": 2,
-      "intervention_reasoning": "WHO is present, but lacks clear WHAT, HOW, or WHEN.",
-      "intervention_type": "indirect"
-    },
-    {
-      "measure_text": "156.Matsvinnet i kommunen ska minska. Det gäller både kökssvinn, serveringssvinn och tallrikssvinn. Målvärdet är att det sammanlagda svinnet per serverad portion ska uppgå till max 25 gram.",
-      "activity": "food waste management",
-      "activity_shift_score": 6,
-      "activity_shifts": [
-        {
-          "activity": "managing food waste",
-          "shift_from": "high food waste",
-          "shift_to": "reduced food waste",
-          "need": "waste management",
-          "type": "Utilisation Shift",
-          "type_reasoning": "The measure focuses on reducing food waste, which is a change in utilisation of food resources.",
-          "score": 6,
-          "reasoning": "The measure clearly identifies the activity (managing food waste), the shift from high to reduced waste, and the need (waste management).",
-          "transition_element_matches": [],
-          "transition_element_suggested_new": {
-            "short_label": "Reduction in Food Waste",
-            "description": "Implement measures to reduce food waste in municipal kitchens, focusing on minimizing kitchen, serving, and plate waste to achieve a target of no more than 25 grams of waste per served portion."
+          {
+            "stable_id": "shift_to_biogas_energy_in_glass_industries",
+            "short_label": "T-2A3-TE-1 - Shift to biogas energy in glass industries",
+            "description": "Shift to biogas energy in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within glass industries. to: biogas usage within glass industries. Industry > Minerals > Glass Production",
+            "sector_path": "Industry > Minerals > Glass Production",
+            "acts_on_labels": ["natural gas usage within glass industries"],
+            "shifts_to_labels": ["biogas usage within glass industries"],
+            "score": 0.2497
           },
-          "transition_element_candidates": [
-            {
-              "stable_id": "shift_to_composting_of_organic_waste",
-              "short_label": "T-6A1-TE-2 - Shift to composting of organic waste",
-              "description": "Shift to composting of organic waste. Shift tonne from solid waste disposal in landfills to composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: composting of organic waste. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc",
-                "incineration and open burning of waste",
-                "open burning of waste",
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "shifts_to_labels": [
-                "composting of organic waste"
-              ],
-              "score": 0.5855
-            },
-            {
-              "stable_id": "increased_recycling",
-              "short_label": "T-6A1-TE-1 - Shift to recycling of solid waste",
-              "description": "Shift to recycling of solid waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to recycling of solid waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: recycling of solid waste. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc",
-                "incineration and open burning of waste",
-                "open burning of waste",
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "shifts_to_labels": [
-                "recycling of solid waste"
-              ],
-              "score": 0.577
-            },
-            {
-              "stable_id": "shift_to_exported_composting_of_organic_waste",
-              "short_label": "T-6A1-TE-3 - Shift to exported composting of organic waste",
-              "description": "Shift to exported composting of organic waste. Shift tonne from solid waste disposal in landfills to exported composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: waste exported for composting. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc",
-                "incineration and open burning of waste",
-                "open burning of waste",
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "shifts_to_labels": [
-                "waste exported for composting"
-              ],
-              "score": 0.5569
-            },
-            {
-              "stable_id": "shift_to_landfill_gas_recovery",
-              "short_label": "T-6A1-TE-4 - Shift to landfill gas recovery",
-              "description": "Shift to landfill gas recovery. Shift tonne from solid waste disposal in landfills without gas recovery to solid waste disposal in landfills with landfill gas recovery in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc. to: solid waste disposal landfill with gas recovery. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc"
-              ],
-              "shifts_to_labels": [
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "score": 0.5346
-            },
-            {
-              "stable_id": "increased_energy_recovery_from_waste",
-              "short_label": "T-5A3-TE-6 - Increased energy recovery from waste",
-              "description": "Increased energy recovery from waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to CHP waste incineration in tonne to fulfill the need of warm premisses. from: incineration and open burning of waste. to: chp waste incineration. Energy > Energy Supply > Combined Heat Power",
-              "sector_path": "Energy > Energy Supply > Combined Heat Power",
-              "acts_on_labels": [
-                "incineration and open burning of waste"
-              ],
-              "shifts_to_labels": [
-                "chp waste incineration"
-              ],
-              "score": 0.4879
-            },
-            {
-              "stable_id": "shift_to_sustainable_healthy_diet",
-              "short_label": "T-3A1-TE-1 - Shift to Sustainable Healthy Diets",
-              "description": "Shift to Sustainable Healthy Diets. This Transition Element is the shift from animal based diets to plant based diets.. from: enteric fermentation cattle, enteric fermentation sheep, enteric fermentation swine, enteric fermentation other livestock. Afolu > Livestock > Enteric Fermentation",
-              "sector_path": "Afolu > Livestock > Enteric Fermentation",
-              "acts_on_labels": [
-                "enteric fermentation cattle",
-                "enteric fermentation sheep",
-                "enteric fermentation swine",
-                "enteric fermentation other livestock"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.4509
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_chemical_industries",
-              "short_label": "T-2B9-TE-1 - Shift to biogas energy in chemical industries",
-              "description": "Shift to biogas energy in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within chemical industries. to: biogas usage within chemical industries. Industry > Chemicals > Other",
-              "sector_path": "Industry > Chemicals > Other",
-              "acts_on_labels": [
-                "natural gas usage within chemical industries"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within chemical industries"
-              ],
-              "score": 0.4078
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_lead_industries",
-              "short_label": "T-2C5-TE-1 - Shift to biogas energy in lead industries",
-              "description": "Shift to biogas energy in lead industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within lead industries. to: biogas usage within lead industries. Industry > Metals > Lead",
-              "sector_path": "Industry > Metals > Lead",
-              "acts_on_labels": [
-                "natural gas usage within lead industries"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within lead industries"
-              ],
-              "score": 0.4048
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_glass_industries",
-              "short_label": "T-2A3-TE-1 - Shift to biogas energy in glass industries",
-              "description": "Shift to biogas energy in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within glass industries. to: biogas usage within glass industries. Industry > Minerals > Glass Production",
-              "sector_path": "Industry > Minerals > Glass Production",
-              "acts_on_labels": [
-                "natural gas usage within glass industries"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within glass industries"
-              ],
-              "score": 0.4041
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_pulp_paper_and_print_industries",
-              "short_label": "T-2D1b-TE-1 - Shift to biogas energy in pulp, paper and print industries",
-              "description": "Shift to biogas energy in pulp, paper and print industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within pulp paper and print industries. to: biogas usage within pulp paper and print industries. Industry > Other > Manufacturing > Pulp Paper Print",
-              "sector_path": "Industry > Other > Manufacturing > Pulp Paper Print",
-              "acts_on_labels": [
-                "natural gas usage within pulp paper and print industries"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within pulp paper and print industries"
-              ],
-              "score": 0.4033
-            },
-            {
-              "stable_id": "chp_waste_incineration",
-              "short_label": "T-5A3-TE-4 - CHP from waste incineration",
-              "description": "CHP from waste incineration. Alter the amount of district heat and electricity produced by CHP waste incineration. from: chp waste incineration. Energy > Energy Supply > Combined Heat Power",
-              "sector_path": "Energy > Energy Supply > Combined Heat Power",
-              "acts_on_labels": [
-                "chp waste incineration"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.3735
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_hydrogen_refinement",
-              "short_label": "T-5B4-TE-3 - Shift to biogas energy in hydrogen refinement",
-              "description": "Shift to biogas energy in hydrogen refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within hydrogen refinement. to: biogas usage within hydrogen refinement. Energy > Energy Transformation > Hydrogen Refinement",
-              "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
-              "acts_on_labels": [
-                "natural gas usage within hydrogen refinement"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within hydrogen refinement"
-              ],
-              "score": 0.3469
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_other_industries",
-              "short_label": "T-2D5-TE-2 - Shift to biogas energy in other industries",
-              "description": "Shift to biogas energy in other industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: industrial unregulated gas use. to: industrial unregulated biogas use. Industry > Other > Other",
-              "sector_path": "Industry > Other > Other",
-              "acts_on_labels": [
-                "industrial unregulated gas use"
-              ],
-              "shifts_to_labels": [
-                "industrial unregulated biogas use"
-              ],
-              "score": 0.3306
-            },
-            {
-              "stable_id": "biogas_in_methane_reforming_for_hydrogen_production",
-              "short_label": "T-5B4-TE-1 - Biogas in methane reforming for hydrogen production",
-              "description": "Biogas in methane reforming for hydrogen production. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: reforming of methane for hydrogen production. Energy > Energy Transformation > Hydrogen Refinement",
-              "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
-              "acts_on_labels": [
-                "reforming of methane for hydrogen production"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.3233
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_magnesium_industries",
-              "short_label": "T-2C4-TE-2 - Shift to biogas energy in magnesium industries",
-              "description": "Shift to biogas energy in magnesium industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within magnesium industries. to: biogas usage within magnesium industries. Industry > Metals > Magnesium",
-              "sector_path": "Industry > Metals > Magnesium",
-              "acts_on_labels": [
-                "natural gas usage within magnesium industries"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within magnesium industries"
-              ],
-              "score": 0.3194
-            }
-          ]
-        }
-      ],
-      "intervention_who": "none",
-      "intervention_when": "none",
-      "intervention_what": "reduce food waste",
-      "intervention_how": "none",
-      "intervention_score": 2,
-      "intervention_reasoning": "WHAT is present, but lacks WHO, HOW, or WHEN.",
-      "intervention_type": "indirect"
-    },
-    {
-      "measure_text": "157.Lokala initiativ till livsmedelsförsörjning utanför traditionell jordbruksmark ska uppmuntras och främjas. Det kan till exempel vara kolonilotter, odlingslådor, hydroponik (odla med vatten istället för jord) eller akvaponik (ett hållbart matproduktionssystem som kombinerar t.ex. fiskodling och växtodling).",
-      "activity": "food production",
-      "activity_shift_score": 5,
-      "activity_shifts": [
-        {
-          "activity": "producing food",
-          "shift_from": "traditional agriculture",
-          "shift_to": "urban agriculture",
-          "need": "food provision",
-          "type": "Type Shift",
-          "type_reasoning": "The measure encourages a shift from traditional agriculture to alternative methods like hydroponics and aquaponics.",
-          "score": 5,
-          "reasoning": "The measure implies a shift from traditional agriculture to alternative methods, with the need for food provision clear, but FROM and TO are not explicitly named.",
-          "transition_element_matches": [],
-          "transition_element_suggested_new": {
-            "short_label": "Shift to Urban Agriculture",
-            "description": "Encouraging local food production initiatives such as community gardens, hydroponics, and aquaponics to enhance food provision outside traditional agricultural lands."
+          {
+            "stable_id": "energy_efficient_other_agriculture_forestry_fishing_electric_appliances",
+            "short_label": "T-3C6-TE-1 - Energy efficient agriculture, forestry and fishing electrical appliances",
+            "description": "Energy efficient agriculture, forestry and fishing electrical appliances. Reduce the amount of energy required to operate agriculture, forestry and fishing electrical appliances. from: agriculture forestry fishing unregulated electricity use. Afolu > Aggregate Sources Other > Other",
+            "sector_path": "Afolu > Aggregate Sources Other > Other",
+            "acts_on_labels": [
+              "agriculture forestry fishing unregulated electricity use"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.2472
           },
-          "transition_element_candidates": [
-            {
-              "stable_id": "shift_to_sustainable_healthy_diet",
-              "short_label": "T-3A1-TE-1 - Shift to Sustainable Healthy Diets",
-              "description": "Shift to Sustainable Healthy Diets. This Transition Element is the shift from animal based diets to plant based diets.. from: enteric fermentation cattle, enteric fermentation sheep, enteric fermentation swine, enteric fermentation other livestock. Afolu > Livestock > Enteric Fermentation",
-              "sector_path": "Afolu > Livestock > Enteric Fermentation",
-              "acts_on_labels": [
-                "enteric fermentation cattle",
-                "enteric fermentation sheep",
-                "enteric fermentation swine",
-                "enteric fermentation other livestock"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.4742
-            },
-            {
-              "stable_id": "shift_to_composting_of_organic_waste",
-              "short_label": "T-6A1-TE-2 - Shift to composting of organic waste",
-              "description": "Shift to composting of organic waste. Shift tonne from solid waste disposal in landfills to composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: composting of organic waste. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc",
-                "incineration and open burning of waste",
-                "open burning of waste",
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "shifts_to_labels": [
-                "composting of organic waste"
-              ],
-              "score": 0.3733
-            },
-            {
-              "stable_id": "shift_to_residential_electric_cooking_stoves",
-              "short_label": "T-4A2d-TE-2 - Shift to residential electric cooking stoves",
-              "description": "Shift to residential electric cooking stoves. Shift kWh from residential cooking gas stoves to residential electric cooking stoves in kWh to fullfill the need for cooking. from: residential gas cooking stoves. to: residential electric cooking stoves. Buildings > Residential > Other Energy Usage > Unregulated",
-              "sector_path": "Buildings > Residential > Other Energy Usage > Unregulated",
-              "acts_on_labels": [
-                "residential gas cooking stoves"
-              ],
-              "shifts_to_labels": [
-                "residential electric cooking stoves"
-              ],
-              "score": 0.3716
-            },
-            {
-              "stable_id": "increased_proportion_of_walking_and_cycling",
-              "short_label": "T-1A1a-TE-10 - Shift to walking and cycling",
-              "description": "Shift to walking and cycling. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to walking cycling. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: walking cycling. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles",
-                "lpg vehicles",
-                "gas vehicles"
-              ],
-              "shifts_to_labels": [
-                "walking cycling"
-              ],
-              "score": 0.3656
-            },
-            {
-              "stable_id": "shift_from_passenger_air_transport_to_railway",
-              "short_label": "T-1A3-TE-4 - Shift from air travel to railway",
-              "description": "Shift from air travel to railway. Shift person kilometer from passenger transportation by air to electric rail in person kilometer to fulfill the need of mobility. from: passenger transportation by air. to: electric rail. Transport > Mobility > Aviation",
-              "sector_path": "Transport > Mobility > Aviation",
-              "acts_on_labels": [
-                "passenger transportation by air"
-              ],
-              "shifts_to_labels": [
-                "electric rail"
-              ],
-              "score": 0.3646
-            },
-            {
-              "stable_id": "shift_to_electric_bikes",
-              "short_label": "T-1A1a-TE-11 - Shift to electric bikes",
-              "description": "Shift to electric bikes. Shift vehicle kilometer from petrol,diesel and LPG vehicles to electric bike in vehicle kilometer to fulfill the need of mobility. from: petrol vehicles, diesel vehicles, lpg vehicles. to: electric bikes. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles",
-                "lpg vehicles"
-              ],
-              "shifts_to_labels": [
-                "electric bikes"
-              ],
-              "score": 0.3641
-            },
-            {
-              "stable_id": "shift_to_electric_cargo_bikes",
-              "short_label": "T-1B1a-TE-10 - Shift to electric cargo bikes",
-              "description": "Shift to electric cargo bikes. Shift vehicle kilometer from diesel and petrol light truck to electric carg bikes in vehicle kilometer to fulfill the need of logistics. from: diesel light trucks, petrol light trucks. to: electric cargo bikes. Transport > Freight > Road > Light Duty Trucks",
-              "sector_path": "Transport > Freight > Road > Light Duty Trucks",
-              "acts_on_labels": [
-                "diesel light trucks",
-                "petrol light trucks"
-              ],
-              "shifts_to_labels": [
-                "electric cargo bikes"
-              ],
-              "score": 0.3553
-            },
-            {
-              "stable_id": "shift_to_commercial_electric_cooking_stoves",
-              "short_label": "T-4B2b-TE-1 - Shift to commercial electric cooking stoves",
-              "description": "Shift to commercial electric cooking stoves. Shift kWh from commercial cooking gas stoves to commercial electric cooking stoves in kWh to fullfill the need for cooking. from: commercial gas cooking stoves. to: commercial electric cooking stoves. Buildings > Non Residential > Other Energy Usage > Equipment Appliances",
-              "sector_path": "Buildings > Non Residential > Other Energy Usage > Equipment Appliances",
-              "acts_on_labels": [
-                "commercial gas cooking stoves"
-              ],
-              "shifts_to_labels": [
-                "commercial electric cooking stoves"
-              ],
-              "score": 0.355
-            },
-            {
-              "stable_id": "transfer_from_car_to_remote_working",
-              "short_label": "T-1A1a-TE-8 - Shift from car to remote working",
-              "description": "Shift from car to remote working. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to remote working. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: remote working. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles",
-                "lpg vehicles",
-                "gas vehicles"
-              ],
-              "shifts_to_labels": [
-                "remote working"
-              ],
-              "score": 0.3462
-            },
-            {
-              "stable_id": "increased_recycling",
-              "short_label": "T-6A1-TE-1 - Shift to recycling of solid waste",
-              "description": "Shift to recycling of solid waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to recycling of solid waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: recycling of solid waste. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc",
-                "incineration and open burning of waste",
-                "open burning of waste",
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "shifts_to_labels": [
-                "recycling of solid waste"
-              ],
-              "score": 0.3461
-            },
-            {
-              "stable_id": "energy_efficient_other_agriculture_forestry_fishing_electric_appliances",
-              "short_label": "T-3C6-TE-1 - Energy efficient agriculture, forestry and fishing electrical appliances",
-              "description": "Energy efficient agriculture, forestry and fishing electrical appliances. Reduce the amount of energy required to operate agriculture, forestry and fishing electrical appliances. from: agriculture forestry fishing unregulated electricity use. Afolu > Aggregate Sources Other > Other",
-              "sector_path": "Afolu > Aggregate Sources Other > Other",
-              "acts_on_labels": [
-                "agriculture forestry fishing unregulated electricity use"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.3269
-            },
-            {
-              "stable_id": "biogas_in_methane_reforming_for_ammonia_production",
-              "short_label": "T-2B1-TE-1 - Biogas in methane reforming for ammonia production",
-              "description": "Biogas in methane reforming for ammonia production. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: reforming of methane for ammonia production. Industry > Chemicals > Ammonia Production",
-              "sector_path": "Industry > Chemicals > Ammonia Production",
-              "acts_on_labels": [
-                "reforming of methane for ammonia production"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.302
-            },
-            {
-              "stable_id": "biogas_in_methane_reforming_for_hydrogen_production",
-              "short_label": "T-5B4-TE-1 - Biogas in methane reforming for hydrogen production",
-              "description": "Biogas in methane reforming for hydrogen production. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: reforming of methane for hydrogen production. Energy > Energy Transformation > Hydrogen Refinement",
-              "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
-              "acts_on_labels": [
-                "reforming of methane for hydrogen production"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.291
-            },
-            {
-              "stable_id": "shift_to_exported_composting_of_organic_waste",
-              "short_label": "T-6A1-TE-3 - Shift to exported composting of organic waste",
-              "description": "Shift to exported composting of organic waste. Shift tonne from solid waste disposal in landfills to exported composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: waste exported for composting. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc",
-                "incineration and open burning of waste",
-                "open burning of waste",
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "shifts_to_labels": [
-                "waste exported for composting"
-              ],
-              "score": 0.2819
-            },
-            {
-              "stable_id": "chp_biofuels",
-              "short_label": "T-5A3-TE-5 - CHP from biomass",
-              "description": "CHP from biomass. Alter the amount of district heat and electricity produced by CHP biofuels. from: chp biofuels. Energy > Energy Supply > Combined Heat Power",
-              "sector_path": "Energy > Energy Supply > Combined Heat Power",
-              "acts_on_labels": [
-                "chp biofuels"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.2811
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_other_industries",
-              "short_label": "T-2D5-TE-2 - Shift to biogas energy in other industries",
-              "description": "Shift to biogas energy in other industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: industrial unregulated gas use. to: industrial unregulated biogas use. Industry > Other > Other",
-              "sector_path": "Industry > Other > Other",
-              "acts_on_labels": [
-                "industrial unregulated gas use"
-              ],
-              "shifts_to_labels": [
-                "industrial unregulated biogas use"
-              ],
-              "score": 0.2809
-            },
-            {
-              "stable_id": "shift_to_biofuel_in_district_heating",
-              "short_label": "T-5A3-TE-7 - Shift to biofuel in district heating",
-              "description": "Shift to biofuel in district heating. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: chp coal, chp natural gas, chp oil. to: chp biofuels. Energy > Energy Supply > Combined Heat Power",
-              "sector_path": "Energy > Energy Supply > Combined Heat Power",
-              "acts_on_labels": [
-                "chp coal",
-                "chp natural gas",
-                "chp oil"
-              ],
-              "shifts_to_labels": [
-                "chp biofuels"
-              ],
-              "score": 0.2736
-            },
-            {
-              "stable_id": "shift_to_electrolysis_of_water_for_hydrogen_production",
-              "short_label": "T-5B4-TE-6 - Shift to electrolysis of water for hydrogen production",
-              "description": "Shift to electrolysis of water for hydrogen production. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: reforming of methane for hydrogen production, gasification of carbon for hydrogen production. to: electrolysis of water for hydrogen production. Energy > Energy Transformation > Hydrogen Refinement",
-              "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
-              "acts_on_labels": [
-                "reforming of methane for hydrogen production",
-                "gasification of carbon for hydrogen production"
-              ],
-              "shifts_to_labels": [
-                "electrolysis of water for hydrogen production"
-              ],
-              "score": 0.2723
-            },
-            {
-              "stable_id": "shift_to_biomass_energy_in_other_industries",
-              "short_label": "T-2D5-TE-1 - Shift to biomass energy in other industries",
-              "description": "Shift to biomass energy in other industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: industrial unregulated coal use. to: industrial unregulated biomass use. Industry > Other > Other",
-              "sector_path": "Industry > Other > Other",
-              "acts_on_labels": [
-                "industrial unregulated coal use"
-              ],
-              "shifts_to_labels": [
-                "industrial unregulated biomass use"
-              ],
-              "score": 0.2645
-            },
-            {
-              "stable_id": "biofuel_for_gas_vehicles",
-              "short_label": "T-1A1a-TE-20 - Biofuel for gas cars",
-              "description": "Biofuel for gas cars. Increase the proportion of biogas in gas mix. from: gas vehicles. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "gas vehicles"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.2622
-            },
-            {
-              "stable_id": "increased_energy_recovery_from_waste",
-              "short_label": "T-5A3-TE-6 - Increased energy recovery from waste",
-              "description": "Increased energy recovery from waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to CHP waste incineration in tonne to fulfill the need of warm premisses. from: incineration and open burning of waste. to: chp waste incineration. Energy > Energy Supply > Combined Heat Power",
-              "sector_path": "Energy > Energy Supply > Combined Heat Power",
-              "acts_on_labels": [
-                "incineration and open burning of waste"
-              ],
-              "shifts_to_labels": [
-                "chp waste incineration"
-              ],
-              "score": 0.2619
-            }
-          ]
-        }
-      ],
-      "intervention_who": "none",
-      "intervention_when": "none",
-      "intervention_what": "encourage local food initiatives",
-      "intervention_how": "none",
-      "intervention_score": 2,
-      "intervention_reasoning": "WHAT is present, but lacks WHO, HOW, or WHEN.",
-      "intervention_type": "enabling"
-    },
-    {
-      "measure_text": "158.Den sammanlagda exponeringen för kemiska ämnen via alla exponeringsvägar behöver vara så låg att den inte är skadlig för människor eller den biologiska mångfalden.",
-      "activity": "chemical exposure management",
-      "activity_shift_score": 1,
-      "activity_shifts": [],
-      "intervention_who": "none",
-      "intervention_when": "none",
-      "intervention_what": "reduce chemical exposure",
-      "intervention_how": "none",
-      "intervention_score": 1,
-      "intervention_reasoning": "No specific WHO, WHEN, WHAT, or HOW is provided.",
-      "intervention_type": "none"
-    },
-    {
-      "measure_text": "159.Antalet produkter och material innehållande utfasningsämnen (enligt Kemikalieinspektionens kriterier) ska minska.",
-      "activity": "product management",
-      "activity_shift_score": 2,
-      "activity_shifts": [
-        {
-          "activity": "using products",
-          "shift_from": "using products with phased-out substances",
-          "shift_to": "using products without phased-out substances",
-          "need": "product safety",
-          "type": "Resource Shift",
-          "type_reasoning": "The measure aims to reduce the use of products containing phased-out substances, shifting to safer alternatives.",
-          "score": 2,
-          "reasoning": "The measure implies a shift but lacks clear FROM and TO details.",
-          "transition_element_matches": [],
-          "transition_element_suggested_new": {
-            "short_label": "Shift to safer chemical products",
-            "description": "Transition from using products containing phased-out substances to those without, enhancing product safety and compliance with chemical regulations."
+          {
+            "stable_id": "shift_to_composting_of_organic_waste",
+            "short_label": "T-6A1-TE-2 - Shift to composting of organic waste",
+            "description": "Shift to composting of organic waste. Shift tonne from solid waste disposal in landfills to composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: composting of organic waste. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc",
+              "incineration and open burning of waste",
+              "open burning of waste",
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "shifts_to_labels": ["composting of organic waste"],
+            "score": 0.2442
           },
-          "transition_element_candidates": [
-            {
-              "stable_id": "shift_to_electricity_in_chemical_industries",
-              "short_label": "T-2B9-TE-3 - Shift to electricity in chemical industries",
-              "description": "Shift to electricity in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within chemical industries, natural gas usage within chemical industries. to: electricity usage within chemical industries. Industry > Chemicals > Other",
-              "sector_path": "Industry > Chemicals > Other",
-              "acts_on_labels": [
-                "coal usage within chemical industries",
-                "natural gas usage within chemical industries"
-              ],
-              "shifts_to_labels": [
-                "electricity usage within chemical industries"
-              ],
-              "score": 0.399
-            },
-            {
-              "stable_id": "shift_to_hydrogen_energy_in_chemical_industries",
-              "short_label": "T-2B9-TE-4 - Shift to hydrogen energy in chemical industries",
-              "description": "Shift to hydrogen energy in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within chemical industries. to: hydrogen usage within chemical industries. Industry > Chemicals > Other",
-              "sector_path": "Industry > Chemicals > Other",
-              "acts_on_labels": [
-                "natural gas usage within chemical industries"
-              ],
-              "shifts_to_labels": [
-                "hydrogen usage within chemical industries"
-              ],
-              "score": 0.3821
-            },
-            {
-              "stable_id": "shift_to_biomass_energy_in_chemical_industries",
-              "short_label": "T-2B9-TE-2 - Shift to biomass energy in chemical industries",
-              "description": "Shift to biomass energy in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within chemical industries. to: biomass usage within chemical industries. Industry > Chemicals > Other",
-              "sector_path": "Industry > Chemicals > Other",
-              "acts_on_labels": [
-                "coal usage within chemical industries"
-              ],
-              "shifts_to_labels": [
-                "biomass usage within chemical industries"
-              ],
-              "score": 0.3768
-            },
-            {
-              "stable_id": "shift_to_electricity_in_lead_industries",
-              "short_label": "T-2C5-TE-3 - Shift to electricity in lead industries",
-              "description": "Shift to electricity in lead industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within lead industries, oil usage within lead industries, natural gas usage within lead industries. to: electricity usage within lead industries. Industry > Metals > Lead",
-              "sector_path": "Industry > Metals > Lead",
-              "acts_on_labels": [
-                "coal usage within lead industries",
-                "oil usage within lead industries",
-                "natural gas usage within lead industries"
-              ],
-              "shifts_to_labels": [
-                "electricity usage within lead industries"
-              ],
-              "score": 0.3749
-            },
-            {
-              "stable_id": "increased_proportion_of_non_travel_meetings_and_services",
-              "short_label": "T-1A1a-TE-7 - Shift to online meetings and services",
-              "description": "Shift to online meetings and services. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to e-meetings in hours to fulfill the need of business trips. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: e meetings. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles",
-                "lpg vehicles",
-                "gas vehicles"
-              ],
-              "shifts_to_labels": [
-                "e meetings"
-              ],
-              "score": 0.373
-            },
-            {
-              "stable_id": "increased_proportion_of_walking_and_cycling",
-              "short_label": "T-1A1a-TE-10 - Shift to walking and cycling",
-              "description": "Shift to walking and cycling. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to walking cycling. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: walking cycling. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles",
-                "lpg vehicles",
-                "gas vehicles"
-              ],
-              "shifts_to_labels": [
-                "walking cycling"
-              ],
-              "score": 0.3684
-            },
-            {
-              "stable_id": "shift_to_gas_vehicles",
-              "short_label": "T-1A1a-TE-19 - Shift to gas cars",
-              "description": "Shift to gas cars. Shift vehicle kilometer from petrol and diesel vehicles to gas vehicles in vehicle kilometer to fulfill the need of mobility. from: petrol vehicles, diesel vehicles. to: gas vehicles. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles"
-              ],
-              "shifts_to_labels": [
-                "gas vehicles"
-              ],
-              "score": 0.3681
-            },
-            {
-              "stable_id": "shift_to_electric_vehicles",
-              "short_label": "T-1A1a-TE-1 - Shift to electric cars",
-              "description": "Shift to electric cars. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to battery electric vehicles in vehicle kilometer to fulfill the need of mobility. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: battery electric vehicles. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles",
-                "lpg vehicles",
-                "gas vehicles"
-              ],
-              "shifts_to_labels": [
-                "battery electric vehicles"
-              ],
-              "score": 0.367
-            },
-            {
-              "stable_id": "shift_to_sustainable_healthy_diet",
-              "short_label": "T-3A1-TE-1 - Shift to Sustainable Healthy Diets",
-              "description": "Shift to Sustainable Healthy Diets. This Transition Element is the shift from animal based diets to plant based diets.. from: enteric fermentation cattle, enteric fermentation sheep, enteric fermentation swine, enteric fermentation other livestock. Afolu > Livestock > Enteric Fermentation",
-              "sector_path": "Afolu > Livestock > Enteric Fermentation",
-              "acts_on_labels": [
-                "enteric fermentation cattle",
-                "enteric fermentation sheep",
-                "enteric fermentation swine",
-                "enteric fermentation other livestock"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.3639
-            },
-            {
-              "stable_id": "shift_to_hydrogen_vehicles",
-              "short_label": "T-1A1a-TE-2 - Shift to hydrogen cars",
-              "description": "Shift to hydrogen cars. Shift vehicle kilometer from petrol and diesel vehicles to hydrogen vehicles in vehicle kilometer to fulfill the need of mobility. from: petrol vehicles, diesel vehicles. to: hydrogen vehicles. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles"
-              ],
-              "shifts_to_labels": [
-                "hydrogen vehicles"
-              ],
-              "score": 0.363
-            },
-            {
-              "stable_id": "increased_recycling",
-              "short_label": "T-6A1-TE-1 - Shift to recycling of solid waste",
-              "description": "Shift to recycling of solid waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to recycling of solid waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: recycling of solid waste. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc",
-                "incineration and open burning of waste",
-                "open burning of waste",
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "shifts_to_labels": [
-                "recycling of solid waste"
-              ],
-              "score": 0.3135
-            },
-            {
-              "stable_id": "shift_to_exported_composting_of_organic_waste",
-              "short_label": "T-6A1-TE-3 - Shift to exported composting of organic waste",
-              "description": "Shift to exported composting of organic waste. Shift tonne from solid waste disposal in landfills to exported composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: waste exported for composting. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc",
-                "incineration and open burning of waste",
-                "open burning of waste",
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "shifts_to_labels": [
-                "waste exported for composting"
-              ],
-              "score": 0.3097
-            },
-            {
-              "stable_id": "shift_to_biomass_energy_in_lead_industries",
-              "short_label": "T-2C5-TE-2 - Shift to biomass energy in lead industries",
-              "description": "Shift to biomass energy in lead industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within lead industries. to: biomass usage within lead industries. Industry > Metals > Lead",
-              "sector_path": "Industry > Metals > Lead",
-              "acts_on_labels": [
-                "coal usage within lead industries"
-              ],
-              "shifts_to_labels": [
-                "biomass usage within lead industries"
-              ],
-              "score": 0.3077
-            },
-            {
-              "stable_id": "shift_to_composting_of_organic_waste",
-              "short_label": "T-6A1-TE-2 - Shift to composting of organic waste",
-              "description": "Shift to composting of organic waste. Shift tonne from solid waste disposal in landfills to composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: composting of organic waste. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc",
-                "incineration and open burning of waste",
-                "open burning of waste",
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "shifts_to_labels": [
-                "composting of organic waste"
-              ],
-              "score": 0.3033
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_chemical_industries",
-              "short_label": "T-2B9-TE-1 - Shift to biogas energy in chemical industries",
-              "description": "Shift to biogas energy in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within chemical industries. to: biogas usage within chemical industries. Industry > Chemicals > Other",
-              "sector_path": "Industry > Chemicals > Other",
-              "acts_on_labels": [
-                "natural gas usage within chemical industries"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within chemical industries"
-              ],
-              "score": 0.301
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_lead_industries",
-              "short_label": "T-2C5-TE-1 - Shift to biogas energy in lead industries",
-              "description": "Shift to biogas energy in lead industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within lead industries. to: biogas usage within lead industries. Industry > Metals > Lead",
-              "sector_path": "Industry > Metals > Lead",
-              "acts_on_labels": [
-                "natural gas usage within lead industries"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within lead industries"
-              ],
-              "score": 0.2984
-            },
-            {
-              "stable_id": "shift_to_electricity_in_other_industries",
-              "short_label": "T-2D5-TE-3 - Shift to electricity in other industries",
-              "description": "Shift to electricity in other industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: industrial unregulated coal use, industrial unregulated oil use, industrial unregulated gas use. to: industrial unregulated electricity use. Industry > Other > Other",
-              "sector_path": "Industry > Other > Other",
-              "acts_on_labels": [
-                "industrial unregulated coal use",
-                "industrial unregulated oil use",
-                "industrial unregulated gas use"
-              ],
-              "shifts_to_labels": [
-                "industrial unregulated electricity use"
-              ],
-              "score": 0.2946
-            }
-          ]
-        }
-      ],
-      "intervention_who": "none",
-      "intervention_when": "none",
-      "intervention_what": "reduce products with phased-out substances",
-      "intervention_how": "none",
-      "intervention_score": 2,
-      "intervention_reasoning": "WHAT is present, but lacks WHO, HOW, or WHEN.",
-      "intervention_type": "indirect"
-    },
-    {
-      "measure_text": "160.Hantera kemiska produkter och övriga kemiska riskkällor i enlighet med 'Rutin för kemikaliehantering'. Det vill säga att inventera och riskbedöma",
-      "activity": "chemical risk management",
-      "activity_shift_score": 1,
-      "activity_shifts": [],
-      "intervention_who": "none",
-      "intervention_when": "none",
-      "intervention_what": "manage chemical products and risks",
-      "intervention_how": "in accordance with 'Rutin för kemikaliehantering'",
-      "intervention_score": 3,
-      "intervention_reasoning": "WHAT and HOW are present, but lacks WHO or WHEN.",
-      "intervention_type": "indirect"
-    },
-    {
-      "measure_text": "161.Förutsättningar för längre och smartare resursutnyttjande ska skapas genom att upprätta cirkulära processer, vid nybyggnation och underhåll.",
-      "activity": "resource utilisation",
-      "activity_shift_score": 4,
-      "activity_shifts": [
-        {
-          "activity": "utilising resources",
-          "shift_from": "linear resource use",
-          "shift_to": "circular resource use",
-          "need": "resource efficiency",
-          "type": "Resource Efficiency Shift",
-          "type_reasoning": "The measure aims to shift from linear to circular resource use, improving efficiency.",
-          "score": 4,
-          "reasoning": "The measure implies a shift towards circular resource use, but FROM and TO are not explicitly named.",
-          "transition_element_matches": [],
-          "transition_element_candidates": [
-            {
-              "stable_id": "increased_recycling",
-              "short_label": "T-6A1-TE-1 - Shift to recycling of solid waste",
-              "description": "Shift to recycling of solid waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to recycling of solid waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: recycling of solid waste. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc",
-                "incineration and open burning of waste",
-                "open burning of waste",
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "shifts_to_labels": [
-                "recycling of solid waste"
-              ],
-              "score": 0.4426
-            },
-            {
-              "stable_id": "shift_to_sustainable_healthy_diet",
-              "short_label": "T-3A1-TE-1 - Shift to Sustainable Healthy Diets",
-              "description": "Shift to Sustainable Healthy Diets. This Transition Element is the shift from animal based diets to plant based diets.. from: enteric fermentation cattle, enteric fermentation sheep, enteric fermentation swine, enteric fermentation other livestock. Afolu > Livestock > Enteric Fermentation",
-              "sector_path": "Afolu > Livestock > Enteric Fermentation",
-              "acts_on_labels": [
-                "enteric fermentation cattle",
-                "enteric fermentation sheep",
-                "enteric fermentation swine",
-                "enteric fermentation other livestock"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.4411
-            },
-            {
-              "stable_id": "increased_proportion_of_walking_and_cycling",
-              "short_label": "T-1A1a-TE-10 - Shift to walking and cycling",
-              "description": "Shift to walking and cycling. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to walking cycling. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: walking cycling. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles",
-                "lpg vehicles",
-                "gas vehicles"
-              ],
-              "shifts_to_labels": [
-                "walking cycling"
-              ],
-              "score": 0.4198
-            },
-            {
-              "stable_id": "shift_to_biomass_energy_in_iron_and_steel_industries",
-              "short_label": "T-2C1-TE-2 - Shift to biomass energy in iron and steel industries",
-              "description": "Shift to biomass energy in iron and steel industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within iron and steel industries. to: biomass usage within iron and steel industries. Industry > Metals > Iron Steel",
-              "sector_path": "Industry > Metals > Iron Steel",
-              "acts_on_labels": [
-                "coal usage within iron and steel industries"
-              ],
-              "shifts_to_labels": [
-                "biomass usage within iron and steel industries"
-              ],
-              "score": 0.4128
-            },
-            {
-              "stable_id": "shift_to_biomass_energy_in_lead_industries",
-              "short_label": "T-2C5-TE-2 - Shift to biomass energy in lead industries",
-              "description": "Shift to biomass energy in lead industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within lead industries. to: biomass usage within lead industries. Industry > Metals > Lead",
-              "sector_path": "Industry > Metals > Lead",
-              "acts_on_labels": [
-                "coal usage within lead industries"
-              ],
-              "shifts_to_labels": [
-                "biomass usage within lead industries"
-              ],
-              "score": 0.4082
-            },
-            {
-              "stable_id": "biofuels_for_cement_and_mineral_industry",
-              "short_label": "T-2A1-TE-1 - Shift to use biofuel in cement and mineral industry",
-              "description": "Shift to use biofuel in cement and mineral industry. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: cement mineral industries coal usage. to: cement mineral industries biomass usage. Industry > Minerals > Cement",
-              "sector_path": "Industry > Minerals > Cement",
-              "acts_on_labels": [
-                "cement mineral industries coal usage"
-              ],
-              "shifts_to_labels": [
-                "cement mineral industries biomass usage"
-              ],
-              "score": 0.4081
-            },
-            {
-              "stable_id": "shift_to_biomass_energy_in_glass_industries",
-              "short_label": "T-2A3-TE-2 - Shift to biomass energy in glass industries",
-              "description": "Shift to biomass energy in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within glass industries. to: biomass usage within glass industries. Industry > Minerals > Glass Production",
-              "sector_path": "Industry > Minerals > Glass Production",
-              "acts_on_labels": [
-                "coal usage within glass industries"
-              ],
-              "shifts_to_labels": [
-                "biomass usage within glass industries"
-              ],
-              "score": 0.4074
-            },
-            {
-              "stable_id": "increased_energy_recovery_from_waste",
-              "short_label": "T-5A3-TE-6 - Increased energy recovery from waste",
-              "description": "Increased energy recovery from waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to CHP waste incineration in tonne to fulfill the need of warm premisses. from: incineration and open burning of waste. to: chp waste incineration. Energy > Energy Supply > Combined Heat Power",
-              "sector_path": "Energy > Energy Supply > Combined Heat Power",
-              "acts_on_labels": [
-                "incineration and open burning of waste"
-              ],
-              "shifts_to_labels": [
-                "chp waste incineration"
-              ],
-              "score": 0.4064
-            },
-            {
-              "stable_id": "shift_to_biomass_energy_in_petroleum_refinement",
-              "short_label": "T-5B1-TE-1 - Shift to biomass energy in petroleum refinement",
-              "description": "Shift to biomass energy in petroleum refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: crude oil usage within petroleum refinement. to: biomass usage within petroleum refinement. Energy > Energy Transformation > Petroleum Refinement",
-              "sector_path": "Energy > Energy Transformation > Petroleum Refinement",
-              "acts_on_labels": [
-                "crude oil usage within petroleum refinement"
-              ],
-              "shifts_to_labels": [
-                "biomass usage within petroleum refinement"
-              ],
-              "score": 0.4062
-            },
-            {
-              "stable_id": "shift_to_biomass_energy_in_hydrogen_refinement",
-              "short_label": "T-5B4-TE-4 - Shift to biomass energy in hydrogen refinement",
-              "description": "Shift to biomass energy in hydrogen refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within hydrogen refinement. to: biomass usage within hydrogen refinement. Energy > Energy Transformation > Hydrogen Refinement",
-              "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
-              "acts_on_labels": [
-                "coal usage within hydrogen refinement"
-              ],
-              "shifts_to_labels": [
-                "biomass usage within hydrogen refinement"
-              ],
-              "score": 0.4057
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_iron_and_steel_industries",
-              "short_label": "T-2C1-TE-1 - Shift to biogas energy in iron and steel industries",
-              "description": "Shift to biogas energy in iron and steel industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within iron and steel industries. to: biogas usage within iron and steel industries. Industry > Metals > Iron Steel",
-              "sector_path": "Industry > Metals > Iron Steel",
-              "acts_on_labels": [
-                "natural gas usage within iron and steel industries"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within iron and steel industries"
-              ],
-              "score": 0.363
-            },
-            {
-              "stable_id": "shift_to_biomass_energy_in_chemical_industries",
-              "short_label": "T-2B9-TE-2 - Shift to biomass energy in chemical industries",
-              "description": "Shift to biomass energy in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within chemical industries. to: biomass usage within chemical industries. Industry > Chemicals > Other",
-              "sector_path": "Industry > Chemicals > Other",
-              "acts_on_labels": [
-                "coal usage within chemical industries"
-              ],
-              "shifts_to_labels": [
-                "biomass usage within chemical industries"
-              ],
-              "score": 0.3591
-            },
-            {
-              "stable_id": "shift_to_biomass_energy_in_magnesium_industries",
-              "short_label": "T-2C4-TE-3 - Shift to biomass energy in magnesium industries",
-              "description": "Shift to biomass energy in magnesium industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within magnesium industries. to: biomass usage within magnesium industries. Industry > Metals > Magnesium",
-              "sector_path": "Industry > Metals > Magnesium",
-              "acts_on_labels": [
-                "coal usage within magnesium industries"
-              ],
-              "shifts_to_labels": [
-                "biomass usage within magnesium industries"
-              ],
-              "score": 0.3586
-            },
-            {
-              "stable_id": "shift_to_biomass_energy_in_pulp_paper_and_print_industries",
-              "short_label": "T-2D1b-TE-2 - Shift to biomass energy in pulp, paper and print industries",
-              "description": "Shift to biomass energy in pulp, paper and print industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within pulp paper and print industries. to: biomass usage within pulp paper and print industries. Industry > Other > Manufacturing > Pulp Paper Print",
-              "sector_path": "Industry > Other > Manufacturing > Pulp Paper Print",
-              "acts_on_labels": [
-                "coal usage within pulp paper and print industries"
-              ],
-              "shifts_to_labels": [
-                "biomass usage within pulp paper and print industries"
-              ],
-              "score": 0.358
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_lead_industries",
-              "short_label": "T-2C5-TE-1 - Shift to biogas energy in lead industries",
-              "description": "Shift to biogas energy in lead industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within lead industries. to: biogas usage within lead industries. Industry > Metals > Lead",
-              "sector_path": "Industry > Metals > Lead",
-              "acts_on_labels": [
-                "natural gas usage within lead industries"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within lead industries"
-              ],
-              "score": 0.3562
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_pulp_paper_and_print_industries",
-              "short_label": "T-2D1b-TE-1 - Shift to biogas energy in pulp, paper and print industries",
-              "description": "Shift to biogas energy in pulp, paper and print industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within pulp paper and print industries. to: biogas usage within pulp paper and print industries. Industry > Other > Manufacturing > Pulp Paper Print",
-              "sector_path": "Industry > Other > Manufacturing > Pulp Paper Print",
-              "acts_on_labels": [
-                "natural gas usage within pulp paper and print industries"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within pulp paper and print industries"
-              ],
-              "score": 0.3545
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_glass_industries",
-              "short_label": "T-2A3-TE-1 - Shift to biogas energy in glass industries",
-              "description": "Shift to biogas energy in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within glass industries. to: biogas usage within glass industries. Industry > Minerals > Glass Production",
-              "sector_path": "Industry > Minerals > Glass Production",
-              "acts_on_labels": [
-                "natural gas usage within glass industries"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within glass industries"
-              ],
-              "score": 0.3517
-            }
-          ]
-        }
-      ],
-      "intervention_who": "none",
-      "intervention_when": "none",
-      "intervention_what": "establish circular processes",
-      "intervention_how": "none",
-      "intervention_score": 2,
-      "intervention_reasoning": "WHAT is present, but lacks WHO, HOW, or WHEN.",
-      "intervention_type": "enabling"
-    },
-    {
-      "measure_text": "162.Kommunen ska i dialog med byggentreprenörer arbeta för hållbart byggande i samband med exploateringsavtal, både sett till materialval, energiförbrukning, produktion och ekosystemtjänster.",
-      "activity": "construction",
-      "activity_shift_score": 3,
-      "activity_shifts": [
-        {
-          "activity": "constructing buildings",
-          "shift_from": "traditional construction methods",
-          "shift_to": "sustainable construction methods",
-          "need": "sustainable development",
-          "type": "Type Shift",
-          "type_reasoning": "The measure aims to shift construction practices to more sustainable methods.",
-          "score": 3,
-          "reasoning": "The measure implies a shift towards sustainable construction, but FROM and TO are not clearly defined.",
-          "transition_element_matches": [],
-          "transition_element_suggested_new": {
-            "short_label": "Sustainable Construction Practices",
-            "description": "Transition from traditional to sustainable construction methods focusing on material choice, energy consumption, production, and ecosystem services."
+          {
+            "stable_id": "shift_to_biogas_energy_in_lead_industries",
+            "short_label": "T-2C5-TE-1 - Shift to biogas energy in lead industries",
+            "description": "Shift to biogas energy in lead industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within lead industries. to: biogas usage within lead industries. Industry > Metals > Lead",
+            "sector_path": "Industry > Metals > Lead",
+            "acts_on_labels": ["natural gas usage within lead industries"],
+            "shifts_to_labels": ["biogas usage within lead industries"],
+            "score": 0.244
           },
-          "transition_element_candidates": [
-            {
-              "stable_id": "low_carbon_construction_of_multi_family_residential_housing",
-              "short_label": "T-4C1-TE-2 - Low carbon construction of multi-family buildings",
-              "description": "Low carbon construction of multi-family buildings. Shift square meter from residential multi family standard construction to residential multi family low carbon construction in square meter to fulfill the need of housing. from: residential multi family standard construction. to: residential multi family low carbon construction. Buildings > Building Stocks > Construction",
-              "sector_path": "Buildings > Building Stocks > Construction",
-              "acts_on_labels": [
-                "residential multi family standard construction"
-              ],
-              "shifts_to_labels": [
-                "residential multi family low carbon construction"
-              ],
-              "score": 0.5077
-            },
-            {
-              "stable_id": "low_carbon_construction_of_non_residential_commercial_buildings",
-              "short_label": "T-4C1-TE-3 - Low carbon construction of commercial buildings",
-              "description": "Low carbon construction of commercial buildings. Shift square meter from non residential commercial standard construction to non residential commercial low carbon construction in square meter to fulfill the need of housing. from: non residential commercial standard construction. to: non residential commercial low carbon construction. Buildings > Building Stocks > Construction",
-              "sector_path": "Buildings > Building Stocks > Construction",
-              "acts_on_labels": [
-                "non residential commercial standard construction"
-              ],
-              "shifts_to_labels": [
-                "non residential commercial low carbon construction"
-              ],
-              "score": 0.5043
-            },
-            {
-              "stable_id": "low_carbon_construction_of_buildings",
-              "short_label": "T-4C1-TE-1 - Low carbon construction of buildings",
-              "description": "Low carbon construction of buildings. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: non residential commercial standard construction. to: non residential commercial low carbon construction. Buildings > Building Stocks > Construction",
-              "sector_path": "Buildings > Building Stocks > Construction",
-              "acts_on_labels": [
-                "non residential commercial standard construction"
-              ],
-              "shifts_to_labels": [
-                "non residential commercial low carbon construction"
-              ],
-              "score": 0.4863
-            },
-            {
-              "stable_id": "shift_to_sustainable_healthy_diet",
-              "short_label": "T-3A1-TE-1 - Shift to Sustainable Healthy Diets",
-              "description": "Shift to Sustainable Healthy Diets. This Transition Element is the shift from animal based diets to plant based diets.. from: enteric fermentation cattle, enteric fermentation sheep, enteric fermentation swine, enteric fermentation other livestock. Afolu > Livestock > Enteric Fermentation",
-              "sector_path": "Afolu > Livestock > Enteric Fermentation",
-              "acts_on_labels": [
-                "enteric fermentation cattle",
-                "enteric fermentation sheep",
-                "enteric fermentation swine",
-                "enteric fermentation other livestock"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.4624
-            },
-            {
-              "stable_id": "biofuels_for_cement_and_mineral_industry",
-              "short_label": "T-2A1-TE-1 - Shift to use biofuel in cement and mineral industry",
-              "description": "Shift to use biofuel in cement and mineral industry. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: cement mineral industries coal usage. to: cement mineral industries biomass usage. Industry > Minerals > Cement",
-              "sector_path": "Industry > Minerals > Cement",
-              "acts_on_labels": [
-                "cement mineral industries coal usage"
-              ],
-              "shifts_to_labels": [
-                "cement mineral industries biomass usage"
-              ],
-              "score": 0.4358
-            },
-            {
-              "stable_id": "shift_to_biomass_energy_in_glass_industries",
-              "short_label": "T-2A3-TE-2 - Shift to biomass energy in glass industries",
-              "description": "Shift to biomass energy in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within glass industries. to: biomass usage within glass industries. Industry > Minerals > Glass Production",
-              "sector_path": "Industry > Minerals > Glass Production",
-              "acts_on_labels": [
-                "coal usage within glass industries"
-              ],
-              "shifts_to_labels": [
-                "biomass usage within glass industries"
-              ],
-              "score": 0.4193
-            },
-            {
-              "stable_id": "shift_to_biomass_energy_in_lead_industries",
-              "short_label": "T-2C5-TE-2 - Shift to biomass energy in lead industries",
-              "description": "Shift to biomass energy in lead industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within lead industries. to: biomass usage within lead industries. Industry > Metals > Lead",
-              "sector_path": "Industry > Metals > Lead",
-              "acts_on_labels": [
-                "coal usage within lead industries"
-              ],
-              "shifts_to_labels": [
-                "biomass usage within lead industries"
-              ],
-              "score": 0.4115
-            },
-            {
-              "stable_id": "shift_to_solar_thermal_in_industrial_buildings",
-              "short_label": "T-4B1c-TE-5 - Shift to solar thermal in industrial buildings",
-              "description": "Shift to solar thermal in industrial buildings. Shift square meter from industrial building heated with gas, oil, direct. from: industrial building heating with gas, industrial building heating with oil, industrial building heating with direct electric heaters, industrial building heating with lpg, industrial building heating with coal, industrial building heating with gas oil. to: industrial building heating with solar thermal. Buildings > Non Residential > Hvac > Other Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Other Hvac",
-              "acts_on_labels": [
-                "industrial building heating with gas",
-                "industrial building heating with oil",
-                "industrial building heating with direct electric heaters",
-                "industrial building heating with lpg",
-                "industrial building heating with coal",
-                "industrial building heating with gas oil"
-              ],
-              "shifts_to_labels": [
-                "industrial building heating with solar thermal"
-              ],
-              "score": 0.4081
-            },
-            {
-              "stable_id": "shift_to_hydrogen_energy_in_glass_industries",
-              "short_label": "T-2A3-TE-4 - Shift to hydrogen energy in glass industries",
-              "description": "Shift to hydrogen energy in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within glass industries. to: hydrogen usage within glass industries. Industry > Minerals > Glass Production",
-              "sector_path": "Industry > Minerals > Glass Production",
-              "acts_on_labels": [
-                "natural gas usage within glass industries"
-              ],
-              "shifts_to_labels": [
-                "hydrogen usage within glass industries"
-              ],
-              "score": 0.4055
-            },
-            {
-              "stable_id": "shift_to_biomass_energy_in_magnesium_industries",
-              "short_label": "T-2C4-TE-3 - Shift to biomass energy in magnesium industries",
-              "description": "Shift to biomass energy in magnesium industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within magnesium industries. to: biomass usage within magnesium industries. Industry > Metals > Magnesium",
-              "sector_path": "Industry > Metals > Magnesium",
-              "acts_on_labels": [
-                "coal usage within magnesium industries"
-              ],
-              "shifts_to_labels": [
-                "biomass usage within magnesium industries"
-              ],
-              "score": 0.4051
-            },
-            {
-              "stable_id": "energy_efficient_new_commercial_buildings",
-              "short_label": "T-4B1a-TE-9 - Energy efficient new Commercial Buildings",
-              "description": "Energy efficient new Commercial Buildings. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: heating of new public buildings, heating of new commercial buildings, heating of new industrial buildings. Buildings > Non Residential > Hvac > Commercial Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Commercial Hvac",
-              "acts_on_labels": [
-                "heating of new public buildings",
-                "heating of new commercial buildings",
-                "heating of new industrial buildings"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.3852
-            },
-            {
-              "stable_id": "energy_efficient_new_housing",
-              "short_label": "T-4A1-TE-1 - Energy efficient new Housing",
-              "description": "Energy efficient new Housing. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: heating of new residential single family buildings, heating of new residential multi family buildings. Buildings > Residential > Hvac",
-              "sector_path": "Buildings > Residential > Hvac",
-              "acts_on_labels": [
-                "heating of new residential single family buildings",
-                "heating of new residential multi family buildings"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.3852
-            },
-            {
-              "stable_id": "energy_efficient_non_residential_public_buildings_retrofitting",
-              "short_label": "T-4B1b-TE-6 - Retrofitting public buildings for efficient heating",
-              "description": "Retrofitting public buildings for efficient heating. Reduce the amount of energy required to heat public building heating. from: public building heating with solid biofuels, public building heating with direct electric heaters, public building heating with gas, public building heating with propane, public building heating with oil, public building heating with heatpump, public building heating with district heating, public building heating with coal, public building heating with solar thermal, public building heating with lpg, public building heating with hydrogen, public building heating with gas oil. Buildings > Non Residential > Hvac > Institutional Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
-              "acts_on_labels": [
-                "public building heating with solid biofuels",
-                "public building heating with direct electric heaters",
-                "public building heating with gas",
-                "public building heating with propane",
-                "public building heating with oil",
-                "public building heating with heatpump",
-                "public building heating with district heating",
-                "public building heating with coal",
-                "public building heating with solar thermal",
-                "public building heating with lpg",
-                "public building heating with hydrogen",
-                "public building heating with gas oil"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.3846
-            },
-            {
-              "stable_id": "energy_efficient_non_residential_industrial_buildings_retrofitting",
-              "short_label": "T-4B1c-TE-6 - Retrofitting industrial buildings for efficient heating",
-              "description": "Retrofitting industrial buildings for efficient heating. Reduce the amount of energy required to heat industrial building with. from: industrial building heating with solid biofuels, industrial building heating with direct electric heaters, industrial building heating with district heating, industrial building heating with heatpump, industrial building heating with oil, industrial building heating with gas, industrial building heating with lpg, industrial building heating with coal, industrial building heating with hydrogen, industrial building heating with solar thermal, industrial building heating with gas oil. Buildings > Non Residential > Hvac > Other Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Other Hvac",
-              "acts_on_labels": [
-                "industrial building heating with solid biofuels",
-                "industrial building heating with direct electric heaters",
-                "industrial building heating with district heating",
-                "industrial building heating with heatpump",
-                "industrial building heating with oil",
-                "industrial building heating with gas",
-                "industrial building heating with lpg",
-                "industrial building heating with coal",
-                "industrial building heating with hydrogen",
-                "industrial building heating with solar thermal",
-                "industrial building heating with gas oil"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.3758
-            },
-            {
-              "stable_id": "shift_to_solar_thermal_in_public_buildings",
-              "short_label": "T-4B1b-TE-5 - Shift to solar thermal in public buildings",
-              "description": "Shift to solar thermal in public buildings. Shift square meter from public building heated with oil, gas, direct. from: public building heating with oil, public building heating with gas, public building heating with propane, public building heating with direct electric heaters, public building heating with coal, public building heating with lpg, public building heating with gas oil. to: public building heating with solar thermal. Buildings > Non Residential > Hvac > Institutional Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
-              "acts_on_labels": [
-                "public building heating with oil",
-                "public building heating with gas",
-                "public building heating with propane",
-                "public building heating with direct electric heaters",
-                "public building heating with coal",
-                "public building heating with lpg",
-                "public building heating with gas oil"
-              ],
-              "shifts_to_labels": [
-                "public building heating with solar thermal"
-              ],
-              "score": 0.3662
-            },
-            {
-              "stable_id": "shift_to_solar_thermal_in_commercial_buildings",
-              "short_label": "T-4B1a-TE-5 - Shift to solar thermal in commercial buildings",
-              "description": "Shift to solar thermal in commercial buildings. Shift square meter from commercial building heated with gas, oil, direct. from: commercial building heating with gas, commercial building heating with propane, commercial building heating with oil, commercial building heating with direct electric heaters, commercial building heating with coal, commercial building heating with lpg, commercial building heating with gas oil. to: commercial building heating with solar thermal. Buildings > Non Residential > Hvac > Commercial Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Commercial Hvac",
-              "acts_on_labels": [
-                "commercial building heating with gas",
-                "commercial building heating with propane",
-                "commercial building heating with oil",
-                "commercial building heating with direct electric heaters",
-                "commercial building heating with coal",
-                "commercial building heating with lpg",
-                "commercial building heating with gas oil"
-              ],
-              "shifts_to_labels": [
-                "commercial building heating with solar thermal"
-              ],
-              "score": 0.3646
-            },
-            {
-              "stable_id": "heating_non_residential_commercial_buildings_with_renewable_solid_biofuels",
-              "short_label": "T-4B1a-TE-4 - Shift to biofuel in commercial buildings",
-              "description": "Shift to biofuel in commercial buildings. Shift square meter from commercial buildings heated with gas, oil, direct. from: commercial building heating with gas, commercial building heating with propane, commercial building heating with oil, commercial building heating with direct electric heaters, commercial building heating with coal, commercial building heating with lpg, commercial building heating with gas oil. to: commercial building heating with solid biofuels. Buildings > Non Residential > Hvac > Commercial Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Commercial Hvac",
-              "acts_on_labels": [
-                "commercial building heating with gas",
-                "commercial building heating with propane",
-                "commercial building heating with oil",
-                "commercial building heating with direct electric heaters",
-                "commercial building heating with coal",
-                "commercial building heating with lpg",
-                "commercial building heating with gas oil"
-              ],
-              "shifts_to_labels": [
-                "commercial building heating with solid biofuels"
-              ],
-              "score": 0.3593
-            },
-            {
-              "stable_id": "heating_non_residential_public_buildings_with_renewable_solid_biofuels",
-              "short_label": "T-4B1b-TE-4 - Shift to biofuel in public buildings",
-              "description": "Shift to biofuel in public buildings. Shift square meter from public buildings heated with oil, gas, direct. from: public building heating with oil, public building heating with gas, public building heating with propane, public building heating with direct electric heaters, public building heating with coal, public building heating with lpg, public building heating with gas oil. to: public building heating with solid biofuels. Buildings > Non Residential > Hvac > Institutional Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
-              "acts_on_labels": [
-                "public building heating with oil",
-                "public building heating with gas",
-                "public building heating with propane",
-                "public building heating with direct electric heaters",
-                "public building heating with coal",
-                "public building heating with lpg",
-                "public building heating with gas oil"
-              ],
-              "shifts_to_labels": [
-                "public building heating with solid biofuels"
-              ],
-              "score": 0.3591
-            },
-            {
-              "stable_id": "energy_efficient_non_residential_public_buildings_retrofitting_cooling",
-              "short_label": "T-4B1b-TE-7 - Retrofitting public buildings for efficient cooling",
-              "description": "Retrofitting public buildings for efficient cooling. Reduce the amount of energy required to cool public building with AC and disitrct cooling through retrofitting. from: public building cooling with ac, public building cooling with district cooling. Buildings > Non Residential > Hvac > Institutional Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
-              "acts_on_labels": [
-                "public building cooling with ac",
-                "public building cooling with district cooling"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.3588
-            },
-            {
-              "stable_id": "shift_to_biogas_heating_of_non_residential_commercial_buildings",
-              "short_label": "T-4B1a-TE-10 - Shift to biogas in commercial buildings",
-              "description": "Shift to biogas in commercial buildings. Shift square meter from commercial building heating with gas to commercial building heating with biogas in square meter to fulfill the need of comfortable premises. from: commercial building heating with gas. to: commercial building heating with biogas. Buildings > Non Residential > Hvac > Commercial Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Commercial Hvac",
-              "acts_on_labels": [
-                "commercial building heating with gas"
-              ],
-              "shifts_to_labels": [
-                "commercial building heating with biogas"
-              ],
-              "score": 0.3552
-            },
-            {
-              "stable_id": "energy_efficient_non_residential_industrial_buildings_retrofitting_cooling",
-              "short_label": "T-4B1c-TE-7 - Retrofitting industrial buildings for efficient cooling",
-              "description": "Retrofitting industrial buildings for efficient cooling. Reduce the amount of energy required to cool industrial building with AC and disitrct cooling through retrofitting. from: industrial building cooling with ac, industrial building cooling with district cooling. Buildings > Non Residential > Hvac > Other Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Other Hvac",
-              "acts_on_labels": [
-                "industrial building cooling with ac",
-                "industrial building cooling with district cooling"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.3549
-            }
-          ]
-        }
-      ],
-      "intervention_who": "kommunen",
-      "intervention_when": "none",
-      "intervention_what": "work for sustainable construction",
-      "intervention_how": "in dialogue with builders",
-      "intervention_score": 4,
-      "intervention_reasoning": "WHO, WHAT, and HOW are present, but lacks WHEN.",
-      "intervention_type": "indirect"
-    },
-    {
-      "measure_text": "163.Kommunala lokaler och anläggningar ska öka i nyttjandegrad och i högre utsträckning vara tillgängliga för användande.",
-      "activity": "facility utilisation",
-      "activity_shift_score": 3,
-      "activity_shifts": [
-        {
-          "activity": "using facilities",
-          "shift_from": "low utilisation",
-          "shift_to": "high utilisation",
-          "need": "space efficiency",
-          "type": "Utilisation Shift",
-          "type_reasoning": "The measure aims to increase the utilisation of municipal facilities.",
-          "score": 3,
-          "reasoning": "The measure implies a shift towards higher utilisation, but FROM and TO are not clearly defined.",
-          "transition_element_matches": [],
-          "transition_element_suggested_new": {
-            "short_label": "Increased Utilisation of Municipal Facilities",
-            "description": "Enhancing the utilisation rate of municipal buildings and facilities to improve space efficiency and reduce energy consumption per unit of use."
+          {
+            "stable_id": "shift_to_hydrogen_energy_in_glass_industries",
+            "short_label": "T-2A3-TE-4 - Shift to hydrogen energy in glass industries",
+            "description": "Shift to hydrogen energy in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within glass industries. to: hydrogen usage within glass industries. Industry > Minerals > Glass Production",
+            "sector_path": "Industry > Minerals > Glass Production",
+            "acts_on_labels": ["natural gas usage within glass industries"],
+            "shifts_to_labels": ["hydrogen usage within glass industries"],
+            "score": 0.2432
           },
-          "transition_element_candidates": [
-            {
-              "stable_id": "energy_efficient_other_institutional_electric_appliances",
-              "short_label": "T-4B2c-TE-3 - Energy efficient public electrical appliances",
-              "description": "Energy efficient public electrical appliances. Reduce the amount of energy required to operate institutional electrical appliances. from: institutional unregulated electricity use. Buildings > Non Residential > Other Energy Usage > Other",
-              "sector_path": "Buildings > Non Residential > Other Energy Usage > Other",
-              "acts_on_labels": [
-                "institutional unregulated electricity use"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.4034
-            },
-            {
-              "stable_id": "shift_to_district_cooling_in_public_buildings",
-              "short_label": "T-4B1b-TE-2 - Shift to district cooling in public buildings",
-              "description": "Shift to district cooling in public buildings. Shift square meter from industrial building cooling with AC to industrial building cooling with district cooling in square meter to fulfill the need of comfortable premises. from: public building cooling with ac. to: public building cooling with district cooling. Buildings > Non Residential > Hvac > Institutional Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
-              "acts_on_labels": [
-                "public building cooling with ac"
-              ],
-              "shifts_to_labels": [
-                "public building cooling with district cooling"
-              ],
-              "score": 0.3792
-            },
-            {
-              "stable_id": "efficient_use_multi_family_residential_buildings_cooling",
-              "short_label": "T-4A1a-TE-7 - Energy efficient use of ACs in multi-family buildings",
-              "description": "Energy efficient use of ACs in multi-family buildings. Reduce the amount of energy required to cool multi family buildings with AC through efficient use of AC units. from: multi family building cooling with ac. Buildings > Residential > Hvac > Multi Family Hvac",
-              "sector_path": "Buildings > Residential > Hvac > Multi Family Hvac",
-              "acts_on_labels": [
-                "multi family building cooling with ac"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.3731
-            },
-            {
-              "stable_id": "shift_to_district_cooling_in_multi_family_buildings",
-              "short_label": "T-4A1a-TE-3 - Shift to district cooling in multi-family buildings",
-              "description": "Shift to district cooling in multi-family buildings. Shift square meter from multi family building cooling with AC to multi family building cooling with district cooling in square meter to fulfill the need of comfortable premises. from: multi family building cooling with ac. to: multi family building cooling with district cooling. Buildings > Residential > Hvac > Multi Family Hvac",
-              "sector_path": "Buildings > Residential > Hvac > Multi Family Hvac",
-              "acts_on_labels": [
-                "multi family building cooling with ac"
-              ],
-              "shifts_to_labels": [
-                "multi family building cooling with district cooling"
-              ],
-              "score": 0.3639
-            },
-            {
-              "stable_id": "energy_efficient_other_industrial_electric_appliances",
-              "short_label": "T-4B2c-TE-2 - Energy efficient industrial electrical appliances",
-              "description": "Energy efficient industrial electrical appliances. Reduce the amount of energy required to operate industrial electrical appliances. from: industrial unregulated electricity use. Buildings > Non Residential > Other Energy Usage > Other",
-              "sector_path": "Buildings > Non Residential > Other Energy Usage > Other",
-              "acts_on_labels": [
-                "industrial unregulated electricity use"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.3614
-            },
-            {
-              "stable_id": "shift_to_district_cooling_in_industrial_buildings",
-              "short_label": "T-4B1c-TE-2 - Shift to district cooling in industrial buildings",
-              "description": "Shift to district cooling in industrial buildings. Shift square meter from industrial building cooling with AC to industrial building cooling with district cooling in square meter to fulfill the need of comfortable premises. from: industrial building cooling with ac. to: industrial building cooling with district cooling. Buildings > Non Residential > Hvac > Other Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Other Hvac",
-              "acts_on_labels": [
-                "industrial building cooling with ac"
-              ],
-              "shifts_to_labels": [
-                "industrial building cooling with district cooling"
-              ],
-              "score": 0.3613
-            },
-            {
-              "stable_id": "energy_efficient_multi_family_residential_buildings_cooling",
-              "short_label": "T-4A1a-TE-8 - Energy efficient AC in multi-family buildings",
-              "description": "Energy efficient AC in multi-family buildings. Reduce the amount of energy required to cool multi family buildings with AC through more efficient AC units. from: multi family building cooling with ac. Buildings > Residential > Hvac > Multi Family Hvac",
-              "sector_path": "Buildings > Residential > Hvac > Multi Family Hvac",
-              "acts_on_labels": [
-                "multi family building cooling with ac"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.3549
-            },
-            {
-              "stable_id": "energy_efficient_other_commercial_electric_appliances",
-              "short_label": "T-4B2c-TE-1 - Energy efficient commercial electrical appliances",
-              "description": "Energy efficient commercial electrical appliances. Reduce the amount of energy required to operate commercial electrical appliances. from: commercial unregulated electricity use. Buildings > Non Residential > Other Energy Usage > Other",
-              "sector_path": "Buildings > Non Residential > Other Energy Usage > Other",
-              "acts_on_labels": [
-                "commercial unregulated electricity use"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.3546
-            },
-            {
-              "stable_id": "energy_efficient_non_residential_public_buildings_retrofitting",
-              "short_label": "T-4B1b-TE-6 - Retrofitting public buildings for efficient heating",
-              "description": "Retrofitting public buildings for efficient heating. Reduce the amount of energy required to heat public building heating. from: public building heating with solid biofuels, public building heating with direct electric heaters, public building heating with gas, public building heating with propane, public building heating with oil, public building heating with heatpump, public building heating with district heating, public building heating with coal, public building heating with solar thermal, public building heating with lpg, public building heating with hydrogen, public building heating with gas oil. Buildings > Non Residential > Hvac > Institutional Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
-              "acts_on_labels": [
-                "public building heating with solid biofuels",
-                "public building heating with direct electric heaters",
-                "public building heating with gas",
-                "public building heating with propane",
-                "public building heating with oil",
-                "public building heating with heatpump",
-                "public building heating with district heating",
-                "public building heating with coal",
-                "public building heating with solar thermal",
-                "public building heating with lpg",
-                "public building heating with hydrogen",
-                "public building heating with gas oil"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.3531
-            },
-            {
-              "stable_id": "energy_efficient_non_residential_public_buildings_retrofitting_cooling",
-              "short_label": "T-4B1b-TE-7 - Retrofitting public buildings for efficient cooling",
-              "description": "Retrofitting public buildings for efficient cooling. Reduce the amount of energy required to cool public building with AC and disitrct cooling through retrofitting. from: public building cooling with ac, public building cooling with district cooling. Buildings > Non Residential > Hvac > Institutional Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
-              "acts_on_labels": [
-                "public building cooling with ac",
-                "public building cooling with district cooling"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.3512
-            },
-            {
-              "stable_id": "shift_to_district_cooling_in_commercial_buildings",
-              "short_label": "T-4B1a-TE-2 - Shift to district cooling in commerical buildings",
-              "description": "Shift to district cooling in commerical buildings. Shift square meter from commerical building cooling with AC to commerical building cooling with district cooling in square meter to fulfill the need of comfortable premises. from: commercial building cooling with ac. to: commercial building cooling with district cooling. Buildings > Non Residential > Hvac > Commercial Hvac",
-              "sector_path": "Buildings > Non Residential > Hvac > Commercial Hvac",
-              "acts_on_labels": [
-                "commercial building cooling with ac"
-              ],
-              "shifts_to_labels": [
-                "commercial building cooling with district cooling"
-              ],
-              "score": 0.3508
-            },
-            {
-              "stable_id": "efficient_use_single_family_residential_buildings_cooling",
-              "short_label": "T-4A1b-TE-7 - Energy efficient use of ACs in single-family buildings",
-              "description": "Energy efficient use of ACs in single-family buildings. Reduce the amount of energy required to cool single family buildings with AC through efficient use of AC units. from: single family building cooling with ac. Buildings > Residential > Hvac > Single Family Hvac",
-              "sector_path": "Buildings > Residential > Hvac > Single Family Hvac",
-              "acts_on_labels": [
-                "single family building cooling with ac"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.3491
-            },
-            {
-              "stable_id": "energy_efficient_street_lighting",
-              "short_label": "T-4B2a-TE-1 - Energy efficient street lighting",
-              "description": "Energy efficient street lighting. Reduce the amount of energy required to operate street lighting. from: institutional electric street lighting. Buildings > Non Residential > Other Energy Usage > Lighting",
-              "sector_path": "Buildings > Non Residential > Other Energy Usage > Lighting",
-              "acts_on_labels": [
-                "institutional electric street lighting"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.3473
-            },
-            {
-              "stable_id": "increased_energy_recovery_from_waste",
-              "short_label": "T-5A3-TE-6 - Increased energy recovery from waste",
-              "description": "Increased energy recovery from waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to CHP waste incineration in tonne to fulfill the need of warm premisses. from: incineration and open burning of waste. to: chp waste incineration. Energy > Energy Supply > Combined Heat Power",
-              "sector_path": "Energy > Energy Supply > Combined Heat Power",
-              "acts_on_labels": [
-                "incineration and open burning of waste"
-              ],
-              "shifts_to_labels": [
-                "chp waste incineration"
-              ],
-              "score": 0.3434
-            },
-            {
-              "stable_id": "low_carbon_construction_of_multi_family_residential_housing",
-              "short_label": "T-4C1-TE-2 - Low carbon construction of multi-family buildings",
-              "description": "Low carbon construction of multi-family buildings. Shift square meter from residential multi family standard construction to residential multi family low carbon construction in square meter to fulfill the need of housing. from: residential multi family standard construction. to: residential multi family low carbon construction. Buildings > Building Stocks > Construction",
-              "sector_path": "Buildings > Building Stocks > Construction",
-              "acts_on_labels": [
-                "residential multi family standard construction"
-              ],
-              "shifts_to_labels": [
-                "residential multi family low carbon construction"
-              ],
-              "score": 0.3421
-            },
-            {
-              "stable_id": "shift_to_commercial_electric_cooking_stoves",
-              "short_label": "T-4B2b-TE-1 - Shift to commercial electric cooking stoves",
-              "description": "Shift to commercial electric cooking stoves. Shift kWh from commercial cooking gas stoves to commercial electric cooking stoves in kWh to fullfill the need for cooking. from: commercial gas cooking stoves. to: commercial electric cooking stoves. Buildings > Non Residential > Other Energy Usage > Equipment Appliances",
-              "sector_path": "Buildings > Non Residential > Other Energy Usage > Equipment Appliances",
-              "acts_on_labels": [
-                "commercial gas cooking stoves"
-              ],
-              "shifts_to_labels": [
-                "commercial electric cooking stoves"
-              ],
-              "score": 0.3375
-            },
-            {
-              "stable_id": "improved_load_factor_heavy_trucks",
-              "short_label": "T-1B1b-TE-8 - Improved load factor for heavy trucks",
-              "description": "Improved load factor for heavy trucks. Reduce the amount of energy required to operate diesel heavy trucks through improved load factor. from: diesel heavy trucks, battery electric heavy trucks, hydrogen heavy trucks, gas heavy trucks, petrol heavy trucks. Transport > Freight > Road > Heavy Duty Trucks",
-              "sector_path": "Transport > Freight > Road > Heavy Duty Trucks",
-              "acts_on_labels": [
-                "diesel heavy trucks",
-                "battery electric heavy trucks",
-                "hydrogen heavy trucks",
-                "gas heavy trucks",
-                "petrol heavy trucks"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.3375
-            },
-            {
-              "stable_id": "shift_to_residential_electric_cooking_stoves",
-              "short_label": "T-4A2d-TE-2 - Shift to residential electric cooking stoves",
-              "description": "Shift to residential electric cooking stoves. Shift kWh from residential cooking gas stoves to residential electric cooking stoves in kWh to fullfill the need for cooking. from: residential gas cooking stoves. to: residential electric cooking stoves. Buildings > Residential > Other Energy Usage > Unregulated",
-              "sector_path": "Buildings > Residential > Other Energy Usage > Unregulated",
-              "acts_on_labels": [
-                "residential gas cooking stoves"
-              ],
-              "shifts_to_labels": [
-                "residential electric cooking stoves"
-              ],
-              "score": 0.3351
-            },
-            {
-              "stable_id": "transfer_from_car_to_remote_working",
-              "short_label": "T-1A1a-TE-8 - Shift from car to remote working",
-              "description": "Shift from car to remote working. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to remote working. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: remote working. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles",
-                "lpg vehicles",
-                "gas vehicles"
-              ],
-              "shifts_to_labels": [
-                "remote working"
-              ],
-              "score": 0.3341
-            },
-            {
-              "stable_id": "shift_to_gas_vehicles",
-              "short_label": "T-1A1a-TE-19 - Shift to gas cars",
-              "description": "Shift to gas cars. Shift vehicle kilometer from petrol and diesel vehicles to gas vehicles in vehicle kilometer to fulfill the need of mobility. from: petrol vehicles, diesel vehicles. to: gas vehicles. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles"
-              ],
-              "shifts_to_labels": [
-                "gas vehicles"
-              ],
-              "score": 0.3304
-            },
-            {
-              "stable_id": "shift_to_hydrogen_vehicles",
-              "short_label": "T-1A1a-TE-2 - Shift to hydrogen cars",
-              "description": "Shift to hydrogen cars. Shift vehicle kilometer from petrol and diesel vehicles to hydrogen vehicles in vehicle kilometer to fulfill the need of mobility. from: petrol vehicles, diesel vehicles. to: hydrogen vehicles. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles"
-              ],
-              "shifts_to_labels": [
-                "hydrogen vehicles"
-              ],
-              "score": 0.3279
-            },
-            {
-              "stable_id": "transfer_from_heavy_truck_to_sea",
-              "short_label": "T-1B1b-TE-9 - Shift from heavy truck to sea",
-              "description": "Shift from heavy truck to sea. Shift tonne kilometer from diesel heavy trucks to ship freight in tonne kilometer to fulfill the need of logistics. from: diesel heavy trucks, petrol heavy trucks. to: ship freight. Transport > Freight > Road > Heavy Duty Trucks",
-              "sector_path": "Transport > Freight > Road > Heavy Duty Trucks",
-              "acts_on_labels": [
-                "diesel heavy trucks",
-                "petrol heavy trucks"
-              ],
-              "shifts_to_labels": [
-                "ship freight"
-              ],
-              "score": 0.3268
-            },
-            {
-              "stable_id": "hydrogen_for_heavy_trucks",
-              "short_label": "T-1B1b-TE-4 - Shift to hydrogen for heavy trucks",
-              "description": "Shift to hydrogen for heavy trucks. Shift tonne kilometer from diesel heavy trucks to hydrogen heavy trucks in tonne kilometer to fulfill the need for logistics. from: diesel heavy trucks, petrol heavy trucks. to: hydrogen heavy trucks. Transport > Freight > Road > Heavy Duty Trucks",
-              "sector_path": "Transport > Freight > Road > Heavy Duty Trucks",
-              "acts_on_labels": [
-                "diesel heavy trucks",
-                "petrol heavy trucks"
-              ],
-              "shifts_to_labels": [
-                "hydrogen heavy trucks"
-              ],
-              "score": 0.3257
-            },
-            {
-              "stable_id": "increased_proportion_of_non_travel_meetings_and_services",
-              "short_label": "T-1A1a-TE-7 - Shift to online meetings and services",
-              "description": "Shift to online meetings and services. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to e-meetings in hours to fulfill the need of business trips. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: e meetings. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles",
-                "lpg vehicles",
-                "gas vehicles"
-              ],
-              "shifts_to_labels": [
-                "e meetings"
-              ],
-              "score": 0.3255
-            },
-            {
-              "stable_id": "gas_heavy_trucks",
-              "short_label": "T-1B1b-TE-1 - Shift to gas heavy trucks",
-              "description": "Shift to gas heavy trucks. Shift tonne kilometer from diesel heavy trucks to gas heavy trucks in tonne kilometer to fulfill the need of logistics. from: diesel heavy trucks, petrol heavy trucks. to: gas heavy trucks. Transport > Freight > Road > Heavy Duty Trucks",
-              "sector_path": "Transport > Freight > Road > Heavy Duty Trucks",
-              "acts_on_labels": [
-                "diesel heavy trucks",
-                "petrol heavy trucks"
-              ],
-              "shifts_to_labels": [
-                "gas heavy trucks"
-              ],
-              "score": 0.3254
-            }
-          ]
-        }
-      ],
-      "intervention_who": "none",
-      "intervention_when": "none",
-      "intervention_what": "increase utilisation of facilities",
-      "intervention_how": "none",
-      "intervention_score": 2,
-      "intervention_reasoning": "WHAT is present, but lacks WHO, HOW, or WHEN.",
-      "intervention_type": "indirect"
-    },
-    {
-      "measure_text": "166.Kommunens samtliga verksamheter ska systematiskt arbeta för insatser som minimerar mängden avfall och ökar andelen återanvända produkter.",
-      "activity": "waste management",
-      "activity_shift_score": 5,
-      "activity_shifts": [
-        {
-          "activity": "managing waste",
-          "shift_from": "high waste generation",
-          "shift_to": "waste minimisation and reuse",
-          "need": "waste management",
-          "type": "Utilisation Shift",
-          "type_reasoning": "The measure focuses on reducing waste and increasing reuse, which is a change in utilisation of resources.",
-          "score": 5,
-          "reasoning": "The measure clearly identifies the activity (managing waste), the shift from high waste to minimisation and reuse, and the need (waste management).",
-          "transition_element_matches": [],
-          "transition_element_candidates": [
-            {
-              "stable_id": "increased_recycling",
-              "short_label": "T-6A1-TE-1 - Shift to recycling of solid waste",
-              "description": "Shift to recycling of solid waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to recycling of solid waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: recycling of solid waste. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc",
-                "incineration and open burning of waste",
-                "open burning of waste",
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "shifts_to_labels": [
-                "recycling of solid waste"
-              ],
-              "score": 0.6177
-            },
-            {
-              "stable_id": "shift_to_composting_of_organic_waste",
-              "short_label": "T-6A1-TE-2 - Shift to composting of organic waste",
-              "description": "Shift to composting of organic waste. Shift tonne from solid waste disposal in landfills to composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: composting of organic waste. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc",
-                "incineration and open burning of waste",
-                "open burning of waste",
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "shifts_to_labels": [
-                "composting of organic waste"
-              ],
-              "score": 0.5812
-            },
-            {
-              "stable_id": "shift_to_exported_composting_of_organic_waste",
-              "short_label": "T-6A1-TE-3 - Shift to exported composting of organic waste",
-              "description": "Shift to exported composting of organic waste. Shift tonne from solid waste disposal in landfills to exported composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: waste exported for composting. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc",
-                "incineration and open burning of waste",
-                "open burning of waste",
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "shifts_to_labels": [
-                "waste exported for composting"
-              ],
-              "score": 0.5415
-            },
-            {
-              "stable_id": "shift_to_landfill_gas_recovery",
-              "short_label": "T-6A1-TE-4 - Shift to landfill gas recovery",
-              "description": "Shift to landfill gas recovery. Shift tonne from solid waste disposal in landfills without gas recovery to solid waste disposal in landfills with landfill gas recovery in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc. to: solid waste disposal landfill with gas recovery. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc"
-              ],
-              "shifts_to_labels": [
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "score": 0.5356
-            },
-            {
-              "stable_id": "increased_energy_recovery_from_waste",
-              "short_label": "T-5A3-TE-6 - Increased energy recovery from waste",
-              "description": "Increased energy recovery from waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to CHP waste incineration in tonne to fulfill the need of warm premisses. from: incineration and open burning of waste. to: chp waste incineration. Energy > Energy Supply > Combined Heat Power",
-              "sector_path": "Energy > Energy Supply > Combined Heat Power",
-              "acts_on_labels": [
-                "incineration and open burning of waste"
-              ],
-              "shifts_to_labels": [
-                "chp waste incineration"
-              ],
-              "score": 0.5094
-            },
-            {
-              "stable_id": "biofuels_for_cement_and_mineral_industry",
-              "short_label": "T-2A1-TE-1 - Shift to use biofuel in cement and mineral industry",
-              "description": "Shift to use biofuel in cement and mineral industry. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: cement mineral industries coal usage. to: cement mineral industries biomass usage. Industry > Minerals > Cement",
-              "sector_path": "Industry > Minerals > Cement",
-              "acts_on_labels": [
-                "cement mineral industries coal usage"
-              ],
-              "shifts_to_labels": [
-                "cement mineral industries biomass usage"
-              ],
-              "score": 0.4456
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_glass_industries",
-              "short_label": "T-2A3-TE-1 - Shift to biogas energy in glass industries",
-              "description": "Shift to biogas energy in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within glass industries. to: biogas usage within glass industries. Industry > Minerals > Glass Production",
-              "sector_path": "Industry > Minerals > Glass Production",
-              "acts_on_labels": [
-                "natural gas usage within glass industries"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within glass industries"
-              ],
-              "score": 0.4404
-            },
-            {
-              "stable_id": "shift_to_biomass_energy_in_glass_industries",
-              "short_label": "T-2A3-TE-2 - Shift to biomass energy in glass industries",
-              "description": "Shift to biomass energy in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within glass industries. to: biomass usage within glass industries. Industry > Minerals > Glass Production",
-              "sector_path": "Industry > Minerals > Glass Production",
-              "acts_on_labels": [
-                "coal usage within glass industries"
-              ],
-              "shifts_to_labels": [
-                "biomass usage within glass industries"
-              ],
-              "score": 0.4337
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_lead_industries",
-              "short_label": "T-2C5-TE-1 - Shift to biogas energy in lead industries",
-              "description": "Shift to biogas energy in lead industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within lead industries. to: biogas usage within lead industries. Industry > Metals > Lead",
-              "sector_path": "Industry > Metals > Lead",
-              "acts_on_labels": [
-                "natural gas usage within lead industries"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within lead industries"
-              ],
-              "score": 0.4282
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_chemical_industries",
-              "short_label": "T-2B9-TE-1 - Shift to biogas energy in chemical industries",
-              "description": "Shift to biogas energy in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within chemical industries. to: biogas usage within chemical industries. Industry > Chemicals > Other",
-              "sector_path": "Industry > Chemicals > Other",
-              "acts_on_labels": [
-                "natural gas usage within chemical industries"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within chemical industries"
-              ],
-              "score": 0.426
-            },
-            {
-              "stable_id": "chp_waste_incineration",
-              "short_label": "T-5A3-TE-4 - CHP from waste incineration",
-              "description": "CHP from waste incineration. Alter the amount of district heat and electricity produced by CHP waste incineration. from: chp waste incineration. Energy > Energy Supply > Combined Heat Power",
-              "sector_path": "Energy > Energy Supply > Combined Heat Power",
-              "acts_on_labels": [
-                "chp waste incineration"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.4061
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_pulp_paper_and_print_industries",
-              "short_label": "T-2D1b-TE-1 - Shift to biogas energy in pulp, paper and print industries",
-              "description": "Shift to biogas energy in pulp, paper and print industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within pulp paper and print industries. to: biogas usage within pulp paper and print industries. Industry > Other > Manufacturing > Pulp Paper Print",
-              "sector_path": "Industry > Other > Manufacturing > Pulp Paper Print",
-              "acts_on_labels": [
-                "natural gas usage within pulp paper and print industries"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within pulp paper and print industries"
-              ],
-              "score": 0.3677
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_hydrogen_refinement",
-              "short_label": "T-5B4-TE-3 - Shift to biogas energy in hydrogen refinement",
-              "description": "Shift to biogas energy in hydrogen refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within hydrogen refinement. to: biogas usage within hydrogen refinement. Energy > Energy Transformation > Hydrogen Refinement",
-              "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
-              "acts_on_labels": [
-                "natural gas usage within hydrogen refinement"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within hydrogen refinement"
-              ],
-              "score": 0.3646
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_other_industries",
-              "short_label": "T-2D5-TE-2 - Shift to biogas energy in other industries",
-              "description": "Shift to biogas energy in other industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: industrial unregulated gas use. to: industrial unregulated biogas use. Industry > Other > Other",
-              "sector_path": "Industry > Other > Other",
-              "acts_on_labels": [
-                "industrial unregulated gas use"
-              ],
-              "shifts_to_labels": [
-                "industrial unregulated biogas use"
-              ],
-              "score": 0.358
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_magnesium_industries",
-              "short_label": "T-2C4-TE-2 - Shift to biogas energy in magnesium industries",
-              "description": "Shift to biogas energy in magnesium industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within magnesium industries. to: biogas usage within magnesium industries. Industry > Metals > Magnesium",
-              "sector_path": "Industry > Metals > Magnesium",
-              "acts_on_labels": [
-                "natural gas usage within magnesium industries"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within magnesium industries"
-              ],
-              "score": 0.3525
-            }
-          ]
-        }
-      ],
-      "intervention_who": "kommunens samtliga verksamheter",
-      "intervention_when": "none",
-      "intervention_what": "systematically work to minimise waste",
-      "intervention_how": "none",
-      "intervention_score": 3,
-      "intervention_reasoning": "WHO and WHAT are present, but lacks HOW or WHEN.",
-      "intervention_type": "indirect"
-    },
-    {
-      "measure_text": "167.Nedskräpningen ska minska med 5 procent årligen.",
-      "activity": "litter management",
-      "activity_shift_score": 3,
-      "activity_shifts": [
-        {
-          "activity": "managing litter",
-          "shift_from": "current litter levels",
-          "shift_to": "reduced litter levels",
-          "need": "waste management",
-          "type": "Utilisation Shift",
-          "type_reasoning": "The measure aims to reduce litter, which is a change in utilisation of resources.",
-          "score": 3,
-          "reasoning": "The measure implies a shift towards reduced litter, but FROM and TO are not clearly defined.",
-          "transition_element_matches": [],
-          "transition_element_suggested_new": {
-            "short_label": "Improved Waste Management Practices",
-            "description": "Implement measures to reduce littering by enhancing waste management systems, increasing public awareness, and enforcing stricter regulations on littering."
+          {
+            "stable_id": "shift_to_biogas_energy_in_iron_and_steel_industries",
+            "short_label": "T-2C1-TE-1 - Shift to biogas energy in iron and steel industries",
+            "description": "Shift to biogas energy in iron and steel industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within iron and steel industries. to: biogas usage within iron and steel industries. Industry > Metals > Iron Steel",
+            "sector_path": "Industry > Metals > Iron Steel",
+            "acts_on_labels": [
+              "natural gas usage within iron and steel industries"
+            ],
+            "shifts_to_labels": [
+              "biogas usage within iron and steel industries"
+            ],
+            "score": 0.2431
           },
-          "transition_element_candidates": [
-            {
-              "stable_id": "increased_recycling",
-              "short_label": "T-6A1-TE-1 - Shift to recycling of solid waste",
-              "description": "Shift to recycling of solid waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to recycling of solid waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: recycling of solid waste. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc",
-                "incineration and open burning of waste",
-                "open burning of waste",
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "shifts_to_labels": [
-                "recycling of solid waste"
-              ],
-              "score": 0.5494
-            },
-            {
-              "stable_id": "shift_to_composting_of_organic_waste",
-              "short_label": "T-6A1-TE-2 - Shift to composting of organic waste",
-              "description": "Shift to composting of organic waste. Shift tonne from solid waste disposal in landfills to composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: composting of organic waste. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc",
-                "incineration and open burning of waste",
-                "open burning of waste",
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "shifts_to_labels": [
-                "composting of organic waste"
-              ],
-              "score": 0.5401
-            },
-            {
-              "stable_id": "shift_to_landfill_gas_recovery",
-              "short_label": "T-6A1-TE-4 - Shift to landfill gas recovery",
-              "description": "Shift to landfill gas recovery. Shift tonne from solid waste disposal in landfills without gas recovery to solid waste disposal in landfills with landfill gas recovery in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc. to: solid waste disposal landfill with gas recovery. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc"
-              ],
-              "shifts_to_labels": [
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "score": 0.5231
-            },
-            {
-              "stable_id": "shift_to_exported_composting_of_organic_waste",
-              "short_label": "T-6A1-TE-3 - Shift to exported composting of organic waste",
-              "description": "Shift to exported composting of organic waste. Shift tonne from solid waste disposal in landfills to exported composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: waste exported for composting. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc",
-                "incineration and open burning of waste",
-                "open burning of waste",
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "shifts_to_labels": [
-                "waste exported for composting"
-              ],
-              "score": 0.5139
-            },
-            {
-              "stable_id": "increased_energy_recovery_from_waste",
-              "short_label": "T-5A3-TE-6 - Increased energy recovery from waste",
-              "description": "Increased energy recovery from waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to CHP waste incineration in tonne to fulfill the need of warm premisses. from: incineration and open burning of waste. to: chp waste incineration. Energy > Energy Supply > Combined Heat Power",
-              "sector_path": "Energy > Energy Supply > Combined Heat Power",
-              "acts_on_labels": [
-                "incineration and open burning of waste"
-              ],
-              "shifts_to_labels": [
-                "chp waste incineration"
-              ],
-              "score": 0.4339
-            },
-            {
-              "stable_id": "increased_proportion_of_walking_and_cycling",
-              "short_label": "T-1A1a-TE-10 - Shift to walking and cycling",
-              "description": "Shift to walking and cycling. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to walking cycling. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: walking cycling. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles",
-                "lpg vehicles",
-                "gas vehicles"
-              ],
-              "shifts_to_labels": [
-                "walking cycling"
-              ],
-              "score": 0.4102
-            },
-            {
-              "stable_id": "increased_proportion_of_public_transport_by_lpg_bus",
-              "short_label": "T-1A1a-TE-14 - Shift to travel by LPG bus",
-              "description": "Shift to travel by LPG bus. Shift vehicle kilometer from petrol and diesel vehicles to LPG buses. from: petrol vehicles, diesel vehicles. to: lpg buses. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles"
-              ],
-              "shifts_to_labels": [
-                "lpg buses"
-              ],
-              "score": 0.3896
-            },
-            {
-              "stable_id": "shift_to_sustainable_healthy_diet",
-              "short_label": "T-3A1-TE-1 - Shift to Sustainable Healthy Diets",
-              "description": "Shift to Sustainable Healthy Diets. This Transition Element is the shift from animal based diets to plant based diets.. from: enteric fermentation cattle, enteric fermentation sheep, enteric fermentation swine, enteric fermentation other livestock. Afolu > Livestock > Enteric Fermentation",
-              "sector_path": "Afolu > Livestock > Enteric Fermentation",
-              "acts_on_labels": [
-                "enteric fermentation cattle",
-                "enteric fermentation sheep",
-                "enteric fermentation swine",
-                "enteric fermentation other livestock"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.3871
-            },
-            {
-              "stable_id": "transfer_from_car_to_remote_working",
-              "short_label": "T-1A1a-TE-8 - Shift from car to remote working",
-              "description": "Shift from car to remote working. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to remote working. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: remote working. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles",
-                "lpg vehicles",
-                "gas vehicles"
-              ],
-              "shifts_to_labels": [
-                "remote working"
-              ],
-              "score": 0.386
-            },
-            {
-              "stable_id": "shift_to_electric_bikes",
-              "short_label": "T-1A1a-TE-11 - Shift to electric bikes",
-              "description": "Shift to electric bikes. Shift vehicle kilometer from petrol,diesel and LPG vehicles to electric bike in vehicle kilometer to fulfill the need of mobility. from: petrol vehicles, diesel vehicles, lpg vehicles. to: electric bikes. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles",
-                "lpg vehicles"
-              ],
-              "shifts_to_labels": [
-                "electric bikes"
-              ],
-              "score": 0.3843
-            },
-            {
-              "stable_id": "chp_waste_incineration",
-              "short_label": "T-5A3-TE-4 - CHP from waste incineration",
-              "description": "CHP from waste incineration. Alter the amount of district heat and electricity produced by CHP waste incineration. from: chp waste incineration. Energy > Energy Supply > Combined Heat Power",
-              "sector_path": "Energy > Energy Supply > Combined Heat Power",
-              "acts_on_labels": [
-                "chp waste incineration"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.3153
-            },
-            {
-              "stable_id": "improved_urban_planning",
-              "short_label": "T-1A1a-TE-22 - Improved urban planning",
-              "description": "Improved urban planning. Reduce the amount of vehicle kilometer from cars to fulfill the need of mobility through improved urban planning. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles, lng vehicles, hydrogen vehicles, battery electric vehicles. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles",
-                "lpg vehicles",
-                "gas vehicles",
-                "lng vehicles",
-                "hydrogen vehicles",
-                "battery electric vehicles"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.3111
-            },
-            {
-              "stable_id": "energy_efficient_street_lighting",
-              "short_label": "T-4B2a-TE-1 - Energy efficient street lighting",
-              "description": "Energy efficient street lighting. Reduce the amount of energy required to operate street lighting. from: institutional electric street lighting. Buildings > Non Residential > Other Energy Usage > Lighting",
-              "sector_path": "Buildings > Non Residential > Other Energy Usage > Lighting",
-              "acts_on_labels": [
-                "institutional electric street lighting"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.2977
-            },
-            {
-              "stable_id": "improved_load_factor_light_trucks",
-              "short_label": "T-1B1a-TE-9 - Improved load factor for light trucks",
-              "description": "Improved load factor for light trucks. Reduce the amount of vehicle kilometer from diesel light trucks to fulfill the need of logistics through improving the load factor. from: diesel light trucks, hydrogen light trucks, battery electric light trucks, petrol light trucks, gas light trucks. Transport > Freight > Road > Light Duty Trucks",
-              "sector_path": "Transport > Freight > Road > Light Duty Trucks",
-              "acts_on_labels": [
-                "diesel light trucks",
-                "hydrogen light trucks",
-                "battery electric light trucks",
-                "petrol light trucks",
-                "gas light trucks"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.2969
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_lead_industries",
-              "short_label": "T-2C5-TE-1 - Shift to biogas energy in lead industries",
-              "description": "Shift to biogas energy in lead industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within lead industries. to: biogas usage within lead industries. Industry > Metals > Lead",
-              "sector_path": "Industry > Metals > Lead",
-              "acts_on_labels": [
-                "natural gas usage within lead industries"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within lead industries"
-              ],
-              "score": 0.2959
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_glass_industries",
-              "short_label": "T-2A3-TE-1 - Shift to biogas energy in glass industries",
-              "description": "Shift to biogas energy in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within glass industries. to: biogas usage within glass industries. Industry > Minerals > Glass Production",
-              "sector_path": "Industry > Minerals > Glass Production",
-              "acts_on_labels": [
-                "natural gas usage within glass industries"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within glass industries"
-              ],
-              "score": 0.282
-            },
-            {
-              "stable_id": "more_efficient_commuting_by_car",
-              "short_label": "T-1A1a-TE-5 - Increase journey sharing",
-              "description": "Increase journey sharing. Reduce the number of vehicle kilometers from petrol, diesel, lpg and natural gas vehicles to fulfill the need of commuting through more efficient commuting by car. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles, battery electric vehicles, hydrogen vehicles. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles",
-                "lpg vehicles",
-                "gas vehicles",
-                "battery electric vehicles",
-                "hydrogen vehicles"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.2766
-            }
-          ]
-        }
-      ],
-      "intervention_who": "none",
-      "intervention_when": "annually",
-      "intervention_what": "reduce litter",
-      "intervention_how": "none",
-      "intervention_score": 3,
-      "intervention_reasoning": "WHAT and WHEN are present, but lacks WHO or HOW.",
-      "intervention_type": "indirect"
-    },
-    {
-      "measure_text": "168.65 procent avfall från hushåll ska materialåtervinnas eller förberedas för återanvändning.",
-      "activity": "waste management",
-      "activity_shift_score": 4,
-      "activity_shifts": [
-        {
-          "activity": "managing household waste",
-          "shift_from": "landfilling or incineration",
-          "shift_to": "recycling or reuse",
-          "need": "waste management",
-          "type": "Utilisation Shift",
-          "type_reasoning": "The measure focuses on increasing recycling and reuse, which is a change in utilisation of waste resources.",
-          "score": 4,
-          "reasoning": "The measure implies a shift towards recycling and reuse, but FROM and TO are not explicitly named.",
-          "transition_element_matches": [
-            {
-              "stable_id": "increased_recycling",
-              "short_label": "T-6A1-TE-1 - Shift to recycling of solid waste",
-              "description": "Shift to recycling of solid waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to recycling of solid waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: recycling of solid waste. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc",
-                "incineration and open burning of waste",
-                "open burning of waste",
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "shifts_to_labels": [
-                "recycling of solid waste"
-              ],
-              "score": 0.6829,
-              "match_reasoning": "acts_on=yes, shifts_to=yes, confidence=high",
-              "match_confidence": "high"
-            },
-            {
-              "stable_id": "shift_to_composting_of_organic_waste",
-              "short_label": "T-6A1-TE-2 - Shift to composting of organic waste",
-              "description": "Shift to composting of organic waste. Shift tonne from solid waste disposal in landfills to composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: composting of organic waste. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc",
-                "incineration and open burning of waste",
-                "open burning of waste",
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "shifts_to_labels": [
-                "composting of organic waste"
-              ],
-              "score": 0.5957,
-              "match_reasoning": "acts_on=yes, shifts_to=no, confidence=mid",
-              "match_confidence": "mid"
-            },
-            {
-              "stable_id": "shift_to_exported_composting_of_organic_waste",
-              "short_label": "T-6A1-TE-3 - Shift to exported composting of organic waste",
-              "description": "Shift to exported composting of organic waste. Shift tonne from solid waste disposal in landfills to exported composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: waste exported for composting. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc",
-                "incineration and open burning of waste",
-                "open burning of waste",
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "shifts_to_labels": [
-                "waste exported for composting"
-              ],
-              "score": 0.5663,
-              "match_reasoning": "acts_on=yes, shifts_to=no, confidence=mid",
-              "match_confidence": "mid"
-            },
-            {
-              "stable_id": "shift_to_landfill_gas_recovery",
-              "short_label": "T-6A1-TE-4 - Shift to landfill gas recovery",
-              "description": "Shift to landfill gas recovery. Shift tonne from solid waste disposal in landfills without gas recovery to solid waste disposal in landfills with landfill gas recovery in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc. to: solid waste disposal landfill with gas recovery. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc"
-              ],
-              "shifts_to_labels": [
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "score": 0.565,
-              "match_reasoning": "acts_on=yes, shifts_to=no, confidence=mid",
-              "match_confidence": "mid"
-            },
-            {
-              "stable_id": "increased_energy_recovery_from_waste",
-              "short_label": "T-5A3-TE-6 - Increased energy recovery from waste",
-              "description": "Increased energy recovery from waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to CHP waste incineration in tonne to fulfill the need of warm premisses. from: incineration and open burning of waste. to: chp waste incineration. Energy > Energy Supply > Combined Heat Power",
-              "sector_path": "Energy > Energy Supply > Combined Heat Power",
-              "acts_on_labels": [
-                "incineration and open burning of waste"
-              ],
-              "shifts_to_labels": [
-                "chp waste incineration"
-              ],
-              "score": 0.5241,
-              "match_reasoning": "acts_on=yes, shifts_to=no, confidence=mid",
-              "match_confidence": "mid"
-            }
-          ],
-          "transition_element_candidates": [
-            {
-              "stable_id": "increased_recycling",
-              "short_label": "T-6A1-TE-1 - Shift to recycling of solid waste",
-              "description": "Shift to recycling of solid waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to recycling of solid waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: recycling of solid waste. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc",
-                "incineration and open burning of waste",
-                "open burning of waste",
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "shifts_to_labels": [
-                "recycling of solid waste"
-              ],
-              "score": 0.6829
-            },
-            {
-              "stable_id": "shift_to_composting_of_organic_waste",
-              "short_label": "T-6A1-TE-2 - Shift to composting of organic waste",
-              "description": "Shift to composting of organic waste. Shift tonne from solid waste disposal in landfills to composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: composting of organic waste. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc",
-                "incineration and open burning of waste",
-                "open burning of waste",
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "shifts_to_labels": [
-                "composting of organic waste"
-              ],
-              "score": 0.5957
-            },
-            {
-              "stable_id": "shift_to_exported_composting_of_organic_waste",
-              "short_label": "T-6A1-TE-3 - Shift to exported composting of organic waste",
-              "description": "Shift to exported composting of organic waste. Shift tonne from solid waste disposal in landfills to exported composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: waste exported for composting. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc",
-                "incineration and open burning of waste",
-                "open burning of waste",
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "shifts_to_labels": [
-                "waste exported for composting"
-              ],
-              "score": 0.5663
-            },
-            {
-              "stable_id": "shift_to_landfill_gas_recovery",
-              "short_label": "T-6A1-TE-4 - Shift to landfill gas recovery",
-              "description": "Shift to landfill gas recovery. Shift tonne from solid waste disposal in landfills without gas recovery to solid waste disposal in landfills with landfill gas recovery in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc. to: solid waste disposal landfill with gas recovery. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc"
-              ],
-              "shifts_to_labels": [
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "score": 0.565
-            },
-            {
-              "stable_id": "increased_energy_recovery_from_waste",
-              "short_label": "T-5A3-TE-6 - Increased energy recovery from waste",
-              "description": "Increased energy recovery from waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to CHP waste incineration in tonne to fulfill the need of warm premisses. from: incineration and open burning of waste. to: chp waste incineration. Energy > Energy Supply > Combined Heat Power",
-              "sector_path": "Energy > Energy Supply > Combined Heat Power",
-              "acts_on_labels": [
-                "incineration and open burning of waste"
-              ],
-              "shifts_to_labels": [
-                "chp waste incineration"
-              ],
-              "score": 0.5241
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_lead_industries",
-              "short_label": "T-2C5-TE-1 - Shift to biogas energy in lead industries",
-              "description": "Shift to biogas energy in lead industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within lead industries. to: biogas usage within lead industries. Industry > Metals > Lead",
-              "sector_path": "Industry > Metals > Lead",
-              "acts_on_labels": [
-                "natural gas usage within lead industries"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within lead industries"
-              ],
-              "score": 0.4489
-            },
-            {
-              "stable_id": "shift_to_biomass_energy_in_magnesium_industries",
-              "short_label": "T-2C4-TE-3 - Shift to biomass energy in magnesium industries",
-              "description": "Shift to biomass energy in magnesium industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within magnesium industries. to: biomass usage within magnesium industries. Industry > Metals > Magnesium",
-              "sector_path": "Industry > Metals > Magnesium",
-              "acts_on_labels": [
-                "coal usage within magnesium industries"
-              ],
-              "shifts_to_labels": [
-                "biomass usage within magnesium industries"
-              ],
-              "score": 0.4481
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_magnesium_industries",
-              "short_label": "T-2C4-TE-2 - Shift to biogas energy in magnesium industries",
-              "description": "Shift to biogas energy in magnesium industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within magnesium industries. to: biogas usage within magnesium industries. Industry > Metals > Magnesium",
-              "sector_path": "Industry > Metals > Magnesium",
-              "acts_on_labels": [
-                "natural gas usage within magnesium industries"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within magnesium industries"
-              ],
-              "score": 0.4453
-            },
-            {
-              "stable_id": "shift_to_biomass_energy_in_glass_industries",
-              "short_label": "T-2A3-TE-2 - Shift to biomass energy in glass industries",
-              "description": "Shift to biomass energy in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within glass industries. to: biomass usage within glass industries. Industry > Minerals > Glass Production",
-              "sector_path": "Industry > Minerals > Glass Production",
-              "acts_on_labels": [
-                "coal usage within glass industries"
-              ],
-              "shifts_to_labels": [
-                "biomass usage within glass industries"
-              ],
-              "score": 0.4446
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_glass_industries",
-              "short_label": "T-2A3-TE-1 - Shift to biogas energy in glass industries",
-              "description": "Shift to biogas energy in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within glass industries. to: biogas usage within glass industries. Industry > Minerals > Glass Production",
-              "sector_path": "Industry > Minerals > Glass Production",
-              "acts_on_labels": [
-                "natural gas usage within glass industries"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within glass industries"
-              ],
-              "score": 0.4437
-            },
-            {
-              "stable_id": "chp_waste_incineration",
-              "short_label": "T-5A3-TE-4 - CHP from waste incineration",
-              "description": "CHP from waste incineration. Alter the amount of district heat and electricity produced by CHP waste incineration. from: chp waste incineration. Energy > Energy Supply > Combined Heat Power",
-              "sector_path": "Energy > Energy Supply > Combined Heat Power",
-              "acts_on_labels": [
-                "chp waste incineration"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.4146
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_other_industries",
-              "short_label": "T-2D5-TE-2 - Shift to biogas energy in other industries",
-              "description": "Shift to biogas energy in other industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: industrial unregulated gas use. to: industrial unregulated biogas use. Industry > Other > Other",
-              "sector_path": "Industry > Other > Other",
-              "acts_on_labels": [
-                "industrial unregulated gas use"
-              ],
-              "shifts_to_labels": [
-                "industrial unregulated biogas use"
-              ],
-              "score": 0.3707
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_iron_and_steel_industries",
-              "short_label": "T-2C1-TE-1 - Shift to biogas energy in iron and steel industries",
-              "description": "Shift to biogas energy in iron and steel industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within iron and steel industries. to: biogas usage within iron and steel industries. Industry > Metals > Iron Steel",
-              "sector_path": "Industry > Metals > Iron Steel",
-              "acts_on_labels": [
-                "natural gas usage within iron and steel industries"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within iron and steel industries"
-              ],
-              "score": 0.3583
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_pulp_paper_and_print_industries",
-              "short_label": "T-2D1b-TE-1 - Shift to biogas energy in pulp, paper and print industries",
-              "description": "Shift to biogas energy in pulp, paper and print industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within pulp paper and print industries. to: biogas usage within pulp paper and print industries. Industry > Other > Manufacturing > Pulp Paper Print",
-              "sector_path": "Industry > Other > Manufacturing > Pulp Paper Print",
-              "acts_on_labels": [
-                "natural gas usage within pulp paper and print industries"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within pulp paper and print industries"
-              ],
-              "score": 0.3571
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_hydrogen_refinement",
-              "short_label": "T-5B4-TE-3 - Shift to biogas energy in hydrogen refinement",
-              "description": "Shift to biogas energy in hydrogen refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within hydrogen refinement. to: biogas usage within hydrogen refinement. Energy > Energy Transformation > Hydrogen Refinement",
-              "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
-              "acts_on_labels": [
-                "natural gas usage within hydrogen refinement"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within hydrogen refinement"
-              ],
-              "score": 0.3549
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_chemical_industries",
-              "short_label": "T-2B9-TE-1 - Shift to biogas energy in chemical industries",
-              "description": "Shift to biogas energy in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within chemical industries. to: biogas usage within chemical industries. Industry > Chemicals > Other",
-              "sector_path": "Industry > Chemicals > Other",
-              "acts_on_labels": [
-                "natural gas usage within chemical industries"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within chemical industries"
-              ],
-              "score": 0.3538
-            },
-            {
-              "stable_id": "biogas_in_methane_reforming_for_hydrogen_production",
-              "short_label": "T-5B4-TE-1 - Biogas in methane reforming for hydrogen production",
-              "description": "Biogas in methane reforming for hydrogen production. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: reforming of methane for hydrogen production. Energy > Energy Transformation > Hydrogen Refinement",
-              "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
-              "acts_on_labels": [
-                "reforming of methane for hydrogen production"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.3469
-            }
-          ]
-        }
-      ],
-      "intervention_who": "none",
-      "intervention_when": "none",
-      "intervention_what": "increase recycling and reuse",
-      "intervention_how": "none",
-      "intervention_score": 2,
-      "intervention_reasoning": "WHAT is present, but lacks WHO, HOW, or WHEN.",
-      "intervention_type": "indirect"
-    },
-    {
-      "measure_text": "169.Mat- och restavfallet ska vara max 130 kg per person och år.",
-      "activity": "waste management",
-      "activity_shift_score": 3,
-      "activity_shifts": [
-        {
-          "activity": "managing food and residual waste",
-          "shift_from": "high waste generation",
-          "shift_to": "reduced waste generation",
-          "need": "waste management",
-          "type": "Utilisation Shift",
-          "type_reasoning": "The measure focuses on reducing food and residual waste, which is a change in utilisation of resources.",
-          "score": 3,
-          "reasoning": "The measure implies a shift towards reduced waste, but FROM and TO are not clearly defined.",
-          "transition_element_matches": [
-            {
-              "stable_id": "increased_recycling",
-              "short_label": "T-6A1-TE-1 - Shift to recycling of solid waste",
-              "description": "Shift to recycling of solid waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to recycling of solid waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: recycling of solid waste. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc",
-                "incineration and open burning of waste",
-                "open burning of waste",
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "shifts_to_labels": [
-                "recycling of solid waste"
-              ],
-              "score": 0.6143,
-              "match_reasoning": "acts_on=yes, shifts_to=no, confidence=mid",
-              "match_confidence": "mid"
-            },
-            {
-              "stable_id": "shift_to_composting_of_organic_waste",
-              "short_label": "T-6A1-TE-2 - Shift to composting of organic waste",
-              "description": "Shift to composting of organic waste. Shift tonne from solid waste disposal in landfills to composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: composting of organic waste. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc",
-                "incineration and open burning of waste",
-                "open burning of waste",
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "shifts_to_labels": [
-                "composting of organic waste"
-              ],
-              "score": 0.5875,
-              "match_reasoning": "acts_on=yes, shifts_to=yes, confidence=high",
-              "match_confidence": "high"
-            },
-            {
-              "stable_id": "shift_to_landfill_gas_recovery",
-              "short_label": "T-6A1-TE-4 - Shift to landfill gas recovery",
-              "description": "Shift to landfill gas recovery. Shift tonne from solid waste disposal in landfills without gas recovery to solid waste disposal in landfills with landfill gas recovery in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc. to: solid waste disposal landfill with gas recovery. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc"
-              ],
-              "shifts_to_labels": [
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "score": 0.5632,
-              "match_reasoning": "acts_on=yes, shifts_to=no, confidence=mid",
-              "match_confidence": "mid"
-            },
-            {
-              "stable_id": "shift_to_exported_composting_of_organic_waste",
-              "short_label": "T-6A1-TE-3 - Shift to exported composting of organic waste",
-              "description": "Shift to exported composting of organic waste. Shift tonne from solid waste disposal in landfills to exported composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: waste exported for composting. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc",
-                "incineration and open burning of waste",
-                "open burning of waste",
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "shifts_to_labels": [
-                "waste exported for composting"
-              ],
-              "score": 0.5574,
-              "match_reasoning": "acts_on=yes, shifts_to=yes, confidence=mid",
-              "match_confidence": "mid"
-            }
-          ],
-          "transition_element_candidates": [
-            {
-              "stable_id": "increased_recycling",
-              "short_label": "T-6A1-TE-1 - Shift to recycling of solid waste",
-              "description": "Shift to recycling of solid waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to recycling of solid waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: recycling of solid waste. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc",
-                "incineration and open burning of waste",
-                "open burning of waste",
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "shifts_to_labels": [
-                "recycling of solid waste"
-              ],
-              "score": 0.6143
-            },
-            {
-              "stable_id": "shift_to_composting_of_organic_waste",
-              "short_label": "T-6A1-TE-2 - Shift to composting of organic waste",
-              "description": "Shift to composting of organic waste. Shift tonne from solid waste disposal in landfills to composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: composting of organic waste. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc",
-                "incineration and open burning of waste",
-                "open burning of waste",
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "shifts_to_labels": [
-                "composting of organic waste"
-              ],
-              "score": 0.5875
-            },
-            {
-              "stable_id": "shift_to_landfill_gas_recovery",
-              "short_label": "T-6A1-TE-4 - Shift to landfill gas recovery",
-              "description": "Shift to landfill gas recovery. Shift tonne from solid waste disposal in landfills without gas recovery to solid waste disposal in landfills with landfill gas recovery in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc. to: solid waste disposal landfill with gas recovery. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc"
-              ],
-              "shifts_to_labels": [
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "score": 0.5632
-            },
-            {
-              "stable_id": "shift_to_exported_composting_of_organic_waste",
-              "short_label": "T-6A1-TE-3 - Shift to exported composting of organic waste",
-              "description": "Shift to exported composting of organic waste. Shift tonne from solid waste disposal in landfills to exported composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: waste exported for composting. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc",
-                "incineration and open burning of waste",
-                "open burning of waste",
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "shifts_to_labels": [
-                "waste exported for composting"
-              ],
-              "score": 0.5574
-            },
-            {
-              "stable_id": "increased_energy_recovery_from_waste",
-              "short_label": "T-5A3-TE-6 - Increased energy recovery from waste",
-              "description": "Increased energy recovery from waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to CHP waste incineration in tonne to fulfill the need of warm premisses. from: incineration and open burning of waste. to: chp waste incineration. Energy > Energy Supply > Combined Heat Power",
-              "sector_path": "Energy > Energy Supply > Combined Heat Power",
-              "acts_on_labels": [
-                "incineration and open burning of waste"
-              ],
-              "shifts_to_labels": [
-                "chp waste incineration"
-              ],
-              "score": 0.5196
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_lead_industries",
-              "short_label": "T-2C5-TE-1 - Shift to biogas energy in lead industries",
-              "description": "Shift to biogas energy in lead industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within lead industries. to: biogas usage within lead industries. Industry > Metals > Lead",
-              "sector_path": "Industry > Metals > Lead",
-              "acts_on_labels": [
-                "natural gas usage within lead industries"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within lead industries"
-              ],
-              "score": 0.4573
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_glass_industries",
-              "short_label": "T-2A3-TE-1 - Shift to biogas energy in glass industries",
-              "description": "Shift to biogas energy in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within glass industries. to: biogas usage within glass industries. Industry > Minerals > Glass Production",
-              "sector_path": "Industry > Minerals > Glass Production",
-              "acts_on_labels": [
-                "natural gas usage within glass industries"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within glass industries"
-              ],
-              "score": 0.4443
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_chemical_industries",
-              "short_label": "T-2B9-TE-1 - Shift to biogas energy in chemical industries",
-              "description": "Shift to biogas energy in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within chemical industries. to: biogas usage within chemical industries. Industry > Chemicals > Other",
-              "sector_path": "Industry > Chemicals > Other",
-              "acts_on_labels": [
-                "natural gas usage within chemical industries"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within chemical industries"
-              ],
-              "score": 0.439
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_magnesium_industries",
-              "short_label": "T-2C4-TE-2 - Shift to biogas energy in magnesium industries",
-              "description": "Shift to biogas energy in magnesium industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within magnesium industries. to: biogas usage within magnesium industries. Industry > Metals > Magnesium",
-              "sector_path": "Industry > Metals > Magnesium",
-              "acts_on_labels": [
-                "natural gas usage within magnesium industries"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within magnesium industries"
-              ],
-              "score": 0.4359
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_pulp_paper_and_print_industries",
-              "short_label": "T-2D1b-TE-1 - Shift to biogas energy in pulp, paper and print industries",
-              "description": "Shift to biogas energy in pulp, paper and print industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within pulp paper and print industries. to: biogas usage within pulp paper and print industries. Industry > Other > Manufacturing > Pulp Paper Print",
-              "sector_path": "Industry > Other > Manufacturing > Pulp Paper Print",
-              "acts_on_labels": [
-                "natural gas usage within pulp paper and print industries"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within pulp paper and print industries"
-              ],
-              "score": 0.4354
-            },
-            {
-              "stable_id": "chp_waste_incineration",
-              "short_label": "T-5A3-TE-4 - CHP from waste incineration",
-              "description": "CHP from waste incineration. Alter the amount of district heat and electricity produced by CHP waste incineration. from: chp waste incineration. Energy > Energy Supply > Combined Heat Power",
-              "sector_path": "Energy > Energy Supply > Combined Heat Power",
-              "acts_on_labels": [
-                "chp waste incineration"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.3957
-            },
-            {
-              "stable_id": "shift_to_residual_heat_in_district_heating",
-              "short_label": "T-5A2-TE-6 - Shift to Residual Heat in district heating",
-              "description": "Shift to Residual Heat in district heating. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: chp coal, chp natural gas, chp oil. to: district heating residual heat. Energy > Energy Supply > Heat",
-              "sector_path": "Energy > Energy Supply > Heat",
-              "acts_on_labels": [
-                "chp coal",
-                "chp natural gas",
-                "chp oil"
-              ],
-              "shifts_to_labels": [
-                "district heating residual heat"
-              ],
-              "score": 0.3596
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_hydrogen_refinement",
-              "short_label": "T-5B4-TE-3 - Shift to biogas energy in hydrogen refinement",
-              "description": "Shift to biogas energy in hydrogen refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within hydrogen refinement. to: biogas usage within hydrogen refinement. Energy > Energy Transformation > Hydrogen Refinement",
-              "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
-              "acts_on_labels": [
-                "natural gas usage within hydrogen refinement"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within hydrogen refinement"
-              ],
-              "score": 0.3537
-            },
-            {
-              "stable_id": "district_heating_residual_heat",
-              "short_label": "T-5A2-TE-3 - District heating by residual heat",
-              "description": "District heating by residual heat. Alter the amount of district heat produced by residual heat. from: district heating residual heat. Energy > Energy Supply > Heat",
-              "sector_path": "Energy > Energy Supply > Heat",
-              "acts_on_labels": [
-                "district heating residual heat"
-              ],
-              "shifts_to_labels": [],
-              "score": 0.3523
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_other_industries",
-              "short_label": "T-2D5-TE-2 - Shift to biogas energy in other industries",
-              "description": "Shift to biogas energy in other industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: industrial unregulated gas use. to: industrial unregulated biogas use. Industry > Other > Other",
-              "sector_path": "Industry > Other > Other",
-              "acts_on_labels": [
-                "industrial unregulated gas use"
-              ],
-              "shifts_to_labels": [
-                "industrial unregulated biogas use"
-              ],
-              "score": 0.3516
-            }
-          ]
-        }
-      ],
-      "intervention_who": "none",
-      "intervention_when": "annually",
-      "intervention_what": "reduce food and residual waste",
-      "intervention_how": "none",
-      "intervention_score": 3,
-      "intervention_reasoning": "WHAT and WHEN are present, but lacks WHO or HOW.",
-      "intervention_type": "indirect"
-    },
-    {
-      "measure_text": "170.Fler möjligheter för återbruk ska skapas, där även invånarna har möjlighet att lämna in och köpa begagnade produkter.",
-      "activity": "waste handling",
-      "activity_shift_score": 6,
-      "activity_shifts": [
-        {
-          "activity": "buying goods",
-          "shift_from": "buying new goods",
-          "shift_to": "buying reused goods",
-          "need": "consumption",
-          "type": "Utilisation Shift",
-          "type_reasoning": "The measure promotes the reuse of products, which implies a shift from buying new goods to buying reused goods.",
-          "score": 6,
-          "reasoning": "Activity (buying goods), shift_from (buying new goods), shift_to (buying reused goods), and need (consumption) are all identifiable.",
-          "transition_element_matches": [],
-          "transition_element_suggested_new": {
-            "short_label": "Shift to reuse of goods",
-            "description": "Transition from buying new goods to buying reused goods to promote sustainability and reduce waste."
+          {
+            "stable_id": "shift_to_biogas_energy_in_magnesium_industries",
+            "short_label": "T-2C4-TE-2 - Shift to biogas energy in magnesium industries",
+            "description": "Shift to biogas energy in magnesium industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within magnesium industries. to: biogas usage within magnesium industries. Industry > Metals > Magnesium",
+            "sector_path": "Industry > Metals > Magnesium",
+            "acts_on_labels": ["natural gas usage within magnesium industries"],
+            "shifts_to_labels": ["biogas usage within magnesium industries"],
+            "score": 0.2429
           },
-          "transition_element_candidates": [
-            {
-              "stable_id": "increased_recycling",
-              "short_label": "T-6A1-TE-1 - Shift to recycling of solid waste",
-              "description": "Shift to recycling of solid waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to recycling of solid waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: recycling of solid waste. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc",
-                "incineration and open burning of waste",
-                "open burning of waste",
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "shifts_to_labels": [
-                "recycling of solid waste"
-              ],
-              "score": 0.4257
-            },
-            {
-              "stable_id": "shift_to_composting_of_organic_waste",
-              "short_label": "T-6A1-TE-2 - Shift to composting of organic waste",
-              "description": "Shift to composting of organic waste. Shift tonne from solid waste disposal in landfills to composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: composting of organic waste. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc",
-                "incineration and open burning of waste",
-                "open burning of waste",
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "shifts_to_labels": [
-                "composting of organic waste"
-              ],
-              "score": 0.3752
-            },
-            {
-              "stable_id": "shift_to_electric_bikes",
-              "short_label": "T-1A1a-TE-11 - Shift to electric bikes",
-              "description": "Shift to electric bikes. Shift vehicle kilometer from petrol,diesel and LPG vehicles to electric bike in vehicle kilometer to fulfill the need of mobility. from: petrol vehicles, diesel vehicles, lpg vehicles. to: electric bikes. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles",
-                "lpg vehicles"
-              ],
-              "shifts_to_labels": [
-                "electric bikes"
-              ],
-              "score": 0.3738
-            },
-            {
-              "stable_id": "shift_to_electric_cargo_bikes",
-              "short_label": "T-1B1a-TE-10 - Shift to electric cargo bikes",
-              "description": "Shift to electric cargo bikes. Shift vehicle kilometer from diesel and petrol light truck to electric carg bikes in vehicle kilometer to fulfill the need of logistics. from: diesel light trucks, petrol light trucks. to: electric cargo bikes. Transport > Freight > Road > Light Duty Trucks",
-              "sector_path": "Transport > Freight > Road > Light Duty Trucks",
-              "acts_on_labels": [
-                "diesel light trucks",
-                "petrol light trucks"
-              ],
-              "shifts_to_labels": [
-                "electric cargo bikes"
-              ],
-              "score": 0.3662
-            },
-            {
-              "stable_id": "shift_to_exported_composting_of_organic_waste",
-              "short_label": "T-6A1-TE-3 - Shift to exported composting of organic waste",
-              "description": "Shift to exported composting of organic waste. Shift tonne from solid waste disposal in landfills to exported composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: waste exported for composting. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc",
-                "incineration and open burning of waste",
-                "open burning of waste",
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "shifts_to_labels": [
-                "waste exported for composting"
-              ],
-              "score": 0.3651
-            },
-            {
-              "stable_id": "increased_proportion_of_non_travel_meetings_and_services",
-              "short_label": "T-1A1a-TE-7 - Shift to online meetings and services",
-              "description": "Shift to online meetings and services. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to e-meetings in hours to fulfill the need of business trips. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: e meetings. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles",
-                "lpg vehicles",
-                "gas vehicles"
-              ],
-              "shifts_to_labels": [
-                "e meetings"
-              ],
-              "score": 0.3636
-            },
-            {
-              "stable_id": "shift_to_landfill_gas_recovery",
-              "short_label": "T-6A1-TE-4 - Shift to landfill gas recovery",
-              "description": "Shift to landfill gas recovery. Shift tonne from solid waste disposal in landfills without gas recovery to solid waste disposal in landfills with landfill gas recovery in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc. to: solid waste disposal landfill with gas recovery. Waste > Solids > Solid Waste Disposal",
-              "sector_path": "Waste > Solids > Solid Waste Disposal",
-              "acts_on_labels": [
-                "solid waste disposal in landfills and open dumps etc"
-              ],
-              "shifts_to_labels": [
-                "solid waste disposal landfill with gas recovery"
-              ],
-              "score": 0.3619
-            },
-            {
-              "stable_id": "shift_to_residential_electric_cooking_stoves",
-              "short_label": "T-4A2d-TE-2 - Shift to residential electric cooking stoves",
-              "description": "Shift to residential electric cooking stoves. Shift kWh from residential cooking gas stoves to residential electric cooking stoves in kWh to fullfill the need for cooking. from: residential gas cooking stoves. to: residential electric cooking stoves. Buildings > Residential > Other Energy Usage > Unregulated",
-              "sector_path": "Buildings > Residential > Other Energy Usage > Unregulated",
-              "acts_on_labels": [
-                "residential gas cooking stoves"
-              ],
-              "shifts_to_labels": [
-                "residential electric cooking stoves"
-              ],
-              "score": 0.3602
-            },
-            {
-              "stable_id": "increased_proportion_of_walking_and_cycling",
-              "short_label": "T-1A1a-TE-10 - Shift to walking and cycling",
-              "description": "Shift to walking and cycling. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to walking cycling. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: walking cycling. Transport > Mobility > Road > Light Duty Vehicles",
-              "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
-              "acts_on_labels": [
-                "petrol vehicles",
-                "diesel vehicles",
-                "lpg vehicles",
-                "gas vehicles"
-              ],
-              "shifts_to_labels": [
-                "walking cycling"
-              ],
-              "score": 0.3584
-            },
-            {
-              "stable_id": "shift_to_commercial_electric_cooking_stoves",
-              "short_label": "T-4B2b-TE-1 - Shift to commercial electric cooking stoves",
-              "description": "Shift to commercial electric cooking stoves. Shift kWh from commercial cooking gas stoves to commercial electric cooking stoves in kWh to fullfill the need for cooking. from: commercial gas cooking stoves. to: commercial electric cooking stoves. Buildings > Non Residential > Other Energy Usage > Equipment Appliances",
-              "sector_path": "Buildings > Non Residential > Other Energy Usage > Equipment Appliances",
-              "acts_on_labels": [
-                "commercial gas cooking stoves"
-              ],
-              "shifts_to_labels": [
-                "commercial electric cooking stoves"
-              ],
-              "score": 0.3556
-            },
-            {
-              "stable_id": "increased_energy_recovery_from_waste",
-              "short_label": "T-5A3-TE-6 - Increased energy recovery from waste",
-              "description": "Increased energy recovery from waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to CHP waste incineration in tonne to fulfill the need of warm premisses. from: incineration and open burning of waste. to: chp waste incineration. Energy > Energy Supply > Combined Heat Power",
-              "sector_path": "Energy > Energy Supply > Combined Heat Power",
-              "acts_on_labels": [
-                "incineration and open burning of waste"
-              ],
-              "shifts_to_labels": [
-                "chp waste incineration"
-              ],
-              "score": 0.2867
-            },
-            {
-              "stable_id": "shift_to_biomass_energy_in_glass_industries",
-              "short_label": "T-2A3-TE-2 - Shift to biomass energy in glass industries",
-              "description": "Shift to biomass energy in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within glass industries. to: biomass usage within glass industries. Industry > Minerals > Glass Production",
-              "sector_path": "Industry > Minerals > Glass Production",
-              "acts_on_labels": [
-                "coal usage within glass industries"
-              ],
-              "shifts_to_labels": [
-                "biomass usage within glass industries"
-              ],
-              "score": 0.2788
-            },
-            {
-              "stable_id": "shift_to_electricity_in_glass_industries",
-              "short_label": "T-2A3-TE-3 - Shift to electricity in glass industries",
-              "description": "Shift to electricity in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within glass industries, oil usage within glass industries, natural gas usage within glass industries. to: electricity usage within glass industries. Industry > Minerals > Glass Production",
-              "sector_path": "Industry > Minerals > Glass Production",
-              "acts_on_labels": [
-                "coal usage within glass industries",
-                "oil usage within glass industries",
-                "natural gas usage within glass industries"
-              ],
-              "shifts_to_labels": [
-                "electricity usage within glass industries"
-              ],
-              "score": 0.2772
-            },
-            {
-              "stable_id": "shift_to_biomass_energy_in_petroleum_refinement",
-              "short_label": "T-5B1-TE-1 - Shift to biomass energy in petroleum refinement",
-              "description": "Shift to biomass energy in petroleum refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: crude oil usage within petroleum refinement. to: biomass usage within petroleum refinement. Energy > Energy Transformation > Petroleum Refinement",
-              "sector_path": "Energy > Energy Transformation > Petroleum Refinement",
-              "acts_on_labels": [
-                "crude oil usage within petroleum refinement"
-              ],
-              "shifts_to_labels": [
-                "biomass usage within petroleum refinement"
-              ],
-              "score": 0.273
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_glass_industries",
-              "short_label": "T-2A3-TE-1 - Shift to biogas energy in glass industries",
-              "description": "Shift to biogas energy in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within glass industries. to: biogas usage within glass industries. Industry > Minerals > Glass Production",
-              "sector_path": "Industry > Minerals > Glass Production",
-              "acts_on_labels": [
-                "natural gas usage within glass industries"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within glass industries"
-              ],
-              "score": 0.2714
-            },
-            {
-              "stable_id": "shift_to_electricity_in_pulp_paper_and_print_industries",
-              "short_label": "T-2D1b-TE-3 - Shift to electricity in pulp, paper and print industries",
-              "description": "Shift to electricity in pulp, paper and print industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within pulp paper and print industries, oil usage within pulp paper and print industries, natural gas usage within pulp paper and print industries. to: electricity usage within pulp paper and print industries. Industry > Other > Manufacturing > Pulp Paper Print",
-              "sector_path": "Industry > Other > Manufacturing > Pulp Paper Print",
-              "acts_on_labels": [
-                "coal usage within pulp paper and print industries",
-                "oil usage within pulp paper and print industries",
-                "natural gas usage within pulp paper and print industries"
-              ],
-              "shifts_to_labels": [
-                "electricity usage within pulp paper and print industries"
-              ],
-              "score": 0.2713
-            },
-            {
-              "stable_id": "shift_to_biomass_energy_in_pulp_paper_and_print_industries",
-              "short_label": "T-2D1b-TE-2 - Shift to biomass energy in pulp, paper and print industries",
-              "description": "Shift to biomass energy in pulp, paper and print industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within pulp paper and print industries. to: biomass usage within pulp paper and print industries. Industry > Other > Manufacturing > Pulp Paper Print",
-              "sector_path": "Industry > Other > Manufacturing > Pulp Paper Print",
-              "acts_on_labels": [
-                "coal usage within pulp paper and print industries"
-              ],
-              "shifts_to_labels": [
-                "biomass usage within pulp paper and print industries"
-              ],
-              "score": 0.27
-            },
-            {
-              "stable_id": "shift_to_biomass_energy_in_lead_industries",
-              "short_label": "T-2C5-TE-2 - Shift to biomass energy in lead industries",
-              "description": "Shift to biomass energy in lead industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within lead industries. to: biomass usage within lead industries. Industry > Metals > Lead",
-              "sector_path": "Industry > Metals > Lead",
-              "acts_on_labels": [
-                "coal usage within lead industries"
-              ],
-              "shifts_to_labels": [
-                "biomass usage within lead industries"
-              ],
-              "score": 0.2697
-            },
-            {
-              "stable_id": "shift_to_biomass_energy_in_other_industries",
-              "short_label": "T-2D5-TE-1 - Shift to biomass energy in other industries",
-              "description": "Shift to biomass energy in other industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: industrial unregulated coal use. to: industrial unregulated biomass use. Industry > Other > Other",
-              "sector_path": "Industry > Other > Other",
-              "acts_on_labels": [
-                "industrial unregulated coal use"
-              ],
-              "shifts_to_labels": [
-                "industrial unregulated biomass use"
-              ],
-              "score": 0.2666
-            },
-            {
-              "stable_id": "shift_to_biogas_energy_in_pulp_paper_and_print_industries",
-              "short_label": "T-2D1b-TE-1 - Shift to biogas energy in pulp, paper and print industries",
-              "description": "Shift to biogas energy in pulp, paper and print industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within pulp paper and print industries. to: biogas usage within pulp paper and print industries. Industry > Other > Manufacturing > Pulp Paper Print",
-              "sector_path": "Industry > Other > Manufacturing > Pulp Paper Print",
-              "acts_on_labels": [
-                "natural gas usage within pulp paper and print industries"
-              ],
-              "shifts_to_labels": [
-                "biogas usage within pulp paper and print industries"
-              ],
-              "score": 0.2643
-            }
-          ]
-        }
-      ],
-      "intervention_who": "none",
-      "intervention_when": "none",
-      "intervention_what": "creating more opportunities for reuse",
-      "intervention_how": "none",
-      "intervention_score": 3,
-      "intervention_reasoning": "The measure specifies what (creating more opportunities for reuse) but lacks a named actor, timeline, and mechanism.",
-      "intervention_type": "indirect"
-    }
-  ]
+          {
+            "stable_id": "shift_to_biogas_energy_in_other_industries",
+            "short_label": "T-2D5-TE-2 - Shift to biogas energy in other industries",
+            "description": "Shift to biogas energy in other industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: industrial unregulated gas use. to: industrial unregulated biogas use. Industry > Other > Other",
+            "sector_path": "Industry > Other > Other",
+            "acts_on_labels": ["industrial unregulated gas use"],
+            "shifts_to_labels": ["industrial unregulated biogas use"],
+            "score": 0.2404
+          },
+          {
+            "stable_id": "biogas_in_methane_reforming_for_hydrogen_production",
+            "short_label": "T-5B4-TE-1 - Biogas in methane reforming for hydrogen production",
+            "description": "Biogas in methane reforming for hydrogen production. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: reforming of methane for hydrogen production. Energy > Energy Transformation > Hydrogen Refinement",
+            "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
+            "acts_on_labels": ["reforming of methane for hydrogen production"],
+            "shifts_to_labels": [],
+            "score": 0.2378
+          }
+        ]
+      }
+    ],
+    "intervention_who": "none",
+    "intervention_when": "none",
+    "intervention_what": "utilize nature-based solutions",
+    "intervention_how": "none",
+    "intervention_score": 2,
+    "intervention_reasoning": "What is weakly present, but no specific actor, timeline, or mechanism is provided.",
+    "intervention_type": "indirect"
+  },
+  {
+    "measure_text": "127.Värmeöar i stadsbebyggelsen ska minska genom att öka andelen gröna ytor.",
+    "activity": "urban cooling",
+    "activity_shift_score": 3,
+    "activity_shifts": [
+      {
+        "activity": "cooling urban areas",
+        "shift_from": "none",
+        "shift_to": "increasing green spaces for cooling",
+        "need": "urban cooling",
+        "type": "Type Shift",
+        "type_reasoning": "The measure implies a shift to using green spaces for cooling, which is a change in the method used for urban cooling.",
+        "score": 3,
+        "reasoning": "Activity and shift_to are identifiable, but shift_from is not clearly specified.",
+        "transition_element_matches": [],
+        "transition_element_suggested_new": {
+          "short_label": "Increase Urban Green Spaces for Cooling",
+          "description": "Implement measures to increase the proportion of green areas in urban environments to reduce heat islands and improve urban cooling."
+        },
+        "transition_element_candidates": [
+          {
+            "stable_id": "shift_to_district_cooling_in_public_buildings",
+            "short_label": "T-4B1b-TE-2 - Shift to district cooling in public buildings",
+            "description": "Shift to district cooling in public buildings. Shift square meter from industrial building cooling with AC to industrial building cooling with district cooling in square meter to fulfill the need of comfortable premises. from: public building cooling with ac. to: public building cooling with district cooling. Buildings > Non Residential > Hvac > Institutional Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
+            "acts_on_labels": ["public building cooling with ac"],
+            "shifts_to_labels": [
+              "public building cooling with district cooling"
+            ],
+            "score": 0.5192
+          },
+          {
+            "stable_id": "energy_efficient_non_residential_public_buildings_retrofitting_cooling",
+            "short_label": "T-4B1b-TE-7 - Retrofitting public buildings for efficient cooling",
+            "description": "Retrofitting public buildings for efficient cooling. Reduce the amount of energy required to cool public building with AC and disitrct cooling through retrofitting. from: public building cooling with ac, public building cooling with district cooling. Buildings > Non Residential > Hvac > Institutional Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
+            "acts_on_labels": [
+              "public building cooling with ac",
+              "public building cooling with district cooling"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.5175
+          },
+          {
+            "stable_id": "shift_to_district_cooling_in_industrial_buildings",
+            "short_label": "T-4B1c-TE-2 - Shift to district cooling in industrial buildings",
+            "description": "Shift to district cooling in industrial buildings. Shift square meter from industrial building cooling with AC to industrial building cooling with district cooling in square meter to fulfill the need of comfortable premises. from: industrial building cooling with ac. to: industrial building cooling with district cooling. Buildings > Non Residential > Hvac > Other Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Other Hvac",
+            "acts_on_labels": ["industrial building cooling with ac"],
+            "shifts_to_labels": [
+              "industrial building cooling with district cooling"
+            ],
+            "score": 0.4944
+          },
+          {
+            "stable_id": "energy_efficient_non_residential_industrial_buildings_retrofitting_cooling",
+            "short_label": "T-4B1c-TE-7 - Retrofitting industrial buildings for efficient cooling",
+            "description": "Retrofitting industrial buildings for efficient cooling. Reduce the amount of energy required to cool industrial building with AC and disitrct cooling through retrofitting. from: industrial building cooling with ac, industrial building cooling with district cooling. Buildings > Non Residential > Hvac > Other Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Other Hvac",
+            "acts_on_labels": [
+              "industrial building cooling with ac",
+              "industrial building cooling with district cooling"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.4941
+          },
+          {
+            "stable_id": "energy_efficient_non_residential_commercial_buildings_retrofitting_cooling",
+            "short_label": "T-4B1a-TE-7 - Retrofitting commerical buildings for efficient cooling",
+            "description": "Retrofitting commerical buildings for efficient cooling. Reduce the amount of energy required to cool commerical  building with AC and disitrct cooling through retrofitting. from: commercial building cooling with ac, commercial building cooling with district cooling. Buildings > Non Residential > Hvac > Commercial Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Commercial Hvac",
+            "acts_on_labels": [
+              "commercial building cooling with ac",
+              "commercial building cooling with district cooling"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.4932
+          },
+          {
+            "stable_id": "shift_to_district_cooling_in_commercial_buildings",
+            "short_label": "T-4B1a-TE-2 - Shift to district cooling in commerical buildings",
+            "description": "Shift to district cooling in commerical buildings. Shift square meter from commerical building cooling with AC to commerical building cooling with district cooling in square meter to fulfill the need of comfortable premises. from: commercial building cooling with ac. to: commercial building cooling with district cooling. Buildings > Non Residential > Hvac > Commercial Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Commercial Hvac",
+            "acts_on_labels": ["commercial building cooling with ac"],
+            "shifts_to_labels": [
+              "commercial building cooling with district cooling"
+            ],
+            "score": 0.4811
+          },
+          {
+            "stable_id": "shift_to_district_cooling_in_single_family_buildings",
+            "short_label": "T-4A1b-TE-3 - Shift to district cooling in single-family buildings",
+            "description": "Shift to district cooling in single-family buildings. Shift square meter from single family building cooling with AC to single family building cooling with district cooling in square meter to fulfill the need of comfortable premises. from: single family building cooling with ac. to: single family building cooling with district cooling. Buildings > Residential > Hvac > Single Family Hvac",
+            "sector_path": "Buildings > Residential > Hvac > Single Family Hvac",
+            "acts_on_labels": ["single family building cooling with ac"],
+            "shifts_to_labels": [
+              "single family building cooling with district cooling"
+            ],
+            "score": 0.4692
+          },
+          {
+            "stable_id": "energy_efficient_multi_family_residential_buildings_retrofitting_cooling",
+            "short_label": "T-4A1a-TE-9 - Retrofitting multi-family buildings for efficient cooling",
+            "description": "Retrofitting multi-family buildings for efficient cooling. Reduce the amount of energy required to cool multi family building with AC and disitrct cooling through retrofitting. from: multi family building cooling with ac, multi family building cooling with district cooling. Buildings > Residential > Hvac > Multi Family Hvac",
+            "sector_path": "Buildings > Residential > Hvac > Multi Family Hvac",
+            "acts_on_labels": [
+              "multi family building cooling with ac",
+              "multi family building cooling with district cooling"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.4672
+          },
+          {
+            "stable_id": "energy_efficient_single_family_residential_buildings_retrofitting_cooling",
+            "short_label": "T-4A1b-TE-9 - Retrofitting single-family buildings for efficient cooling",
+            "description": "Retrofitting single-family buildings for efficient cooling. Reduce the amount of energy required to cool single family building with AC and disitrct cooling through retrofitting. from: single family building cooling with ac, single family building cooling with district cooling. Buildings > Residential > Hvac > Single Family Hvac",
+            "sector_path": "Buildings > Residential > Hvac > Single Family Hvac",
+            "acts_on_labels": [
+              "single family building cooling with ac",
+              "single family building cooling with district cooling"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.4656
+          },
+          {
+            "stable_id": "shift_to_district_cooling_in_multi_family_buildings",
+            "short_label": "T-4A1a-TE-3 - Shift to district cooling in multi-family buildings",
+            "description": "Shift to district cooling in multi-family buildings. Shift square meter from multi family building cooling with AC to multi family building cooling with district cooling in square meter to fulfill the need of comfortable premises. from: multi family building cooling with ac. to: multi family building cooling with district cooling. Buildings > Residential > Hvac > Multi Family Hvac",
+            "sector_path": "Buildings > Residential > Hvac > Multi Family Hvac",
+            "acts_on_labels": ["multi family building cooling with ac"],
+            "shifts_to_labels": [
+              "multi family building cooling with district cooling"
+            ],
+            "score": 0.4619
+          },
+          {
+            "stable_id": "efficient_use_multi_family_residential_buildings_cooling",
+            "short_label": "T-4A1a-TE-7 - Energy efficient use of ACs in multi-family buildings",
+            "description": "Energy efficient use of ACs in multi-family buildings. Reduce the amount of energy required to cool multi family buildings with AC through efficient use of AC units. from: multi family building cooling with ac. Buildings > Residential > Hvac > Multi Family Hvac",
+            "sector_path": "Buildings > Residential > Hvac > Multi Family Hvac",
+            "acts_on_labels": ["multi family building cooling with ac"],
+            "shifts_to_labels": [],
+            "score": 0.3865
+          },
+          {
+            "stable_id": "energy_efficient_multi_family_residential_buildings_cooling",
+            "short_label": "T-4A1a-TE-8 - Energy efficient AC in multi-family buildings",
+            "description": "Energy efficient AC in multi-family buildings. Reduce the amount of energy required to cool multi family buildings with AC through more efficient AC units. from: multi family building cooling with ac. Buildings > Residential > Hvac > Multi Family Hvac",
+            "sector_path": "Buildings > Residential > Hvac > Multi Family Hvac",
+            "acts_on_labels": ["multi family building cooling with ac"],
+            "shifts_to_labels": [],
+            "score": 0.3862
+          },
+          {
+            "stable_id": "efficient_use_single_family_residential_buildings_cooling",
+            "short_label": "T-4A1b-TE-7 - Energy efficient use of ACs in single-family buildings",
+            "description": "Energy efficient use of ACs in single-family buildings. Reduce the amount of energy required to cool single family buildings with AC through efficient use of AC units. from: single family building cooling with ac. Buildings > Residential > Hvac > Single Family Hvac",
+            "sector_path": "Buildings > Residential > Hvac > Single Family Hvac",
+            "acts_on_labels": ["single family building cooling with ac"],
+            "shifts_to_labels": [],
+            "score": 0.3806
+          },
+          {
+            "stable_id": "energy_efficient_single_family_residential_buildings_cooling",
+            "short_label": "T-4A1b-TE-8 - Energy efficient AC in single-family buildings",
+            "description": "Energy efficient AC in single-family buildings. Reduce the amount of energy required to cool single family buildings with AC through more efficient AC units. from: single family building cooling with ac. Buildings > Residential > Hvac > Single Family Hvac",
+            "sector_path": "Buildings > Residential > Hvac > Single Family Hvac",
+            "acts_on_labels": ["single family building cooling with ac"],
+            "shifts_to_labels": [],
+            "score": 0.38
+          },
+          {
+            "stable_id": "energy_efficient_non_residential_public_buildings_retrofitting",
+            "short_label": "T-4B1b-TE-6 - Retrofitting public buildings for efficient heating",
+            "description": "Retrofitting public buildings for efficient heating. Reduce the amount of energy required to heat public building heating. from: public building heating with solid biofuels, public building heating with direct electric heaters, public building heating with gas, public building heating with propane, public building heating with oil, public building heating with heatpump, public building heating with district heating, public building heating with coal, public building heating with solar thermal, public building heating with lpg, public building heating with hydrogen, public building heating with gas oil. Buildings > Non Residential > Hvac > Institutional Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
+            "acts_on_labels": [
+              "public building heating with solid biofuels",
+              "public building heating with direct electric heaters",
+              "public building heating with gas",
+              "public building heating with propane",
+              "public building heating with oil",
+              "public building heating with heatpump",
+              "public building heating with district heating",
+              "public building heating with coal",
+              "public building heating with solar thermal",
+              "public building heating with lpg",
+              "public building heating with hydrogen",
+              "public building heating with gas oil"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.3433
+          }
+        ]
+      }
+    ],
+    "intervention_who": "none",
+    "intervention_when": "none",
+    "intervention_what": "increase green spaces",
+    "intervention_how": "none",
+    "intervention_score": 2,
+    "intervention_reasoning": "What is weakly present, but no specific actor, timeline, or mechanism is provided.",
+    "intervention_type": "indirect"
+  },
+  {
+    "measure_text": "128.Kommunkoncernen ska vidta energieffektiviseringsåtgärder så att energianvändningen per kvadratmeter i egenägda fastigheter minskar med minst 20 procent från 2020 till 2030.",
+    "activity": "building energy use",
+    "activity_shift_score": 6,
+    "activity_shifts": [
+      {
+        "activity": "using energy in buildings",
+        "shift_from": "high energy use per square meter",
+        "shift_to": "reduced energy use per square meter",
+        "need": "space heating and cooling",
+        "type": "Resource Efficiency Shift",
+        "type_reasoning": "The measure focuses on reducing energy use per square meter, which is a resource efficiency improvement.",
+        "score": 6,
+        "reasoning": "Activity, shift_from, shift_to, and need are all identifiable.",
+        "transition_element_matches": [
+          {
+            "stable_id": "shift_to_district_heating_in_public_buildings",
+            "short_label": "T-4B1b-TE-1 - Shift to district heating in public buildings",
+            "description": "Shift to district heating in public buildings. Shift square meter from public building heated with oil, gas, direct. from: public building heating with oil, public building heating with gas, public building heating with propane, public building heating with direct electric heaters, public building heating with coal, public building heating with lpg, public building heating with gas oil. to: public building heating with district heating. Buildings > Non Residential > Hvac > Institutional Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
+            "acts_on_labels": [
+              "public building heating with oil",
+              "public building heating with gas",
+              "public building heating with propane",
+              "public building heating with direct electric heaters",
+              "public building heating with coal",
+              "public building heating with lpg",
+              "public building heating with gas oil"
+            ],
+            "shifts_to_labels": [
+              "public building heating with district heating"
+            ],
+            "score": 0.5944,
+            "match_reasoning": "acts_on=yes, shifts_to=yes, confidence=mid",
+            "match_confidence": "mid"
+          },
+          {
+            "stable_id": "heat_pumps_in_non_residential_public_buildings",
+            "short_label": "T-4B1b-TE-3 - Shift to heat pumps in public buildings",
+            "description": "Shift to heat pumps in public buildings. Shift square meter from public buildings heated with oil, gas, direct. from: public building heating with oil, public building heating with gas, public building heating with propane, public building heating with direct electric heaters, public building heating with coal, public building heating with lpg, public building heating with gas oil. to: public building heating with heatpump. Buildings > Non Residential > Hvac > Institutional Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
+            "acts_on_labels": [
+              "public building heating with oil",
+              "public building heating with gas",
+              "public building heating with propane",
+              "public building heating with direct electric heaters",
+              "public building heating with coal",
+              "public building heating with lpg",
+              "public building heating with gas oil"
+            ],
+            "shifts_to_labels": ["public building heating with heatpump"],
+            "score": 0.5889,
+            "match_reasoning": "acts_on=yes, shifts_to=yes, confidence=mid",
+            "match_confidence": "mid"
+          },
+          {
+            "stable_id": "energy_efficient_non_residential_public_buildings_retrofitting",
+            "short_label": "T-4B1b-TE-6 - Retrofitting public buildings for efficient heating",
+            "description": "Retrofitting public buildings for efficient heating. Reduce the amount of energy required to heat public building heating. from: public building heating with solid biofuels, public building heating with direct electric heaters, public building heating with gas, public building heating with propane, public building heating with oil, public building heating with heatpump, public building heating with district heating, public building heating with coal, public building heating with solar thermal, public building heating with lpg, public building heating with hydrogen, public building heating with gas oil. Buildings > Non Residential > Hvac > Institutional Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
+            "acts_on_labels": [
+              "public building heating with solid biofuels",
+              "public building heating with direct electric heaters",
+              "public building heating with gas",
+              "public building heating with propane",
+              "public building heating with oil",
+              "public building heating with heatpump",
+              "public building heating with district heating",
+              "public building heating with coal",
+              "public building heating with solar thermal",
+              "public building heating with lpg",
+              "public building heating with hydrogen",
+              "public building heating with gas oil"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.5853,
+            "match_reasoning": "acts_on=yes, shifts_to=empty, confidence=mid",
+            "match_confidence": "mid"
+          },
+          {
+            "stable_id": "shift_to_solar_thermal_in_public_buildings",
+            "short_label": "T-4B1b-TE-5 - Shift to solar thermal in public buildings",
+            "description": "Shift to solar thermal in public buildings. Shift square meter from public building heated with oil, gas, direct. from: public building heating with oil, public building heating with gas, public building heating with propane, public building heating with direct electric heaters, public building heating with coal, public building heating with lpg, public building heating with gas oil. to: public building heating with solar thermal. Buildings > Non Residential > Hvac > Institutional Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
+            "acts_on_labels": [
+              "public building heating with oil",
+              "public building heating with gas",
+              "public building heating with propane",
+              "public building heating with direct electric heaters",
+              "public building heating with coal",
+              "public building heating with lpg",
+              "public building heating with gas oil"
+            ],
+            "shifts_to_labels": ["public building heating with solar thermal"],
+            "score": 0.5833,
+            "match_reasoning": "acts_on=yes, shifts_to=yes, confidence=mid",
+            "match_confidence": "mid"
+          },
+          {
+            "stable_id": "heating_non_residential_public_buildings_with_renewable_solid_biofuels",
+            "short_label": "T-4B1b-TE-4 - Shift to biofuel in public buildings",
+            "description": "Shift to biofuel in public buildings. Shift square meter from public buildings heated with oil, gas, direct. from: public building heating with oil, public building heating with gas, public building heating with propane, public building heating with direct electric heaters, public building heating with coal, public building heating with lpg, public building heating with gas oil. to: public building heating with solid biofuels. Buildings > Non Residential > Hvac > Institutional Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
+            "acts_on_labels": [
+              "public building heating with oil",
+              "public building heating with gas",
+              "public building heating with propane",
+              "public building heating with direct electric heaters",
+              "public building heating with coal",
+              "public building heating with lpg",
+              "public building heating with gas oil"
+            ],
+            "shifts_to_labels": ["public building heating with solid biofuels"],
+            "score": 0.5679,
+            "match_reasoning": "acts_on=yes, shifts_to=yes, confidence=mid",
+            "match_confidence": "mid"
+          }
+        ],
+        "transition_element_candidates": [
+          {
+            "stable_id": "shift_to_district_heating_in_commercial_buildings",
+            "short_label": "T-4B1a-TE-1 - Shift to district heating in commercial buildings",
+            "description": "Shift to district heating in commercial buildings. Shift square meter from commercial building heated with gas, oil, direct. from: commercial building heating with gas, commercial building heating with propane, commercial building heating with oil, commercial building heating with direct electric heaters, commercial building heating with coal, commercial building heating with lpg, commercial building heating with gas oil. to: commercial building heating with district heating. Buildings > Non Residential > Hvac > Commercial Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Commercial Hvac",
+            "acts_on_labels": [
+              "commercial building heating with gas",
+              "commercial building heating with propane",
+              "commercial building heating with oil",
+              "commercial building heating with direct electric heaters",
+              "commercial building heating with coal",
+              "commercial building heating with lpg",
+              "commercial building heating with gas oil"
+            ],
+            "shifts_to_labels": [
+              "commercial building heating with district heating"
+            ],
+            "score": 0.6024
+          },
+          {
+            "stable_id": "shift_to_solar_thermal_in_commercial_buildings",
+            "short_label": "T-4B1a-TE-5 - Shift to solar thermal in commercial buildings",
+            "description": "Shift to solar thermal in commercial buildings. Shift square meter from commercial building heated with gas, oil, direct. from: commercial building heating with gas, commercial building heating with propane, commercial building heating with oil, commercial building heating with direct electric heaters, commercial building heating with coal, commercial building heating with lpg, commercial building heating with gas oil. to: commercial building heating with solar thermal. Buildings > Non Residential > Hvac > Commercial Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Commercial Hvac",
+            "acts_on_labels": [
+              "commercial building heating with gas",
+              "commercial building heating with propane",
+              "commercial building heating with oil",
+              "commercial building heating with direct electric heaters",
+              "commercial building heating with coal",
+              "commercial building heating with lpg",
+              "commercial building heating with gas oil"
+            ],
+            "shifts_to_labels": [
+              "commercial building heating with solar thermal"
+            ],
+            "score": 0.598
+          },
+          {
+            "stable_id": "heat_pumps_in_non_residential_commercial_buildings",
+            "short_label": "T-4B1a-TE-3 - Shift to heat pumps in commerical buildings",
+            "description": "Shift to heat pumps in commerical buildings. Shift square meter from commercial buildings heated with gas, oil, direct. from: commercial building heating with gas, commercial building heating with propane, commercial building heating with oil, commercial building heating with direct electric heaters, commercial building heating with coal, commercial building heating with lpg, commercial building heating with gas oil. to: commercial building heating with heatpump. Buildings > Non Residential > Hvac > Commercial Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Commercial Hvac",
+            "acts_on_labels": [
+              "commercial building heating with gas",
+              "commercial building heating with propane",
+              "commercial building heating with oil",
+              "commercial building heating with direct electric heaters",
+              "commercial building heating with coal",
+              "commercial building heating with lpg",
+              "commercial building heating with gas oil"
+            ],
+            "shifts_to_labels": ["commercial building heating with heatpump"],
+            "score": 0.5962
+          },
+          {
+            "stable_id": "shift_to_district_heating_in_public_buildings",
+            "short_label": "T-4B1b-TE-1 - Shift to district heating in public buildings",
+            "description": "Shift to district heating in public buildings. Shift square meter from public building heated with oil, gas, direct. from: public building heating with oil, public building heating with gas, public building heating with propane, public building heating with direct electric heaters, public building heating with coal, public building heating with lpg, public building heating with gas oil. to: public building heating with district heating. Buildings > Non Residential > Hvac > Institutional Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
+            "acts_on_labels": [
+              "public building heating with oil",
+              "public building heating with gas",
+              "public building heating with propane",
+              "public building heating with direct electric heaters",
+              "public building heating with coal",
+              "public building heating with lpg",
+              "public building heating with gas oil"
+            ],
+            "shifts_to_labels": [
+              "public building heating with district heating"
+            ],
+            "score": 0.5944
+          },
+          {
+            "stable_id": "shift_to_district_cooling_in_commercial_buildings",
+            "short_label": "T-4B1a-TE-2 - Shift to district cooling in commerical buildings",
+            "description": "Shift to district cooling in commerical buildings. Shift square meter from commerical building cooling with AC to commerical building cooling with district cooling in square meter to fulfill the need of comfortable premises. from: commercial building cooling with ac. to: commercial building cooling with district cooling. Buildings > Non Residential > Hvac > Commercial Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Commercial Hvac",
+            "acts_on_labels": ["commercial building cooling with ac"],
+            "shifts_to_labels": [
+              "commercial building cooling with district cooling"
+            ],
+            "score": 0.589
+          },
+          {
+            "stable_id": "heat_pumps_in_non_residential_public_buildings",
+            "short_label": "T-4B1b-TE-3 - Shift to heat pumps in public buildings",
+            "description": "Shift to heat pumps in public buildings. Shift square meter from public buildings heated with oil, gas, direct. from: public building heating with oil, public building heating with gas, public building heating with propane, public building heating with direct electric heaters, public building heating with coal, public building heating with lpg, public building heating with gas oil. to: public building heating with heatpump. Buildings > Non Residential > Hvac > Institutional Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
+            "acts_on_labels": [
+              "public building heating with oil",
+              "public building heating with gas",
+              "public building heating with propane",
+              "public building heating with direct electric heaters",
+              "public building heating with coal",
+              "public building heating with lpg",
+              "public building heating with gas oil"
+            ],
+            "shifts_to_labels": ["public building heating with heatpump"],
+            "score": 0.5889
+          },
+          {
+            "stable_id": "heating_non_residential_commercial_buildings_with_renewable_solid_biofuels",
+            "short_label": "T-4B1a-TE-4 - Shift to biofuel in commercial buildings",
+            "description": "Shift to biofuel in commercial buildings. Shift square meter from commercial buildings heated with gas, oil, direct. from: commercial building heating with gas, commercial building heating with propane, commercial building heating with oil, commercial building heating with direct electric heaters, commercial building heating with coal, commercial building heating with lpg, commercial building heating with gas oil. to: commercial building heating with solid biofuels. Buildings > Non Residential > Hvac > Commercial Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Commercial Hvac",
+            "acts_on_labels": [
+              "commercial building heating with gas",
+              "commercial building heating with propane",
+              "commercial building heating with oil",
+              "commercial building heating with direct electric heaters",
+              "commercial building heating with coal",
+              "commercial building heating with lpg",
+              "commercial building heating with gas oil"
+            ],
+            "shifts_to_labels": [
+              "commercial building heating with solid biofuels"
+            ],
+            "score": 0.5879
+          },
+          {
+            "stable_id": "shift_to_district_cooling_in_public_buildings",
+            "short_label": "T-4B1b-TE-2 - Shift to district cooling in public buildings",
+            "description": "Shift to district cooling in public buildings. Shift square meter from industrial building cooling with AC to industrial building cooling with district cooling in square meter to fulfill the need of comfortable premises. from: public building cooling with ac. to: public building cooling with district cooling. Buildings > Non Residential > Hvac > Institutional Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
+            "acts_on_labels": ["public building cooling with ac"],
+            "shifts_to_labels": [
+              "public building cooling with district cooling"
+            ],
+            "score": 0.5877
+          },
+          {
+            "stable_id": "energy_efficient_non_residential_public_buildings_retrofitting",
+            "short_label": "T-4B1b-TE-6 - Retrofitting public buildings for efficient heating",
+            "description": "Retrofitting public buildings for efficient heating. Reduce the amount of energy required to heat public building heating. from: public building heating with solid biofuels, public building heating with direct electric heaters, public building heating with gas, public building heating with propane, public building heating with oil, public building heating with heatpump, public building heating with district heating, public building heating with coal, public building heating with solar thermal, public building heating with lpg, public building heating with hydrogen, public building heating with gas oil. Buildings > Non Residential > Hvac > Institutional Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
+            "acts_on_labels": [
+              "public building heating with solid biofuels",
+              "public building heating with direct electric heaters",
+              "public building heating with gas",
+              "public building heating with propane",
+              "public building heating with oil",
+              "public building heating with heatpump",
+              "public building heating with district heating",
+              "public building heating with coal",
+              "public building heating with solar thermal",
+              "public building heating with lpg",
+              "public building heating with hydrogen",
+              "public building heating with gas oil"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.5853
+          },
+          {
+            "stable_id": "shift_to_solar_thermal_in_public_buildings",
+            "short_label": "T-4B1b-TE-5 - Shift to solar thermal in public buildings",
+            "description": "Shift to solar thermal in public buildings. Shift square meter from public building heated with oil, gas, direct. from: public building heating with oil, public building heating with gas, public building heating with propane, public building heating with direct electric heaters, public building heating with coal, public building heating with lpg, public building heating with gas oil. to: public building heating with solar thermal. Buildings > Non Residential > Hvac > Institutional Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
+            "acts_on_labels": [
+              "public building heating with oil",
+              "public building heating with gas",
+              "public building heating with propane",
+              "public building heating with direct electric heaters",
+              "public building heating with coal",
+              "public building heating with lpg",
+              "public building heating with gas oil"
+            ],
+            "shifts_to_labels": ["public building heating with solar thermal"],
+            "score": 0.5833
+          },
+          {
+            "stable_id": "shift_to_solar_thermal_in_industrial_buildings",
+            "short_label": "T-4B1c-TE-5 - Shift to solar thermal in industrial buildings",
+            "description": "Shift to solar thermal in industrial buildings. Shift square meter from industrial building heated with gas, oil, direct. from: industrial building heating with gas, industrial building heating with oil, industrial building heating with direct electric heaters, industrial building heating with lpg, industrial building heating with coal, industrial building heating with gas oil. to: industrial building heating with solar thermal. Buildings > Non Residential > Hvac > Other Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Other Hvac",
+            "acts_on_labels": [
+              "industrial building heating with gas",
+              "industrial building heating with oil",
+              "industrial building heating with direct electric heaters",
+              "industrial building heating with lpg",
+              "industrial building heating with coal",
+              "industrial building heating with gas oil"
+            ],
+            "shifts_to_labels": [
+              "industrial building heating with solar thermal"
+            ],
+            "score": 0.5832
+          },
+          {
+            "stable_id": "shift_to_district_cooling_in_industrial_buildings",
+            "short_label": "T-4B1c-TE-2 - Shift to district cooling in industrial buildings",
+            "description": "Shift to district cooling in industrial buildings. Shift square meter from industrial building cooling with AC to industrial building cooling with district cooling in square meter to fulfill the need of comfortable premises. from: industrial building cooling with ac. to: industrial building cooling with district cooling. Buildings > Non Residential > Hvac > Other Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Other Hvac",
+            "acts_on_labels": ["industrial building cooling with ac"],
+            "shifts_to_labels": [
+              "industrial building cooling with district cooling"
+            ],
+            "score": 0.5785
+          },
+          {
+            "stable_id": "shift_to_district_cooling_in_single_family_buildings",
+            "short_label": "T-4A1b-TE-3 - Shift to district cooling in single-family buildings",
+            "description": "Shift to district cooling in single-family buildings. Shift square meter from single family building cooling with AC to single family building cooling with district cooling in square meter to fulfill the need of comfortable premises. from: single family building cooling with ac. to: single family building cooling with district cooling. Buildings > Residential > Hvac > Single Family Hvac",
+            "sector_path": "Buildings > Residential > Hvac > Single Family Hvac",
+            "acts_on_labels": ["single family building cooling with ac"],
+            "shifts_to_labels": [
+              "single family building cooling with district cooling"
+            ],
+            "score": 0.5781
+          },
+          {
+            "stable_id": "shift_to_district_heating_in_industrial_buildings",
+            "short_label": "T-4B1c-TE-1 - Shift to district heating in industrial buildings",
+            "description": "Shift to district heating in industrial buildings. Shift square meter from industrial building heated with gas, oil and. from: industrial building heating with gas, industrial building heating with oil, industrial building heating with direct electric heaters, industrial building heating with lpg, industrial building heating with coal, industrial building heating with gas oil. to: industrial building heating with district heating. Buildings > Non Residential > Hvac > Other Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Other Hvac",
+            "acts_on_labels": [
+              "industrial building heating with gas",
+              "industrial building heating with oil",
+              "industrial building heating with direct electric heaters",
+              "industrial building heating with lpg",
+              "industrial building heating with coal",
+              "industrial building heating with gas oil"
+            ],
+            "shifts_to_labels": [
+              "industrial building heating with district heating"
+            ],
+            "score": 0.5774
+          },
+          {
+            "stable_id": "shift_to_biogas_heating_of_non_residential_commercial_buildings",
+            "short_label": "T-4B1a-TE-10 - Shift to biogas in commercial buildings",
+            "description": "Shift to biogas in commercial buildings. Shift square meter from commercial building heating with gas to commercial building heating with biogas in square meter to fulfill the need of comfortable premises. from: commercial building heating with gas. to: commercial building heating with biogas. Buildings > Non Residential > Hvac > Commercial Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Commercial Hvac",
+            "acts_on_labels": ["commercial building heating with gas"],
+            "shifts_to_labels": ["commercial building heating with biogas"],
+            "score": 0.5758
+          },
+          {
+            "stable_id": "heating_non_residential_public_buildings_with_renewable_solid_biofuels",
+            "short_label": "T-4B1b-TE-4 - Shift to biofuel in public buildings",
+            "description": "Shift to biofuel in public buildings. Shift square meter from public buildings heated with oil, gas, direct. from: public building heating with oil, public building heating with gas, public building heating with propane, public building heating with direct electric heaters, public building heating with coal, public building heating with lpg, public building heating with gas oil. to: public building heating with solid biofuels. Buildings > Non Residential > Hvac > Institutional Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
+            "acts_on_labels": [
+              "public building heating with oil",
+              "public building heating with gas",
+              "public building heating with propane",
+              "public building heating with direct electric heaters",
+              "public building heating with coal",
+              "public building heating with lpg",
+              "public building heating with gas oil"
+            ],
+            "shifts_to_labels": ["public building heating with solid biofuels"],
+            "score": 0.5679
+          }
+        ]
+      }
+    ],
+    "intervention_who": "kommunkoncernen",
+    "intervention_when": "from 2020 to 2030",
+    "intervention_what": "implement energy efficiency measures",
+    "intervention_how": "none",
+    "intervention_score": 4,
+    "intervention_reasoning": "Who, when, and what are present, but how is not specified.",
+    "intervention_type": "direct"
+  },
+  {
+    "measure_text": "129.Utbyggnaden av förnybara energikällor ska öka inom kommunkoncernen.",
+    "activity": "energy production",
+    "activity_shift_score": 3,
+    "activity_shifts": [
+      {
+        "activity": "producing energy",
+        "shift_from": "none",
+        "shift_to": "increasing renewable energy sources",
+        "need": "electricity provision",
+        "type": "Resource Shift",
+        "type_reasoning": "The measure implies a shift to renewable energy sources, which is a change in the resource used for energy production.",
+        "score": 3,
+        "reasoning": "Activity and shift_to are identifiable, but shift_from is not clearly specified.",
+        "transition_element_matches": [],
+        "transition_element_suggested_new": {
+          "short_label": "Increase Renewable Energy Sources",
+          "description": "Expansion of renewable energy sources within the municipal corporation to increase electricity provision."
+        },
+        "transition_element_candidates": [
+          {
+            "stable_id": "wind_offshore",
+            "short_label": "T-5A1-TE-9 - Electricity from wind offshore",
+            "description": "Electricity from wind offshore. Alter the amount of electricity produced by wind offshore. from: wind offshore. Energy > Energy Supply > Electricity",
+            "sector_path": "Energy > Energy Supply > Electricity",
+            "acts_on_labels": ["wind offshore"],
+            "shifts_to_labels": [],
+            "score": 0.5344
+          },
+          {
+            "stable_id": "wind_onshore",
+            "short_label": "T-5A1-TE-10 - Electricity from wind onshore",
+            "description": "Electricity from wind onshore. Alter the amount of electricity produced by wind onshore. from: wind onshore. Energy > Energy Supply > Electricity",
+            "sector_path": "Energy > Energy Supply > Electricity",
+            "acts_on_labels": ["wind onshore"],
+            "shifts_to_labels": [],
+            "score": 0.5319
+          },
+          {
+            "stable_id": "solar_rooftops",
+            "short_label": "T-5A1-TE-8 - Electricity from solar rooftops",
+            "description": "Electricity from solar rooftops. Alter the amount of electricity produced by solar rooftops. from: solar rooftops. Energy > Energy Supply > Electricity",
+            "sector_path": "Energy > Energy Supply > Electricity",
+            "acts_on_labels": ["solar rooftops"],
+            "shifts_to_labels": [],
+            "score": 0.522
+          },
+          {
+            "stable_id": "shift_to_electricity_in_hydrogen_refinement",
+            "short_label": "T-5B4-TE-5 - Shift to electricity in hydrogen refinement",
+            "description": "Shift to electricity in hydrogen refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within hydrogen refinement, natural gas usage within hydrogen refinement. to: electricity usage within hydrogen refinement. Energy > Energy Transformation > Hydrogen Refinement",
+            "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
+            "acts_on_labels": [
+              "coal usage within hydrogen refinement",
+              "natural gas usage within hydrogen refinement"
+            ],
+            "shifts_to_labels": [
+              "electricity usage within hydrogen refinement"
+            ],
+            "score": 0.5183
+          },
+          {
+            "stable_id": "solar_parks",
+            "short_label": "T-5A1-TE-7 - Electricity from solar parks",
+            "description": "Electricity from solar parks. Alter the amount of electricity produced by solar parks. from: solar parks. Energy > Energy Supply > Electricity",
+            "sector_path": "Energy > Energy Supply > Electricity",
+            "acts_on_labels": ["solar parks"],
+            "shifts_to_labels": [],
+            "score": 0.514
+          },
+          {
+            "stable_id": "biofuel_fired_power_plants",
+            "short_label": "T-5A1-TE-11 - Electricity from biomass power plants",
+            "description": "Electricity from biomass power plants. Alter the amount of electricity produced by biofuel fired power plants. from: biofuel fired powerplants. Energy > Energy Supply > Electricity",
+            "sector_path": "Energy > Energy Supply > Electricity",
+            "acts_on_labels": ["biofuel fired powerplants"],
+            "shifts_to_labels": [],
+            "score": 0.5139
+          },
+          {
+            "stable_id": "shift_to_electricity_in_glass_industries",
+            "short_label": "T-2A3-TE-3 - Shift to electricity in glass industries",
+            "description": "Shift to electricity in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within glass industries, oil usage within glass industries, natural gas usage within glass industries. to: electricity usage within glass industries. Industry > Minerals > Glass Production",
+            "sector_path": "Industry > Minerals > Glass Production",
+            "acts_on_labels": [
+              "coal usage within glass industries",
+              "oil usage within glass industries",
+              "natural gas usage within glass industries"
+            ],
+            "shifts_to_labels": ["electricity usage within glass industries"],
+            "score": 0.5136
+          },
+          {
+            "stable_id": "shift_to_electricity_in_other_industries",
+            "short_label": "T-2D5-TE-3 - Shift to electricity in other industries",
+            "description": "Shift to electricity in other industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: industrial unregulated coal use, industrial unregulated oil use, industrial unregulated gas use. to: industrial unregulated electricity use. Industry > Other > Other",
+            "sector_path": "Industry > Other > Other",
+            "acts_on_labels": [
+              "industrial unregulated coal use",
+              "industrial unregulated oil use",
+              "industrial unregulated gas use"
+            ],
+            "shifts_to_labels": ["industrial unregulated electricity use"],
+            "score": 0.5131
+          },
+          {
+            "stable_id": "shift_to_electricity_in_chemical_industries",
+            "short_label": "T-2B9-TE-3 - Shift to electricity in chemical industries",
+            "description": "Shift to electricity in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within chemical industries, natural gas usage within chemical industries. to: electricity usage within chemical industries. Industry > Chemicals > Other",
+            "sector_path": "Industry > Chemicals > Other",
+            "acts_on_labels": [
+              "coal usage within chemical industries",
+              "natural gas usage within chemical industries"
+            ],
+            "shifts_to_labels": [
+              "electricity usage within chemical industries"
+            ],
+            "score": 0.5127
+          },
+          {
+            "stable_id": "shift_to_electrolysis_of_water_for_hydrogen_production",
+            "short_label": "T-5B4-TE-6 - Shift to electrolysis of water for hydrogen production",
+            "description": "Shift to electrolysis of water for hydrogen production. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: reforming of methane for hydrogen production, gasification of carbon for hydrogen production. to: electrolysis of water for hydrogen production. Energy > Energy Transformation > Hydrogen Refinement",
+            "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
+            "acts_on_labels": [
+              "reforming of methane for hydrogen production",
+              "gasification of carbon for hydrogen production"
+            ],
+            "shifts_to_labels": [
+              "electrolysis of water for hydrogen production"
+            ],
+            "score": 0.5064
+          },
+          {
+            "stable_id": "improved_grid_electricity",
+            "short_label": "T-5A1-TE-3 - Improved Grid Electricity",
+            "description": "Improved Grid Electricity. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: grid current. to: grid future. Energy > Energy Supply > Electricity",
+            "sector_path": "Energy > Energy Supply > Electricity",
+            "acts_on_labels": ["grid current"],
+            "shifts_to_labels": ["grid future"],
+            "score": 0.5042
+          },
+          {
+            "stable_id": "shift_to_residential_electric_cooking_stoves",
+            "short_label": "T-4A2d-TE-2 - Shift to residential electric cooking stoves",
+            "description": "Shift to residential electric cooking stoves. Shift kWh from residential cooking gas stoves to residential electric cooking stoves in kWh to fullfill the need for cooking. from: residential gas cooking stoves. to: residential electric cooking stoves. Buildings > Residential > Other Energy Usage > Unregulated",
+            "sector_path": "Buildings > Residential > Other Energy Usage > Unregulated",
+            "acts_on_labels": ["residential gas cooking stoves"],
+            "shifts_to_labels": ["residential electric cooking stoves"],
+            "score": 0.4976
+          },
+          {
+            "stable_id": "shift_to_electricity_in_iron_and_steel_industries",
+            "short_label": "T-2C1-TE-4 - Shift to electricity in iron and steel industries",
+            "description": "Shift to electricity in iron and steel industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within iron and steel industries, natural gas usage within iron and steel industries. to: electricity usage within iron and steel industries. Industry > Metals > Iron Steel",
+            "sector_path": "Industry > Metals > Iron Steel",
+            "acts_on_labels": [
+              "coal usage within iron and steel industries",
+              "natural gas usage within iron and steel industries"
+            ],
+            "shifts_to_labels": [
+              "electricity usage within iron and steel industries"
+            ],
+            "score": 0.4924
+          },
+          {
+            "stable_id": "coal_fired_power_plants",
+            "short_label": "T-5A1-TE-1 - Electricity from coal power plants",
+            "description": "Electricity from coal power plants. Alter the amount of electricity produced by coal fired power plants. from: coal fired power plants. Energy > Energy Supply > Electricity",
+            "sector_path": "Energy > Energy Supply > Electricity",
+            "acts_on_labels": ["coal fired power plants"],
+            "shifts_to_labels": [],
+            "score": 0.4867
+          },
+          {
+            "stable_id": "hydro_reservoir",
+            "short_label": "T-5A1-TE-6 - Electricity from hydro reservoir",
+            "description": "Electricity from hydro reservoir. Alter the amount of electricity produced by hydro reservoir. from: hydro reservoir. Energy > Energy Supply > Electricity",
+            "sector_path": "Energy > Energy Supply > Electricity",
+            "acts_on_labels": ["hydro reservoir"],
+            "shifts_to_labels": [],
+            "score": 0.4821
+          },
+          {
+            "stable_id": "gas_fired_power_plants",
+            "short_label": "T-5A1-TE-2 - Electricity from gas power plants",
+            "description": "Electricity from gas power plants. Alter the amount of electricity produced by gas fired power plants. from: gas fired power plants. Energy > Energy Supply > Electricity",
+            "sector_path": "Energy > Energy Supply > Electricity",
+            "acts_on_labels": ["gas fired power plants"],
+            "shifts_to_labels": [],
+            "score": 0.4792
+          },
+          {
+            "stable_id": "oil_fired_power_plants",
+            "short_label": "T-5A1-TE-5 - Electricity from oil power plants",
+            "description": "Electricity from oil power plants. Alter the amount of electricity produced by oil fired power plants. from: oil fired power plants. Energy > Energy Supply > Electricity",
+            "sector_path": "Energy > Energy Supply > Electricity",
+            "acts_on_labels": ["oil fired power plants"],
+            "shifts_to_labels": [],
+            "score": 0.4743
+          },
+          {
+            "stable_id": "chp_biofuels",
+            "short_label": "T-5A3-TE-5 - CHP from biomass",
+            "description": "CHP from biomass. Alter the amount of district heat and electricity produced by CHP biofuels. from: chp biofuels. Energy > Energy Supply > Combined Heat Power",
+            "sector_path": "Energy > Energy Supply > Combined Heat Power",
+            "acts_on_labels": ["chp biofuels"],
+            "shifts_to_labels": [],
+            "score": 0.468
+          },
+          {
+            "stable_id": "increased_energy_recovery_from_waste",
+            "short_label": "T-5A3-TE-6 - Increased energy recovery from waste",
+            "description": "Increased energy recovery from waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to CHP waste incineration in tonne to fulfill the need of warm premisses. from: incineration and open burning of waste. to: chp waste incineration. Energy > Energy Supply > Combined Heat Power",
+            "sector_path": "Energy > Energy Supply > Combined Heat Power",
+            "acts_on_labels": ["incineration and open burning of waste"],
+            "shifts_to_labels": ["chp waste incineration"],
+            "score": 0.4648
+          },
+          {
+            "stable_id": "chp_coal",
+            "short_label": "T-5A3-TE-1 - CHP from coal",
+            "description": "CHP from coal. Alter the amount of district heat and electricity produced by CHP coal. from: chp coal. Energy > Energy Supply > Combined Heat Power",
+            "sector_path": "Energy > Energy Supply > Combined Heat Power",
+            "acts_on_labels": ["chp coal"],
+            "shifts_to_labels": [],
+            "score": 0.4499
+          }
+        ]
+      }
+    ],
+    "intervention_who": "none",
+    "intervention_when": "none",
+    "intervention_what": "increase renewable energy sources",
+    "intervention_how": "none",
+    "intervention_score": 2,
+    "intervention_reasoning": "What is weakly present, but no specific actor, timeline, or mechanism is provided.",
+    "intervention_type": "indirect"
+  },
+  {
+    "measure_text": "130.All el som köps in av kommunkoncernen ska komma från förnybara källor.",
+    "activity": "electricity procurement",
+    "activity_shift_score": 6,
+    "activity_shifts": [
+      {
+        "activity": "procuring electricity",
+        "shift_from": "using non-renewable sources for electricity",
+        "shift_to": "using renewable sources for electricity",
+        "need": "electricity provision",
+        "type": "Resource Shift",
+        "type_reasoning": "The measure specifies a shift to renewable sources for electricity procurement, which is a change in the resource used.",
+        "score": 6,
+        "reasoning": "Activity, shift_from, shift_to, and need are all identifiable.",
+        "transition_element_matches": [],
+        "transition_element_suggested_new": {
+          "short_label": "shift_to_renewable_electricity_in_municipal_operations",
+          "description": "Shift from non-renewable to renewable electricity sources in municipal operations and procurement"
+        },
+        "transition_element_candidates": [
+          {
+            "stable_id": "shift_to_electricity_in_hydrogen_refinement",
+            "short_label": "T-5B4-TE-5 - Shift to electricity in hydrogen refinement",
+            "description": "Shift to electricity in hydrogen refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within hydrogen refinement, natural gas usage within hydrogen refinement. to: electricity usage within hydrogen refinement. Energy > Energy Transformation > Hydrogen Refinement",
+            "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
+            "acts_on_labels": [
+              "coal usage within hydrogen refinement",
+              "natural gas usage within hydrogen refinement"
+            ],
+            "shifts_to_labels": [
+              "electricity usage within hydrogen refinement"
+            ],
+            "score": 0.5552
+          },
+          {
+            "stable_id": "shift_to_electricity_in_chemical_industries",
+            "short_label": "T-2B9-TE-3 - Shift to electricity in chemical industries",
+            "description": "Shift to electricity in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within chemical industries, natural gas usage within chemical industries. to: electricity usage within chemical industries. Industry > Chemicals > Other",
+            "sector_path": "Industry > Chemicals > Other",
+            "acts_on_labels": [
+              "coal usage within chemical industries",
+              "natural gas usage within chemical industries"
+            ],
+            "shifts_to_labels": [
+              "electricity usage within chemical industries"
+            ],
+            "score": 0.5421
+          },
+          {
+            "stable_id": "shift_to_electricity_in_glass_industries",
+            "short_label": "T-2A3-TE-3 - Shift to electricity in glass industries",
+            "description": "Shift to electricity in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within glass industries, oil usage within glass industries, natural gas usage within glass industries. to: electricity usage within glass industries. Industry > Minerals > Glass Production",
+            "sector_path": "Industry > Minerals > Glass Production",
+            "acts_on_labels": [
+              "coal usage within glass industries",
+              "oil usage within glass industries",
+              "natural gas usage within glass industries"
+            ],
+            "shifts_to_labels": ["electricity usage within glass industries"],
+            "score": 0.537
+          },
+          {
+            "stable_id": "shift_to_electricity_in_other_industries",
+            "short_label": "T-2D5-TE-3 - Shift to electricity in other industries",
+            "description": "Shift to electricity in other industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: industrial unregulated coal use, industrial unregulated oil use, industrial unregulated gas use. to: industrial unregulated electricity use. Industry > Other > Other",
+            "sector_path": "Industry > Other > Other",
+            "acts_on_labels": [
+              "industrial unregulated coal use",
+              "industrial unregulated oil use",
+              "industrial unregulated gas use"
+            ],
+            "shifts_to_labels": ["industrial unregulated electricity use"],
+            "score": 0.5368
+          },
+          {
+            "stable_id": "shift_to_electricity_in_iron_and_steel_industries",
+            "short_label": "T-2C1-TE-4 - Shift to electricity in iron and steel industries",
+            "description": "Shift to electricity in iron and steel industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within iron and steel industries, natural gas usage within iron and steel industries. to: electricity usage within iron and steel industries. Industry > Metals > Iron Steel",
+            "sector_path": "Industry > Metals > Iron Steel",
+            "acts_on_labels": [
+              "coal usage within iron and steel industries",
+              "natural gas usage within iron and steel industries"
+            ],
+            "shifts_to_labels": [
+              "electricity usage within iron and steel industries"
+            ],
+            "score": 0.5329
+          },
+          {
+            "stable_id": "shift_to_electrolysis_of_water_for_hydrogen_production",
+            "short_label": "T-5B4-TE-6 - Shift to electrolysis of water for hydrogen production",
+            "description": "Shift to electrolysis of water for hydrogen production. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: reforming of methane for hydrogen production, gasification of carbon for hydrogen production. to: electrolysis of water for hydrogen production. Energy > Energy Transformation > Hydrogen Refinement",
+            "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
+            "acts_on_labels": [
+              "reforming of methane for hydrogen production",
+              "gasification of carbon for hydrogen production"
+            ],
+            "shifts_to_labels": [
+              "electrolysis of water for hydrogen production"
+            ],
+            "score": 0.5236
+          },
+          {
+            "stable_id": "shift_to_electric_passenger_rail",
+            "short_label": "T-1A2-TE-2 - Shift to travel by electric rail",
+            "description": "Shift to travel by electric rail. Shift person kilometer from diesel passenger rail to electric passenger rail in person kilometer to fulfill the need of mobility. from: diesel passenger rail. to: electric rail. Transport > Mobility > Rail",
+            "sector_path": "Transport > Mobility > Rail",
+            "acts_on_labels": ["diesel passenger rail"],
+            "shifts_to_labels": ["electric rail"],
+            "score": 0.5149
+          },
+          {
+            "stable_id": "shift_to_electricity_in_lead_industries",
+            "short_label": "T-2C5-TE-3 - Shift to electricity in lead industries",
+            "description": "Shift to electricity in lead industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within lead industries, oil usage within lead industries, natural gas usage within lead industries. to: electricity usage within lead industries. Industry > Metals > Lead",
+            "sector_path": "Industry > Metals > Lead",
+            "acts_on_labels": [
+              "coal usage within lead industries",
+              "oil usage within lead industries",
+              "natural gas usage within lead industries"
+            ],
+            "shifts_to_labels": ["electricity usage within lead industries"],
+            "score": 0.5145
+          },
+          {
+            "stable_id": "shift_to_residential_electric_cooking_stoves",
+            "short_label": "T-4A2d-TE-2 - Shift to residential electric cooking stoves",
+            "description": "Shift to residential electric cooking stoves. Shift kWh from residential cooking gas stoves to residential electric cooking stoves in kWh to fullfill the need for cooking. from: residential gas cooking stoves. to: residential electric cooking stoves. Buildings > Residential > Other Energy Usage > Unregulated",
+            "sector_path": "Buildings > Residential > Other Energy Usage > Unregulated",
+            "acts_on_labels": ["residential gas cooking stoves"],
+            "shifts_to_labels": ["residential electric cooking stoves"],
+            "score": 0.5138
+          },
+          {
+            "stable_id": "shift_to_electricity_in_pulp_paper_and_print_industries",
+            "short_label": "T-2D1b-TE-3 - Shift to electricity in pulp, paper and print industries",
+            "description": "Shift to electricity in pulp, paper and print industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within pulp paper and print industries, oil usage within pulp paper and print industries, natural gas usage within pulp paper and print industries. to: electricity usage within pulp paper and print industries. Industry > Other > Manufacturing > Pulp Paper Print",
+            "sector_path": "Industry > Other > Manufacturing > Pulp Paper Print",
+            "acts_on_labels": [
+              "coal usage within pulp paper and print industries",
+              "oil usage within pulp paper and print industries",
+              "natural gas usage within pulp paper and print industries"
+            ],
+            "shifts_to_labels": [
+              "electricity usage within pulp paper and print industries"
+            ],
+            "score": 0.5136
+          },
+          {
+            "stable_id": "solar_rooftops",
+            "short_label": "T-5A1-TE-8 - Electricity from solar rooftops",
+            "description": "Electricity from solar rooftops. Alter the amount of electricity produced by solar rooftops. from: solar rooftops. Energy > Energy Supply > Electricity",
+            "sector_path": "Energy > Energy Supply > Electricity",
+            "acts_on_labels": ["solar rooftops"],
+            "shifts_to_labels": [],
+            "score": 0.4866
+          },
+          {
+            "stable_id": "improved_grid_electricity",
+            "short_label": "T-5A1-TE-3 - Improved Grid Electricity",
+            "description": "Improved Grid Electricity. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: grid current. to: grid future. Energy > Energy Supply > Electricity",
+            "sector_path": "Energy > Energy Supply > Electricity",
+            "acts_on_labels": ["grid current"],
+            "shifts_to_labels": ["grid future"],
+            "score": 0.4847
+          },
+          {
+            "stable_id": "wind_onshore",
+            "short_label": "T-5A1-TE-10 - Electricity from wind onshore",
+            "description": "Electricity from wind onshore. Alter the amount of electricity produced by wind onshore. from: wind onshore. Energy > Energy Supply > Electricity",
+            "sector_path": "Energy > Energy Supply > Electricity",
+            "acts_on_labels": ["wind onshore"],
+            "shifts_to_labels": [],
+            "score": 0.4835
+          },
+          {
+            "stable_id": "solar_parks",
+            "short_label": "T-5A1-TE-7 - Electricity from solar parks",
+            "description": "Electricity from solar parks. Alter the amount of electricity produced by solar parks. from: solar parks. Energy > Energy Supply > Electricity",
+            "sector_path": "Energy > Energy Supply > Electricity",
+            "acts_on_labels": ["solar parks"],
+            "shifts_to_labels": [],
+            "score": 0.4814
+          },
+          {
+            "stable_id": "wind_offshore",
+            "short_label": "T-5A1-TE-9 - Electricity from wind offshore",
+            "description": "Electricity from wind offshore. Alter the amount of electricity produced by wind offshore. from: wind offshore. Energy > Energy Supply > Electricity",
+            "sector_path": "Energy > Energy Supply > Electricity",
+            "acts_on_labels": ["wind offshore"],
+            "shifts_to_labels": [],
+            "score": 0.4759
+          },
+          {
+            "stable_id": "biofuel_fired_power_plants",
+            "short_label": "T-5A1-TE-11 - Electricity from biomass power plants",
+            "description": "Electricity from biomass power plants. Alter the amount of electricity produced by biofuel fired power plants. from: biofuel fired powerplants. Energy > Energy Supply > Electricity",
+            "sector_path": "Energy > Energy Supply > Electricity",
+            "acts_on_labels": ["biofuel fired powerplants"],
+            "shifts_to_labels": [],
+            "score": 0.4755
+          },
+          {
+            "stable_id": "coal_fired_power_plants",
+            "short_label": "T-5A1-TE-1 - Electricity from coal power plants",
+            "description": "Electricity from coal power plants. Alter the amount of electricity produced by coal fired power plants. from: coal fired power plants. Energy > Energy Supply > Electricity",
+            "sector_path": "Energy > Energy Supply > Electricity",
+            "acts_on_labels": ["coal fired power plants"],
+            "shifts_to_labels": [],
+            "score": 0.4738
+          },
+          {
+            "stable_id": "gas_fired_power_plants",
+            "short_label": "T-5A1-TE-2 - Electricity from gas power plants",
+            "description": "Electricity from gas power plants. Alter the amount of electricity produced by gas fired power plants. from: gas fired power plants. Energy > Energy Supply > Electricity",
+            "sector_path": "Energy > Energy Supply > Electricity",
+            "acts_on_labels": ["gas fired power plants"],
+            "shifts_to_labels": [],
+            "score": 0.4646
+          },
+          {
+            "stable_id": "oil_fired_power_plants",
+            "short_label": "T-5A1-TE-5 - Electricity from oil power plants",
+            "description": "Electricity from oil power plants. Alter the amount of electricity produced by oil fired power plants. from: oil fired power plants. Energy > Energy Supply > Electricity",
+            "sector_path": "Energy > Energy Supply > Electricity",
+            "acts_on_labels": ["oil fired power plants"],
+            "shifts_to_labels": [],
+            "score": 0.4608
+          },
+          {
+            "stable_id": "hydro_reservoir",
+            "short_label": "T-5A1-TE-6 - Electricity from hydro reservoir",
+            "description": "Electricity from hydro reservoir. Alter the amount of electricity produced by hydro reservoir. from: hydro reservoir. Energy > Energy Supply > Electricity",
+            "sector_path": "Energy > Energy Supply > Electricity",
+            "acts_on_labels": ["hydro reservoir"],
+            "shifts_to_labels": [],
+            "score": 0.4591
+          }
+        ]
+      }
+    ],
+    "intervention_who": "kommunkoncernen",
+    "intervention_when": "none",
+    "intervention_what": "procure renewable electricity",
+    "intervention_how": "none",
+    "intervention_score": 3,
+    "intervention_reasoning": "Who and what are present, but when and how are not specified.",
+    "intervention_type": "direct"
+  },
+  {
+    "measure_text": "131.Användningen av energi, mark, vatten och andra naturresurser ska ske på ett effektivt, resursbesparande och miljöanpassat sätt.",
+    "activity": "resource use",
+    "activity_shift_score": 2,
+    "activity_shifts": [
+      {
+        "activity": "using resources",
+        "shift_from": "none",
+        "shift_to": "using resources efficiently and sustainably",
+        "need": "resource management",
+        "type": "Resource Efficiency Shift",
+        "type_reasoning": "The measure suggests a shift towards more efficient and sustainable use of resources, which is a resource efficiency improvement.",
+        "score": 2,
+        "reasoning": "The shift is faintly implied, but neither shift_from nor shift_to is clearly identifiable.",
+        "transition_element_matches": [
+          {
+            "stable_id": "energy_efficient_other_agriculture_forestry_fishing_electric_appliances",
+            "short_label": "T-3C6-TE-1 - Energy efficient agriculture, forestry and fishing electrical appliances",
+            "description": "Energy efficient agriculture, forestry and fishing electrical appliances. Reduce the amount of energy required to operate agriculture, forestry and fishing electrical appliances. from: agriculture forestry fishing unregulated electricity use. Afolu > Aggregate Sources Other > Other",
+            "sector_path": "Afolu > Aggregate Sources Other > Other",
+            "acts_on_labels": [
+              "agriculture forestry fishing unregulated electricity use"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.3578,
+            "match_reasoning": "acts_on=yes, shifts_to=empty, confidence=mid",
+            "match_confidence": "mid"
+          },
+          {
+            "stable_id": "energy_efficient_other_institutional_electric_appliances",
+            "short_label": "T-4B2c-TE-3 - Energy efficient public electrical appliances",
+            "description": "Energy efficient public electrical appliances. Reduce the amount of energy required to operate institutional electrical appliances. from: institutional unregulated electricity use. Buildings > Non Residential > Other Energy Usage > Other",
+            "sector_path": "Buildings > Non Residential > Other Energy Usage > Other",
+            "acts_on_labels": ["institutional unregulated electricity use"],
+            "shifts_to_labels": [],
+            "score": 0.3356,
+            "match_reasoning": "acts_on=yes, shifts_to=empty, confidence=mid",
+            "match_confidence": "mid"
+          },
+          {
+            "stable_id": "efficient_use_of_mobile_machinery",
+            "short_label": "T-2D4-TE-3 - Efficient use of mobile machinery",
+            "description": "Efficient use of mobile machinery. Reduce the amount of energy required to operate diesel, petrol, biofuel,. from: mobile machinery biofuel, mobile machinery electricity, mobile machinery diesel, mobile machinery petrol, mobile machinery lpg, mobile machinery cng. Industry > Other > Mobile Machinery",
+            "sector_path": "Industry > Other > Mobile Machinery",
+            "acts_on_labels": [
+              "mobile machinery biofuel",
+              "mobile machinery electricity",
+              "mobile machinery diesel",
+              "mobile machinery petrol",
+              "mobile machinery lpg",
+              "mobile machinery cng"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.3264,
+            "match_reasoning": "acts_on=yes, shifts_to=empty, confidence=mid",
+            "match_confidence": "mid"
+          },
+          {
+            "stable_id": "energy_efficient_other_industrial_electric_appliances",
+            "short_label": "T-4B2c-TE-2 - Energy efficient industrial electrical appliances",
+            "description": "Energy efficient industrial electrical appliances. Reduce the amount of energy required to operate industrial electrical appliances. from: industrial unregulated electricity use. Buildings > Non Residential > Other Energy Usage > Other",
+            "sector_path": "Buildings > Non Residential > Other Energy Usage > Other",
+            "acts_on_labels": ["industrial unregulated electricity use"],
+            "shifts_to_labels": [],
+            "score": 0.3203,
+            "match_reasoning": "acts_on=yes, shifts_to=empty, confidence=mid",
+            "match_confidence": "mid"
+          }
+        ],
+        "transition_element_suggested_new": {
+          "short_label": "Efficient Resource Use",
+          "description": "Shift to efficient and sustainable use of energy, land, water, and other natural resources."
+        },
+        "transition_element_candidates": [
+          {
+            "stable_id": "shift_to_sustainable_healthy_diet",
+            "short_label": "T-3A1-TE-1 - Shift to Sustainable Healthy Diets",
+            "description": "Shift to Sustainable Healthy Diets. This Transition Element is the shift from animal based diets to plant based diets.. from: enteric fermentation cattle, enteric fermentation sheep, enteric fermentation swine, enteric fermentation other livestock. Afolu > Livestock > Enteric Fermentation",
+            "sector_path": "Afolu > Livestock > Enteric Fermentation",
+            "acts_on_labels": [
+              "enteric fermentation cattle",
+              "enteric fermentation sheep",
+              "enteric fermentation swine",
+              "enteric fermentation other livestock"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.4938
+          },
+          {
+            "stable_id": "increased_recycling",
+            "short_label": "T-6A1-TE-1 - Shift to recycling of solid waste",
+            "description": "Shift to recycling of solid waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to recycling of solid waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: recycling of solid waste. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc",
+              "incineration and open burning of waste",
+              "open burning of waste",
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "shifts_to_labels": ["recycling of solid waste"],
+            "score": 0.4488
+          },
+          {
+            "stable_id": "shift_to_biomass_energy_in_hydrogen_refinement",
+            "short_label": "T-5B4-TE-4 - Shift to biomass energy in hydrogen refinement",
+            "description": "Shift to biomass energy in hydrogen refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within hydrogen refinement. to: biomass usage within hydrogen refinement. Energy > Energy Transformation > Hydrogen Refinement",
+            "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
+            "acts_on_labels": ["coal usage within hydrogen refinement"],
+            "shifts_to_labels": ["biomass usage within hydrogen refinement"],
+            "score": 0.4388
+          },
+          {
+            "stable_id": "shift_to_biomass_energy_in_lead_industries",
+            "short_label": "T-2C5-TE-2 - Shift to biomass energy in lead industries",
+            "description": "Shift to biomass energy in lead industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within lead industries. to: biomass usage within lead industries. Industry > Metals > Lead",
+            "sector_path": "Industry > Metals > Lead",
+            "acts_on_labels": ["coal usage within lead industries"],
+            "shifts_to_labels": ["biomass usage within lead industries"],
+            "score": 0.433
+          },
+          {
+            "stable_id": "shift_to_biomass_energy_in_magnesium_industries",
+            "short_label": "T-2C4-TE-3 - Shift to biomass energy in magnesium industries",
+            "description": "Shift to biomass energy in magnesium industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within magnesium industries. to: biomass usage within magnesium industries. Industry > Metals > Magnesium",
+            "sector_path": "Industry > Metals > Magnesium",
+            "acts_on_labels": ["coal usage within magnesium industries"],
+            "shifts_to_labels": ["biomass usage within magnesium industries"],
+            "score": 0.4268
+          },
+          {
+            "stable_id": "shift_to_biomass_energy_in_petroleum_refinement",
+            "short_label": "T-5B1-TE-1 - Shift to biomass energy in petroleum refinement",
+            "description": "Shift to biomass energy in petroleum refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: crude oil usage within petroleum refinement. to: biomass usage within petroleum refinement. Energy > Energy Transformation > Petroleum Refinement",
+            "sector_path": "Energy > Energy Transformation > Petroleum Refinement",
+            "acts_on_labels": ["crude oil usage within petroleum refinement"],
+            "shifts_to_labels": ["biomass usage within petroleum refinement"],
+            "score": 0.4252
+          },
+          {
+            "stable_id": "shift_to_biomass_energy_in_glass_industries",
+            "short_label": "T-2A3-TE-2 - Shift to biomass energy in glass industries",
+            "description": "Shift to biomass energy in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within glass industries. to: biomass usage within glass industries. Industry > Minerals > Glass Production",
+            "sector_path": "Industry > Minerals > Glass Production",
+            "acts_on_labels": ["coal usage within glass industries"],
+            "shifts_to_labels": ["biomass usage within glass industries"],
+            "score": 0.4223
+          },
+          {
+            "stable_id": "shift_to_biomass_energy_in_chemical_industries",
+            "short_label": "T-2B9-TE-2 - Shift to biomass energy in chemical industries",
+            "description": "Shift to biomass energy in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within chemical industries. to: biomass usage within chemical industries. Industry > Chemicals > Other",
+            "sector_path": "Industry > Chemicals > Other",
+            "acts_on_labels": ["coal usage within chemical industries"],
+            "shifts_to_labels": ["biomass usage within chemical industries"],
+            "score": 0.4222
+          },
+          {
+            "stable_id": "biofuels_for_cement_and_mineral_industry",
+            "short_label": "T-2A1-TE-1 - Shift to use biofuel in cement and mineral industry",
+            "description": "Shift to use biofuel in cement and mineral industry. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: cement mineral industries coal usage. to: cement mineral industries biomass usage. Industry > Minerals > Cement",
+            "sector_path": "Industry > Minerals > Cement",
+            "acts_on_labels": ["cement mineral industries coal usage"],
+            "shifts_to_labels": ["cement mineral industries biomass usage"],
+            "score": 0.4215
+          },
+          {
+            "stable_id": "shift_to_biomass_energy_in_iron_and_steel_industries",
+            "short_label": "T-2C1-TE-2 - Shift to biomass energy in iron and steel industries",
+            "description": "Shift to biomass energy in iron and steel industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within iron and steel industries. to: biomass usage within iron and steel industries. Industry > Metals > Iron Steel",
+            "sector_path": "Industry > Metals > Iron Steel",
+            "acts_on_labels": ["coal usage within iron and steel industries"],
+            "shifts_to_labels": [
+              "biomass usage within iron and steel industries"
+            ],
+            "score": 0.4193
+          },
+          {
+            "stable_id": "energy_efficient_other_agriculture_forestry_fishing_electric_appliances",
+            "short_label": "T-3C6-TE-1 - Energy efficient agriculture, forestry and fishing electrical appliances",
+            "description": "Energy efficient agriculture, forestry and fishing electrical appliances. Reduce the amount of energy required to operate agriculture, forestry and fishing electrical appliances. from: agriculture forestry fishing unregulated electricity use. Afolu > Aggregate Sources Other > Other",
+            "sector_path": "Afolu > Aggregate Sources Other > Other",
+            "acts_on_labels": [
+              "agriculture forestry fishing unregulated electricity use"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.3578
+          },
+          {
+            "stable_id": "energy_efficient_other_institutional_electric_appliances",
+            "short_label": "T-4B2c-TE-3 - Energy efficient public electrical appliances",
+            "description": "Energy efficient public electrical appliances. Reduce the amount of energy required to operate institutional electrical appliances. from: institutional unregulated electricity use. Buildings > Non Residential > Other Energy Usage > Other",
+            "sector_path": "Buildings > Non Residential > Other Energy Usage > Other",
+            "acts_on_labels": ["institutional unregulated electricity use"],
+            "shifts_to_labels": [],
+            "score": 0.3356
+          },
+          {
+            "stable_id": "energy_efficient_new_housing",
+            "short_label": "T-4A1-TE-1 - Energy efficient new Housing",
+            "description": "Energy efficient new Housing. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: heating of new residential single family buildings, heating of new residential multi family buildings. Buildings > Residential > Hvac",
+            "sector_path": "Buildings > Residential > Hvac",
+            "acts_on_labels": [
+              "heating of new residential single family buildings",
+              "heating of new residential multi family buildings"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.3311
+          },
+          {
+            "stable_id": "efficient_use_of_mobile_machinery",
+            "short_label": "T-2D4-TE-3 - Efficient use of mobile machinery",
+            "description": "Efficient use of mobile machinery. Reduce the amount of energy required to operate diesel, petrol, biofuel,. from: mobile machinery biofuel, mobile machinery electricity, mobile machinery diesel, mobile machinery petrol, mobile machinery lpg, mobile machinery cng. Industry > Other > Mobile Machinery",
+            "sector_path": "Industry > Other > Mobile Machinery",
+            "acts_on_labels": [
+              "mobile machinery biofuel",
+              "mobile machinery electricity",
+              "mobile machinery diesel",
+              "mobile machinery petrol",
+              "mobile machinery lpg",
+              "mobile machinery cng"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.3264
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_hydrogen_refinement",
+            "short_label": "T-5B4-TE-3 - Shift to biogas energy in hydrogen refinement",
+            "description": "Shift to biogas energy in hydrogen refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within hydrogen refinement. to: biogas usage within hydrogen refinement. Energy > Energy Transformation > Hydrogen Refinement",
+            "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
+            "acts_on_labels": ["natural gas usage within hydrogen refinement"],
+            "shifts_to_labels": ["biogas usage within hydrogen refinement"],
+            "score": 0.3228
+          },
+          {
+            "stable_id": "increased_energy_recovery_from_waste",
+            "short_label": "T-5A3-TE-6 - Increased energy recovery from waste",
+            "description": "Increased energy recovery from waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to CHP waste incineration in tonne to fulfill the need of warm premisses. from: incineration and open burning of waste. to: chp waste incineration. Energy > Energy Supply > Combined Heat Power",
+            "sector_path": "Energy > Energy Supply > Combined Heat Power",
+            "acts_on_labels": ["incineration and open burning of waste"],
+            "shifts_to_labels": ["chp waste incineration"],
+            "score": 0.3216
+          },
+          {
+            "stable_id": "energy_efficient_other_industrial_electric_appliances",
+            "short_label": "T-4B2c-TE-2 - Energy efficient industrial electrical appliances",
+            "description": "Energy efficient industrial electrical appliances. Reduce the amount of energy required to operate industrial electrical appliances. from: industrial unregulated electricity use. Buildings > Non Residential > Other Energy Usage > Other",
+            "sector_path": "Buildings > Non Residential > Other Energy Usage > Other",
+            "acts_on_labels": ["industrial unregulated electricity use"],
+            "shifts_to_labels": [],
+            "score": 0.3203
+          },
+          {
+            "stable_id": "ecodriving_of_cars",
+            "short_label": "T-1A1a-TE-3 - Ecodriving of cars",
+            "description": "Ecodriving of cars. Reduce the amount of energy required to drive petrol, diesel, LPG and natural gas vehicles through ecodriving. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles, hydrogen vehicles. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": [
+              "petrol vehicles",
+              "diesel vehicles",
+              "lpg vehicles",
+              "gas vehicles",
+              "hydrogen vehicles"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.3194
+          }
+        ]
+      }
+    ],
+    "intervention_who": "none",
+    "intervention_when": "none",
+    "intervention_what": "use resources efficiently",
+    "intervention_how": "none",
+    "intervention_score": 1,
+    "intervention_reasoning": "No specific action, responsible actor, timeline, or mechanism is provided.",
+    "intervention_type": "none"
+  },
+  {
+    "measure_text": "132.Förvaltning av tätortsnära natur ska ske genom att värna kommunens ansvarsarter* och hotade arter genom ett nyskapande av deras behov av naturmiljöer vid varje större åtgärd på natur- och parkmark.",
+    "activity": "nature management",
+    "activity_shift_score": 2,
+    "activity_shifts": [
+      {
+        "activity": "managing nature",
+        "shift_from": "none",
+        "shift_to": "protecting species through habitat creation",
+        "need": "biodiversity conservation",
+        "type": "Type Shift",
+        "type_reasoning": "The measure implies a shift towards creating habitats for species, which is a change in the method of nature management.",
+        "score": 2,
+        "reasoning": "The shift is faintly implied, but neither shift_from nor shift_to is clearly identifiable.",
+        "transition_element_matches": [],
+        "transition_element_suggested_new": {
+          "short_label": "Habitat Creation for Biodiversity Conservation",
+          "description": "Managing urban nature by creating habitats to protect species and enhance biodiversity."
+        },
+        "transition_element_candidates": [
+          {
+            "stable_id": "shift_to_sustainable_healthy_diet",
+            "short_label": "T-3A1-TE-1 - Shift to Sustainable Healthy Diets",
+            "description": "Shift to Sustainable Healthy Diets. This Transition Element is the shift from animal based diets to plant based diets.. from: enteric fermentation cattle, enteric fermentation sheep, enteric fermentation swine, enteric fermentation other livestock. Afolu > Livestock > Enteric Fermentation",
+            "sector_path": "Afolu > Livestock > Enteric Fermentation",
+            "acts_on_labels": [
+              "enteric fermentation cattle",
+              "enteric fermentation sheep",
+              "enteric fermentation swine",
+              "enteric fermentation other livestock"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.3671
+          },
+          {
+            "stable_id": "shift_to_electric_bikes",
+            "short_label": "T-1A1a-TE-11 - Shift to electric bikes",
+            "description": "Shift to electric bikes. Shift vehicle kilometer from petrol,diesel and LPG vehicles to electric bike in vehicle kilometer to fulfill the need of mobility. from: petrol vehicles, diesel vehicles, lpg vehicles. to: electric bikes. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": [
+              "petrol vehicles",
+              "diesel vehicles",
+              "lpg vehicles"
+            ],
+            "shifts_to_labels": ["electric bikes"],
+            "score": 0.3448
+          },
+          {
+            "stable_id": "increased_proportion_of_walking_and_cycling",
+            "short_label": "T-1A1a-TE-10 - Shift to walking and cycling",
+            "description": "Shift to walking and cycling. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to walking cycling. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: walking cycling. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": [
+              "petrol vehicles",
+              "diesel vehicles",
+              "lpg vehicles",
+              "gas vehicles"
+            ],
+            "shifts_to_labels": ["walking cycling"],
+            "score": 0.3295
+          },
+          {
+            "stable_id": "increased_proportion_of_public_transport_by_petrol_bus",
+            "short_label": "T-1A1a-TE-16 - Shift to travel by petrol bus",
+            "description": "Shift to travel by petrol bus. Shift vehicle kilometer from petrol and diesel vehicles to petrol buses. from: petrol vehicles, diesel vehicles. to: petrol buses. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": ["petrol vehicles", "diesel vehicles"],
+            "shifts_to_labels": ["petrol buses"],
+            "score": 0.3197
+          },
+          {
+            "stable_id": "shift_to_biomass_energy_in_lead_industries",
+            "short_label": "T-2C5-TE-2 - Shift to biomass energy in lead industries",
+            "description": "Shift to biomass energy in lead industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within lead industries. to: biomass usage within lead industries. Industry > Metals > Lead",
+            "sector_path": "Industry > Metals > Lead",
+            "acts_on_labels": ["coal usage within lead industries"],
+            "shifts_to_labels": ["biomass usage within lead industries"],
+            "score": 0.3151
+          },
+          {
+            "stable_id": "shift_to_electric_vehicles",
+            "short_label": "T-1A1a-TE-1 - Shift to electric cars",
+            "description": "Shift to electric cars. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to battery electric vehicles in vehicle kilometer to fulfill the need of mobility. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: battery electric vehicles. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": [
+              "petrol vehicles",
+              "diesel vehicles",
+              "lpg vehicles",
+              "gas vehicles"
+            ],
+            "shifts_to_labels": ["battery electric vehicles"],
+            "score": 0.3085
+          },
+          {
+            "stable_id": "shift_to_hydrogen_vehicles",
+            "short_label": "T-1A1a-TE-2 - Shift to hydrogen cars",
+            "description": "Shift to hydrogen cars. Shift vehicle kilometer from petrol and diesel vehicles to hydrogen vehicles in vehicle kilometer to fulfill the need of mobility. from: petrol vehicles, diesel vehicles. to: hydrogen vehicles. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": ["petrol vehicles", "diesel vehicles"],
+            "shifts_to_labels": ["hydrogen vehicles"],
+            "score": 0.3079
+          },
+          {
+            "stable_id": "shift_to_biomass_energy_in_petroleum_refinement",
+            "short_label": "T-5B1-TE-1 - Shift to biomass energy in petroleum refinement",
+            "description": "Shift to biomass energy in petroleum refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: crude oil usage within petroleum refinement. to: biomass usage within petroleum refinement. Energy > Energy Transformation > Petroleum Refinement",
+            "sector_path": "Energy > Energy Transformation > Petroleum Refinement",
+            "acts_on_labels": ["crude oil usage within petroleum refinement"],
+            "shifts_to_labels": ["biomass usage within petroleum refinement"],
+            "score": 0.3078
+          },
+          {
+            "stable_id": "increased_proportion_of_commuting_by_electric_bus",
+            "short_label": "T-1A1a-TE-12 - Shift to travel by electric bus",
+            "description": "Shift to travel by electric bus. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to electric bus. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: electric bus. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": [
+              "petrol vehicles",
+              "diesel vehicles",
+              "lpg vehicles",
+              "gas vehicles"
+            ],
+            "shifts_to_labels": ["electric bus"],
+            "score": 0.307
+          },
+          {
+            "stable_id": "shift_to_biomass_energy_in_hydrogen_refinement",
+            "short_label": "T-5B4-TE-4 - Shift to biomass energy in hydrogen refinement",
+            "description": "Shift to biomass energy in hydrogen refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within hydrogen refinement. to: biomass usage within hydrogen refinement. Energy > Energy Transformation > Hydrogen Refinement",
+            "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
+            "acts_on_labels": ["coal usage within hydrogen refinement"],
+            "shifts_to_labels": ["biomass usage within hydrogen refinement"],
+            "score": 0.3064
+          },
+          {
+            "stable_id": "shift_to_composting_of_organic_waste",
+            "short_label": "T-6A1-TE-2 - Shift to composting of organic waste",
+            "description": "Shift to composting of organic waste. Shift tonne from solid waste disposal in landfills to composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: composting of organic waste. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc",
+              "incineration and open burning of waste",
+              "open burning of waste",
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "shifts_to_labels": ["composting of organic waste"],
+            "score": 0.2161
+          },
+          {
+            "stable_id": "energy_efficient_other_agriculture_forestry_fishing_electric_appliances",
+            "short_label": "T-3C6-TE-1 - Energy efficient agriculture, forestry and fishing electrical appliances",
+            "description": "Energy efficient agriculture, forestry and fishing electrical appliances. Reduce the amount of energy required to operate agriculture, forestry and fishing electrical appliances. from: agriculture forestry fishing unregulated electricity use. Afolu > Aggregate Sources Other > Other",
+            "sector_path": "Afolu > Aggregate Sources Other > Other",
+            "acts_on_labels": [
+              "agriculture forestry fishing unregulated electricity use"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.2147
+          },
+          {
+            "stable_id": "shift_to_biomass_energy_in_glass_industries",
+            "short_label": "T-2A3-TE-2 - Shift to biomass energy in glass industries",
+            "description": "Shift to biomass energy in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within glass industries. to: biomass usage within glass industries. Industry > Minerals > Glass Production",
+            "sector_path": "Industry > Minerals > Glass Production",
+            "acts_on_labels": ["coal usage within glass industries"],
+            "shifts_to_labels": ["biomass usage within glass industries"],
+            "score": 0.2136
+          },
+          {
+            "stable_id": "biogas_in_methane_reforming_for_hydrogen_production",
+            "short_label": "T-5B4-TE-1 - Biogas in methane reforming for hydrogen production",
+            "description": "Biogas in methane reforming for hydrogen production. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: reforming of methane for hydrogen production. Energy > Energy Transformation > Hydrogen Refinement",
+            "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
+            "acts_on_labels": ["reforming of methane for hydrogen production"],
+            "shifts_to_labels": [],
+            "score": 0.2135
+          },
+          {
+            "stable_id": "increased_recycling",
+            "short_label": "T-6A1-TE-1 - Shift to recycling of solid waste",
+            "description": "Shift to recycling of solid waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to recycling of solid waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: recycling of solid waste. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc",
+              "incineration and open burning of waste",
+              "open burning of waste",
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "shifts_to_labels": ["recycling of solid waste"],
+            "score": 0.2113
+          },
+          {
+            "stable_id": "low_carbon_construction_of_non_residential_commercial_buildings",
+            "short_label": "T-4C1-TE-3 - Low carbon construction of commercial buildings",
+            "description": "Low carbon construction of commercial buildings. Shift square meter from non residential commercial standard construction to non residential commercial low carbon construction in square meter to fulfill the need of housing. from: non residential commercial standard construction. to: non residential commercial low carbon construction. Buildings > Building Stocks > Construction",
+            "sector_path": "Buildings > Building Stocks > Construction",
+            "acts_on_labels": [
+              "non residential commercial standard construction"
+            ],
+            "shifts_to_labels": [
+              "non residential commercial low carbon construction"
+            ],
+            "score": 0.2113
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_hydrogen_refinement",
+            "short_label": "T-5B4-TE-3 - Shift to biogas energy in hydrogen refinement",
+            "description": "Shift to biogas energy in hydrogen refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within hydrogen refinement. to: biogas usage within hydrogen refinement. Energy > Energy Transformation > Hydrogen Refinement",
+            "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
+            "acts_on_labels": ["natural gas usage within hydrogen refinement"],
+            "shifts_to_labels": ["biogas usage within hydrogen refinement"],
+            "score": 0.2102
+          },
+          {
+            "stable_id": "biofuels_for_cement_and_mineral_industry",
+            "short_label": "T-2A1-TE-1 - Shift to use biofuel in cement and mineral industry",
+            "description": "Shift to use biofuel in cement and mineral industry. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: cement mineral industries coal usage. to: cement mineral industries biomass usage. Industry > Minerals > Cement",
+            "sector_path": "Industry > Minerals > Cement",
+            "acts_on_labels": ["cement mineral industries coal usage"],
+            "shifts_to_labels": ["cement mineral industries biomass usage"],
+            "score": 0.2097
+          },
+          {
+            "stable_id": "energy_efficient_new_housing",
+            "short_label": "T-4A1-TE-1 - Energy efficient new Housing",
+            "description": "Energy efficient new Housing. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: heating of new residential single family buildings, heating of new residential multi family buildings. Buildings > Residential > Hvac",
+            "sector_path": "Buildings > Residential > Hvac",
+            "acts_on_labels": [
+              "heating of new residential single family buildings",
+              "heating of new residential multi family buildings"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.2092
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_glass_industries",
+            "short_label": "T-2A3-TE-1 - Shift to biogas energy in glass industries",
+            "description": "Shift to biogas energy in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within glass industries. to: biogas usage within glass industries. Industry > Minerals > Glass Production",
+            "sector_path": "Industry > Minerals > Glass Production",
+            "acts_on_labels": ["natural gas usage within glass industries"],
+            "shifts_to_labels": ["biogas usage within glass industries"],
+            "score": 0.2054
+          },
+          {
+            "stable_id": "shift_to_biomass_energy_in_other_industries",
+            "short_label": "T-2D5-TE-1 - Shift to biomass energy in other industries",
+            "description": "Shift to biomass energy in other industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: industrial unregulated coal use. to: industrial unregulated biomass use. Industry > Other > Other",
+            "sector_path": "Industry > Other > Other",
+            "acts_on_labels": ["industrial unregulated coal use"],
+            "shifts_to_labels": ["industrial unregulated biomass use"],
+            "score": 0.2024
+          }
+        ]
+      }
+    ],
+    "intervention_who": "none",
+    "intervention_when": "none",
+    "intervention_what": "protect species through habitat creation",
+    "intervention_how": "none",
+    "intervention_score": 1,
+    "intervention_reasoning": "No specific action, responsible actor, timeline, or mechanism is provided.",
+    "intervention_type": "none"
+  },
+  {
+    "measure_text": "133.Vattenkvaliteten och den fysiska miljön i sjöar och vattendrag behöver förbättras. Det innebär att 85 procent av vattnen i kommunen som omfattas av vattenförvaltningens statusklassning (så kallade ytvattenförekomster*) ska uppnå miljökvalitetsnormerna god status både när det gäller ekologiska och kemiska värden. Vattenanvändningen ska effektiviseras och vattenförsörjningen ska vara klimatanpassad, säker och trygg.",
+    "activity": "water management",
+    "activity_shift_score": 3,
+    "activity_shifts": [
+      {
+        "activity": "managing water",
+        "shift_from": "none",
+        "shift_to": "improving water quality and efficiency",
+        "need": "water management",
+        "type": "Resource Efficiency Shift",
+        "type_reasoning": "The measure suggests improving water quality and efficiency, which is a resource efficiency improvement.",
+        "score": 3,
+        "reasoning": "Activity and shift_to are identifiable, but shift_from is not clearly specified.",
+        "transition_element_matches": [],
+        "transition_element_suggested_new": {
+          "short_label": "Water Quality and Efficiency Improvement",
+          "description": "Focus on improving water quality and efficiency in municipal water management systems."
+        },
+        "transition_element_candidates": [
+          {
+            "stable_id": "shift_to_electrolysis_of_water_for_hydrogen_production",
+            "short_label": "T-5B4-TE-6 - Shift to electrolysis of water for hydrogen production",
+            "description": "Shift to electrolysis of water for hydrogen production. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: reforming of methane for hydrogen production, gasification of carbon for hydrogen production. to: electrolysis of water for hydrogen production. Energy > Energy Transformation > Hydrogen Refinement",
+            "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
+            "acts_on_labels": [
+              "reforming of methane for hydrogen production",
+              "gasification of carbon for hydrogen production"
+            ],
+            "shifts_to_labels": [
+              "electrolysis of water for hydrogen production"
+            ],
+            "score": 0.4429
+          },
+          {
+            "stable_id": "shift_to_sustainable_healthy_diet",
+            "short_label": "T-3A1-TE-1 - Shift to Sustainable Healthy Diets",
+            "description": "Shift to Sustainable Healthy Diets. This Transition Element is the shift from animal based diets to plant based diets.. from: enteric fermentation cattle, enteric fermentation sheep, enteric fermentation swine, enteric fermentation other livestock. Afolu > Livestock > Enteric Fermentation",
+            "sector_path": "Afolu > Livestock > Enteric Fermentation",
+            "acts_on_labels": [
+              "enteric fermentation cattle",
+              "enteric fermentation sheep",
+              "enteric fermentation swine",
+              "enteric fermentation other livestock"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.4094
+          },
+          {
+            "stable_id": "increased_recycling",
+            "short_label": "T-6A1-TE-1 - Shift to recycling of solid waste",
+            "description": "Shift to recycling of solid waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to recycling of solid waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: recycling of solid waste. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc",
+              "incineration and open burning of waste",
+              "open burning of waste",
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "shifts_to_labels": ["recycling of solid waste"],
+            "score": 0.4035
+          },
+          {
+            "stable_id": "shift_to_hydrogen_energy_in_chemical_industries",
+            "short_label": "T-2B9-TE-4 - Shift to hydrogen energy in chemical industries",
+            "description": "Shift to hydrogen energy in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within chemical industries. to: hydrogen usage within chemical industries. Industry > Chemicals > Other",
+            "sector_path": "Industry > Chemicals > Other",
+            "acts_on_labels": ["natural gas usage within chemical industries"],
+            "shifts_to_labels": ["hydrogen usage within chemical industries"],
+            "score": 0.399
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_hydrogen_refinement",
+            "short_label": "T-5B4-TE-3 - Shift to biogas energy in hydrogen refinement",
+            "description": "Shift to biogas energy in hydrogen refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within hydrogen refinement. to: biogas usage within hydrogen refinement. Energy > Energy Transformation > Hydrogen Refinement",
+            "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
+            "acts_on_labels": ["natural gas usage within hydrogen refinement"],
+            "shifts_to_labels": ["biogas usage within hydrogen refinement"],
+            "score": 0.3964
+          },
+          {
+            "stable_id": "electrification_of_domestic_sea_passenger_transport",
+            "short_label": "T-1A4-TE-5 - Shift to electric marine passenger transportion",
+            "description": "Shift to electric marine passenger transportion. Shift person kilometer from ship passenger to electric shipping passenger in person kilometer to fulfill the need of mobility. from: ship passenger, gas oil shipping passenger. to: electric shipping passenger. Transport > Mobility > Waterborne",
+            "sector_path": "Transport > Mobility > Waterborne",
+            "acts_on_labels": ["ship passenger", "gas oil shipping passenger"],
+            "shifts_to_labels": ["electric shipping passenger"],
+            "score": 0.3949
+          },
+          {
+            "stable_id": "shift_to_electricity_in_hydrogen_refinement",
+            "short_label": "T-5B4-TE-5 - Shift to electricity in hydrogen refinement",
+            "description": "Shift to electricity in hydrogen refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within hydrogen refinement, natural gas usage within hydrogen refinement. to: electricity usage within hydrogen refinement. Energy > Energy Transformation > Hydrogen Refinement",
+            "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
+            "acts_on_labels": [
+              "coal usage within hydrogen refinement",
+              "natural gas usage within hydrogen refinement"
+            ],
+            "shifts_to_labels": [
+              "electricity usage within hydrogen refinement"
+            ],
+            "score": 0.3912
+          },
+          {
+            "stable_id": "shift_to_biomass_energy_in_hydrogen_refinement",
+            "short_label": "T-5B4-TE-4 - Shift to biomass energy in hydrogen refinement",
+            "description": "Shift to biomass energy in hydrogen refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within hydrogen refinement. to: biomass usage within hydrogen refinement. Energy > Energy Transformation > Hydrogen Refinement",
+            "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
+            "acts_on_labels": ["coal usage within hydrogen refinement"],
+            "shifts_to_labels": ["biomass usage within hydrogen refinement"],
+            "score": 0.3905
+          },
+          {
+            "stable_id": "shift_to_composting_of_organic_waste",
+            "short_label": "T-6A1-TE-2 - Shift to composting of organic waste",
+            "description": "Shift to composting of organic waste. Shift tonne from solid waste disposal in landfills to composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: composting of organic waste. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc",
+              "incineration and open burning of waste",
+              "open burning of waste",
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "shifts_to_labels": ["composting of organic waste"],
+            "score": 0.3832
+          },
+          {
+            "stable_id": "shift_to_hydrogen_vehicles",
+            "short_label": "T-1A1a-TE-2 - Shift to hydrogen cars",
+            "description": "Shift to hydrogen cars. Shift vehicle kilometer from petrol and diesel vehicles to hydrogen vehicles in vehicle kilometer to fulfill the need of mobility. from: petrol vehicles, diesel vehicles. to: hydrogen vehicles. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": ["petrol vehicles", "diesel vehicles"],
+            "shifts_to_labels": ["hydrogen vehicles"],
+            "score": 0.3807
+          },
+          {
+            "stable_id": "energy_efficient_other_agriculture_forestry_fishing_electric_appliances",
+            "short_label": "T-3C6-TE-1 - Energy efficient agriculture, forestry and fishing electrical appliances",
+            "description": "Energy efficient agriculture, forestry and fishing electrical appliances. Reduce the amount of energy required to operate agriculture, forestry and fishing electrical appliances. from: agriculture forestry fishing unregulated electricity use. Afolu > Aggregate Sources Other > Other",
+            "sector_path": "Afolu > Aggregate Sources Other > Other",
+            "acts_on_labels": [
+              "agriculture forestry fishing unregulated electricity use"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.3472
+          },
+          {
+            "stable_id": "energy_efficient_other_institutional_electric_appliances",
+            "short_label": "T-4B2c-TE-3 - Energy efficient public electrical appliances",
+            "description": "Energy efficient public electrical appliances. Reduce the amount of energy required to operate institutional electrical appliances. from: institutional unregulated electricity use. Buildings > Non Residential > Other Energy Usage > Other",
+            "sector_path": "Buildings > Non Residential > Other Energy Usage > Other",
+            "acts_on_labels": ["institutional unregulated electricity use"],
+            "shifts_to_labels": [],
+            "score": 0.3127
+          },
+          {
+            "stable_id": "energy_efficient_other_industrial_electric_appliances",
+            "short_label": "T-4B2c-TE-2 - Energy efficient industrial electrical appliances",
+            "description": "Energy efficient industrial electrical appliances. Reduce the amount of energy required to operate industrial electrical appliances. from: industrial unregulated electricity use. Buildings > Non Residential > Other Energy Usage > Other",
+            "sector_path": "Buildings > Non Residential > Other Energy Usage > Other",
+            "acts_on_labels": ["industrial unregulated electricity use"],
+            "shifts_to_labels": [],
+            "score": 0.3081
+          },
+          {
+            "stable_id": "energy_efficient_new_housing",
+            "short_label": "T-4A1-TE-1 - Energy efficient new Housing",
+            "description": "Energy efficient new Housing. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: heating of new residential single family buildings, heating of new residential multi family buildings. Buildings > Residential > Hvac",
+            "sector_path": "Buildings > Residential > Hvac",
+            "acts_on_labels": [
+              "heating of new residential single family buildings",
+              "heating of new residential multi family buildings"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.284
+          },
+          {
+            "stable_id": "energy_efficient_non_residential_public_buildings_retrofitting_cooling",
+            "short_label": "T-4B1b-TE-7 - Retrofitting public buildings for efficient cooling",
+            "description": "Retrofitting public buildings for efficient cooling. Reduce the amount of energy required to cool public building with AC and disitrct cooling through retrofitting. from: public building cooling with ac, public building cooling with district cooling. Buildings > Non Residential > Hvac > Institutional Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
+            "acts_on_labels": [
+              "public building cooling with ac",
+              "public building cooling with district cooling"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.2834
+          },
+          {
+            "stable_id": "efficient_use_multi_family_residential_buildings_cooling",
+            "short_label": "T-4A1a-TE-7 - Energy efficient use of ACs in multi-family buildings",
+            "description": "Energy efficient use of ACs in multi-family buildings. Reduce the amount of energy required to cool multi family buildings with AC through efficient use of AC units. from: multi family building cooling with ac. Buildings > Residential > Hvac > Multi Family Hvac",
+            "sector_path": "Buildings > Residential > Hvac > Multi Family Hvac",
+            "acts_on_labels": ["multi family building cooling with ac"],
+            "shifts_to_labels": [],
+            "score": 0.2834
+          },
+          {
+            "stable_id": "energy_efficient_street_lighting",
+            "short_label": "T-4B2a-TE-1 - Energy efficient street lighting",
+            "description": "Energy efficient street lighting. Reduce the amount of energy required to operate street lighting. from: institutional electric street lighting. Buildings > Non Residential > Other Energy Usage > Lighting",
+            "sector_path": "Buildings > Non Residential > Other Energy Usage > Lighting",
+            "acts_on_labels": ["institutional electric street lighting"],
+            "shifts_to_labels": [],
+            "score": 0.2828
+          },
+          {
+            "stable_id": "energy_efficient_multi_family_residential_buildings_cooling",
+            "short_label": "T-4A1a-TE-8 - Energy efficient AC in multi-family buildings",
+            "description": "Energy efficient AC in multi-family buildings. Reduce the amount of energy required to cool multi family buildings with AC through more efficient AC units. from: multi family building cooling with ac. Buildings > Residential > Hvac > Multi Family Hvac",
+            "sector_path": "Buildings > Residential > Hvac > Multi Family Hvac",
+            "acts_on_labels": ["multi family building cooling with ac"],
+            "shifts_to_labels": [],
+            "score": 0.2783
+          },
+          {
+            "stable_id": "energy_efficient_other_commercial_electric_appliances",
+            "short_label": "T-4B2c-TE-1 - Energy efficient commercial electrical appliances",
+            "description": "Energy efficient commercial electrical appliances. Reduce the amount of energy required to operate commercial electrical appliances. from: commercial unregulated electricity use. Buildings > Non Residential > Other Energy Usage > Other",
+            "sector_path": "Buildings > Non Residential > Other Energy Usage > Other",
+            "acts_on_labels": ["commercial unregulated electricity use"],
+            "shifts_to_labels": [],
+            "score": 0.2759
+          },
+          {
+            "stable_id": "hydro_reservoir",
+            "short_label": "T-5A1-TE-6 - Electricity from hydro reservoir",
+            "description": "Electricity from hydro reservoir. Alter the amount of electricity produced by hydro reservoir. from: hydro reservoir. Energy > Energy Supply > Electricity",
+            "sector_path": "Energy > Energy Supply > Electricity",
+            "acts_on_labels": ["hydro reservoir"],
+            "shifts_to_labels": [],
+            "score": 0.2747
+          },
+          {
+            "stable_id": "more_efficient_sea_passenger_transportation",
+            "short_label": "T-1A4-TE-2 - More efficient marine passenger transport",
+            "description": "More efficient marine passenger transport. Reduce the amount of energy required to operate diesel, LNG passenger shipping through more more efficient sea passenger transportation. from: ship passenger, gas oil shipping passenger, electric shipping passenger, lng shipping passenger. Transport > Mobility > Waterborne",
+            "sector_path": "Transport > Mobility > Waterborne",
+            "acts_on_labels": [
+              "ship passenger",
+              "gas oil shipping passenger",
+              "electric shipping passenger",
+              "lng shipping passenger"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.2739
+          },
+          {
+            "stable_id": "biogas_in_methane_reforming_for_hydrogen_production",
+            "short_label": "T-5B4-TE-1 - Biogas in methane reforming for hydrogen production",
+            "description": "Biogas in methane reforming for hydrogen production. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: reforming of methane for hydrogen production. Energy > Energy Transformation > Hydrogen Refinement",
+            "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
+            "acts_on_labels": ["reforming of methane for hydrogen production"],
+            "shifts_to_labels": [],
+            "score": 0.2717
+          },
+          {
+            "stable_id": "energy_efficient_multi_family_residential_buildings_retrofitting_cooling",
+            "short_label": "T-4A1a-TE-9 - Retrofitting multi-family buildings for efficient cooling",
+            "description": "Retrofitting multi-family buildings for efficient cooling. Reduce the amount of energy required to cool multi family building with AC and disitrct cooling through retrofitting. from: multi family building cooling with ac, multi family building cooling with district cooling. Buildings > Residential > Hvac > Multi Family Hvac",
+            "sector_path": "Buildings > Residential > Hvac > Multi Family Hvac",
+            "acts_on_labels": [
+              "multi family building cooling with ac",
+              "multi family building cooling with district cooling"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.2703
+          }
+        ]
+      }
+    ],
+    "intervention_who": "none",
+    "intervention_when": "none",
+    "intervention_what": "improve water quality and efficiency",
+    "intervention_how": "none",
+    "intervention_score": 2,
+    "intervention_reasoning": "What is weakly present, but no specific actor, timeline, or mechanism is provided.",
+    "intervention_type": "indirect"
+  },
+  {
+    "measure_text": "134.Grundvattenförekomster, både befintliga och de som är utpekade som intressanta för framtiden, ska uppnå en god kemisk och kvalitativ status. Det innebär att vattnet ska ha god kvalitet och vattenmängden ska vara stabil.",
+    "activity": "groundwater management",
+    "activity_shift_score": 3,
+    "activity_shifts": [
+      {
+        "activity": "managing groundwater",
+        "shift_from": "none",
+        "shift_to": "achieving good chemical and qualitative status",
+        "need": "water management",
+        "type": "Resource Efficiency Shift",
+        "type_reasoning": "The measure suggests achieving good status for groundwater, which is a resource efficiency improvement.",
+        "score": 3,
+        "reasoning": "Activity and shift_to are identifiable, but shift_from is not clearly specified.",
+        "transition_element_matches": [],
+        "transition_element_suggested_new": {
+          "short_label": "Shift to sustainable groundwater management",
+          "description": "Implement measures to ensure groundwater achieves good chemical and qualitative status, focusing on water quality and stable water quantity."
+        },
+        "transition_element_candidates": [
+          {
+            "stable_id": "shift_to_hydrogen_energy_in_chemical_industries",
+            "short_label": "T-2B9-TE-4 - Shift to hydrogen energy in chemical industries",
+            "description": "Shift to hydrogen energy in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within chemical industries. to: hydrogen usage within chemical industries. Industry > Chemicals > Other",
+            "sector_path": "Industry > Chemicals > Other",
+            "acts_on_labels": ["natural gas usage within chemical industries"],
+            "shifts_to_labels": ["hydrogen usage within chemical industries"],
+            "score": 0.396
+          },
+          {
+            "stable_id": "shift_to_sustainable_healthy_diet",
+            "short_label": "T-3A1-TE-1 - Shift to Sustainable Healthy Diets",
+            "description": "Shift to Sustainable Healthy Diets. This Transition Element is the shift from animal based diets to plant based diets.. from: enteric fermentation cattle, enteric fermentation sheep, enteric fermentation swine, enteric fermentation other livestock. Afolu > Livestock > Enteric Fermentation",
+            "sector_path": "Afolu > Livestock > Enteric Fermentation",
+            "acts_on_labels": [
+              "enteric fermentation cattle",
+              "enteric fermentation sheep",
+              "enteric fermentation swine",
+              "enteric fermentation other livestock"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.3918
+          },
+          {
+            "stable_id": "shift_to_electricity_in_chemical_industries",
+            "short_label": "T-2B9-TE-3 - Shift to electricity in chemical industries",
+            "description": "Shift to electricity in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within chemical industries, natural gas usage within chemical industries. to: electricity usage within chemical industries. Industry > Chemicals > Other",
+            "sector_path": "Industry > Chemicals > Other",
+            "acts_on_labels": [
+              "coal usage within chemical industries",
+              "natural gas usage within chemical industries"
+            ],
+            "shifts_to_labels": [
+              "electricity usage within chemical industries"
+            ],
+            "score": 0.3859
+          },
+          {
+            "stable_id": "shift_to_biomass_energy_in_chemical_industries",
+            "short_label": "T-2B9-TE-2 - Shift to biomass energy in chemical industries",
+            "description": "Shift to biomass energy in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within chemical industries. to: biomass usage within chemical industries. Industry > Chemicals > Other",
+            "sector_path": "Industry > Chemicals > Other",
+            "acts_on_labels": ["coal usage within chemical industries"],
+            "shifts_to_labels": ["biomass usage within chemical industries"],
+            "score": 0.3828
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_chemical_industries",
+            "short_label": "T-2B9-TE-1 - Shift to biogas energy in chemical industries",
+            "description": "Shift to biogas energy in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within chemical industries. to: biogas usage within chemical industries. Industry > Chemicals > Other",
+            "sector_path": "Industry > Chemicals > Other",
+            "acts_on_labels": ["natural gas usage within chemical industries"],
+            "shifts_to_labels": ["biogas usage within chemical industries"],
+            "score": 0.3813
+          },
+          {
+            "stable_id": "shift_to_electrolysis_of_water_for_hydrogen_production",
+            "short_label": "T-5B4-TE-6 - Shift to electrolysis of water for hydrogen production",
+            "description": "Shift to electrolysis of water for hydrogen production. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: reforming of methane for hydrogen production, gasification of carbon for hydrogen production. to: electrolysis of water for hydrogen production. Energy > Energy Transformation > Hydrogen Refinement",
+            "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
+            "acts_on_labels": [
+              "reforming of methane for hydrogen production",
+              "gasification of carbon for hydrogen production"
+            ],
+            "shifts_to_labels": [
+              "electrolysis of water for hydrogen production"
+            ],
+            "score": 0.3788
+          },
+          {
+            "stable_id": "electrification_of_domestic_sea_passenger_transport",
+            "short_label": "T-1A4-TE-5 - Shift to electric marine passenger transportion",
+            "description": "Shift to electric marine passenger transportion. Shift person kilometer from ship passenger to electric shipping passenger in person kilometer to fulfill the need of mobility. from: ship passenger, gas oil shipping passenger. to: electric shipping passenger. Transport > Mobility > Waterborne",
+            "sector_path": "Transport > Mobility > Waterborne",
+            "acts_on_labels": ["ship passenger", "gas oil shipping passenger"],
+            "shifts_to_labels": ["electric shipping passenger"],
+            "score": 0.3757
+          },
+          {
+            "stable_id": "shift_to_hydrogen_vehicles",
+            "short_label": "T-1A1a-TE-2 - Shift to hydrogen cars",
+            "description": "Shift to hydrogen cars. Shift vehicle kilometer from petrol and diesel vehicles to hydrogen vehicles in vehicle kilometer to fulfill the need of mobility. from: petrol vehicles, diesel vehicles. to: hydrogen vehicles. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": ["petrol vehicles", "diesel vehicles"],
+            "shifts_to_labels": ["hydrogen vehicles"],
+            "score": 0.3669
+          },
+          {
+            "stable_id": "increased_proportion_of_walking_and_cycling",
+            "short_label": "T-1A1a-TE-10 - Shift to walking and cycling",
+            "description": "Shift to walking and cycling. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to walking cycling. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: walking cycling. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": [
+              "petrol vehicles",
+              "diesel vehicles",
+              "lpg vehicles",
+              "gas vehicles"
+            ],
+            "shifts_to_labels": ["walking cycling"],
+            "score": 0.3644
+          },
+          {
+            "stable_id": "increased_recycling",
+            "short_label": "T-6A1-TE-1 - Shift to recycling of solid waste",
+            "description": "Shift to recycling of solid waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to recycling of solid waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: recycling of solid waste. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc",
+              "incineration and open burning of waste",
+              "open burning of waste",
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "shifts_to_labels": ["recycling of solid waste"],
+            "score": 0.3621
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_hydrogen_refinement",
+            "short_label": "T-5B4-TE-3 - Shift to biogas energy in hydrogen refinement",
+            "description": "Shift to biogas energy in hydrogen refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within hydrogen refinement. to: biogas usage within hydrogen refinement. Energy > Energy Transformation > Hydrogen Refinement",
+            "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
+            "acts_on_labels": ["natural gas usage within hydrogen refinement"],
+            "shifts_to_labels": ["biogas usage within hydrogen refinement"],
+            "score": 0.272
+          },
+          {
+            "stable_id": "shift_to_landfill_gas_recovery",
+            "short_label": "T-6A1-TE-4 - Shift to landfill gas recovery",
+            "description": "Shift to landfill gas recovery. Shift tonne from solid waste disposal in landfills without gas recovery to solid waste disposal in landfills with landfill gas recovery in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc. to: solid waste disposal landfill with gas recovery. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc"
+            ],
+            "shifts_to_labels": [
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "score": 0.2673
+          },
+          {
+            "stable_id": "biogas_in_methane_reforming_for_hydrogen_production",
+            "short_label": "T-5B4-TE-1 - Biogas in methane reforming for hydrogen production",
+            "description": "Biogas in methane reforming for hydrogen production. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: reforming of methane for hydrogen production. Energy > Energy Transformation > Hydrogen Refinement",
+            "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
+            "acts_on_labels": ["reforming of methane for hydrogen production"],
+            "shifts_to_labels": [],
+            "score": 0.2624
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_magnesium_industries",
+            "short_label": "T-2C4-TE-2 - Shift to biogas energy in magnesium industries",
+            "description": "Shift to biogas energy in magnesium industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within magnesium industries. to: biogas usage within magnesium industries. Industry > Metals > Magnesium",
+            "sector_path": "Industry > Metals > Magnesium",
+            "acts_on_labels": ["natural gas usage within magnesium industries"],
+            "shifts_to_labels": ["biogas usage within magnesium industries"],
+            "score": 0.2581
+          },
+          {
+            "stable_id": "shift_to_hydrogen_energy_in_glass_industries",
+            "short_label": "T-2A3-TE-4 - Shift to hydrogen energy in glass industries",
+            "description": "Shift to hydrogen energy in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within glass industries. to: hydrogen usage within glass industries. Industry > Minerals > Glass Production",
+            "sector_path": "Industry > Minerals > Glass Production",
+            "acts_on_labels": ["natural gas usage within glass industries"],
+            "shifts_to_labels": ["hydrogen usage within glass industries"],
+            "score": 0.254
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_glass_industries",
+            "short_label": "T-2A3-TE-1 - Shift to biogas energy in glass industries",
+            "description": "Shift to biogas energy in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within glass industries. to: biogas usage within glass industries. Industry > Minerals > Glass Production",
+            "sector_path": "Industry > Minerals > Glass Production",
+            "acts_on_labels": ["natural gas usage within glass industries"],
+            "shifts_to_labels": ["biogas usage within glass industries"],
+            "score": 0.2524
+          },
+          {
+            "stable_id": "shift_to_composting_of_organic_waste",
+            "short_label": "T-6A1-TE-2 - Shift to composting of organic waste",
+            "description": "Shift to composting of organic waste. Shift tonne from solid waste disposal in landfills to composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: composting of organic waste. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc",
+              "incineration and open burning of waste",
+              "open burning of waste",
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "shifts_to_labels": ["composting of organic waste"],
+            "score": 0.2503
+          },
+          {
+            "stable_id": "biogas_in_methane_reforming_for_ammonia_production",
+            "short_label": "T-2B1-TE-1 - Biogas in methane reforming for ammonia production",
+            "description": "Biogas in methane reforming for ammonia production. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: reforming of methane for ammonia production. Industry > Chemicals > Ammonia Production",
+            "sector_path": "Industry > Chemicals > Ammonia Production",
+            "acts_on_labels": ["reforming of methane for ammonia production"],
+            "shifts_to_labels": [],
+            "score": 0.2487
+          },
+          {
+            "stable_id": "shift_to_biomass_energy_in_hydrogen_refinement",
+            "short_label": "T-5B4-TE-4 - Shift to biomass energy in hydrogen refinement",
+            "description": "Shift to biomass energy in hydrogen refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within hydrogen refinement. to: biomass usage within hydrogen refinement. Energy > Energy Transformation > Hydrogen Refinement",
+            "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
+            "acts_on_labels": ["coal usage within hydrogen refinement"],
+            "shifts_to_labels": ["biomass usage within hydrogen refinement"],
+            "score": 0.2454
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_lead_industries",
+            "short_label": "T-2C5-TE-1 - Shift to biogas energy in lead industries",
+            "description": "Shift to biogas energy in lead industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within lead industries. to: biogas usage within lead industries. Industry > Metals > Lead",
+            "sector_path": "Industry > Metals > Lead",
+            "acts_on_labels": ["natural gas usage within lead industries"],
+            "shifts_to_labels": ["biogas usage within lead industries"],
+            "score": 0.2429
+          }
+        ]
+      }
+    ],
+    "intervention_who": "none",
+    "intervention_when": "none",
+    "intervention_what": "achieve good groundwater status",
+    "intervention_how": "none",
+    "intervention_score": 2,
+    "intervention_reasoning": "What is weakly present, but no specific actor, timeline, or mechanism is provided.",
+    "intervention_type": "indirect"
+  },
+  {
+    "measure_text": "135.Kommunen ska arbeta för att minska utsläpp av kemikalier (bland annat mikroplaster, svårbrytbara kemiska föreningar och läkemedelsrester) för att värna vattnet.",
+    "activity": "chemical emissions management",
+    "activity_shift_score": 3,
+    "activity_shifts": [
+      {
+        "activity": "managing chemical emissions",
+        "shift_from": "none",
+        "shift_to": "reducing chemical emissions",
+        "need": "water protection",
+        "type": "Type Shift",
+        "type_reasoning": "The measure implies a shift towards reducing chemical emissions, which is a change in the method of managing chemical emissions.",
+        "score": 3,
+        "reasoning": "Activity and shift_to are identifiable, but shift_from is not clearly specified.",
+        "transition_element_matches": [],
+        "transition_element_suggested_new": {
+          "short_label": "Reduce Chemical Emissions",
+          "description": "Focus on reducing emissions of microplastics, persistent chemical compounds, and pharmaceutical residues to protect water resources."
+        },
+        "transition_element_candidates": [
+          {
+            "stable_id": "shift_to_hydrogen_energy_in_chemical_industries",
+            "short_label": "T-2B9-TE-4 - Shift to hydrogen energy in chemical industries",
+            "description": "Shift to hydrogen energy in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within chemical industries. to: hydrogen usage within chemical industries. Industry > Chemicals > Other",
+            "sector_path": "Industry > Chemicals > Other",
+            "acts_on_labels": ["natural gas usage within chemical industries"],
+            "shifts_to_labels": ["hydrogen usage within chemical industries"],
+            "score": 0.5344
+          },
+          {
+            "stable_id": "shift_to_electricity_in_chemical_industries",
+            "short_label": "T-2B9-TE-3 - Shift to electricity in chemical industries",
+            "description": "Shift to electricity in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within chemical industries, natural gas usage within chemical industries. to: electricity usage within chemical industries. Industry > Chemicals > Other",
+            "sector_path": "Industry > Chemicals > Other",
+            "acts_on_labels": [
+              "coal usage within chemical industries",
+              "natural gas usage within chemical industries"
+            ],
+            "shifts_to_labels": [
+              "electricity usage within chemical industries"
+            ],
+            "score": 0.5312
+          },
+          {
+            "stable_id": "shift_to_biomass_energy_in_chemical_industries",
+            "short_label": "T-2B9-TE-2 - Shift to biomass energy in chemical industries",
+            "description": "Shift to biomass energy in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within chemical industries. to: biomass usage within chemical industries. Industry > Chemicals > Other",
+            "sector_path": "Industry > Chemicals > Other",
+            "acts_on_labels": ["coal usage within chemical industries"],
+            "shifts_to_labels": ["biomass usage within chemical industries"],
+            "score": 0.5074
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_chemical_industries",
+            "short_label": "T-2B9-TE-1 - Shift to biogas energy in chemical industries",
+            "description": "Shift to biogas energy in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within chemical industries. to: biogas usage within chemical industries. Industry > Chemicals > Other",
+            "sector_path": "Industry > Chemicals > Other",
+            "acts_on_labels": ["natural gas usage within chemical industries"],
+            "shifts_to_labels": ["biogas usage within chemical industries"],
+            "score": 0.5003
+          },
+          {
+            "stable_id": "shift_to_electrolysis_of_water_for_hydrogen_production",
+            "short_label": "T-5B4-TE-6 - Shift to electrolysis of water for hydrogen production",
+            "description": "Shift to electrolysis of water for hydrogen production. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: reforming of methane for hydrogen production, gasification of carbon for hydrogen production. to: electrolysis of water for hydrogen production. Energy > Energy Transformation > Hydrogen Refinement",
+            "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
+            "acts_on_labels": [
+              "reforming of methane for hydrogen production",
+              "gasification of carbon for hydrogen production"
+            ],
+            "shifts_to_labels": [
+              "electrolysis of water for hydrogen production"
+            ],
+            "score": 0.4825
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_lead_industries",
+            "short_label": "T-2C5-TE-1 - Shift to biogas energy in lead industries",
+            "description": "Shift to biogas energy in lead industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within lead industries. to: biogas usage within lead industries. Industry > Metals > Lead",
+            "sector_path": "Industry > Metals > Lead",
+            "acts_on_labels": ["natural gas usage within lead industries"],
+            "shifts_to_labels": ["biogas usage within lead industries"],
+            "score": 0.4539
+          },
+          {
+            "stable_id": "shift_to_hydrogen_energy_in_glass_industries",
+            "short_label": "T-2A3-TE-4 - Shift to hydrogen energy in glass industries",
+            "description": "Shift to hydrogen energy in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within glass industries. to: hydrogen usage within glass industries. Industry > Minerals > Glass Production",
+            "sector_path": "Industry > Minerals > Glass Production",
+            "acts_on_labels": ["natural gas usage within glass industries"],
+            "shifts_to_labels": ["hydrogen usage within glass industries"],
+            "score": 0.4461
+          },
+          {
+            "stable_id": "shift_to_sustainable_healthy_diet",
+            "short_label": "T-3A1-TE-1 - Shift to Sustainable Healthy Diets",
+            "description": "Shift to Sustainable Healthy Diets. This Transition Element is the shift from animal based diets to plant based diets.. from: enteric fermentation cattle, enteric fermentation sheep, enteric fermentation swine, enteric fermentation other livestock. Afolu > Livestock > Enteric Fermentation",
+            "sector_path": "Afolu > Livestock > Enteric Fermentation",
+            "acts_on_labels": [
+              "enteric fermentation cattle",
+              "enteric fermentation sheep",
+              "enteric fermentation swine",
+              "enteric fermentation other livestock"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.4427
+          },
+          {
+            "stable_id": "shift_to_hydrogen_energy_in_pulp_paper_and_print_industries",
+            "short_label": "T-2D1b-TE-4 - Shift to hydrogen energy in pulp, paper and print industries",
+            "description": "Shift to hydrogen energy in pulp, paper and print industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within pulp paper and print industries. to: hydrogen usage within pulp paper and print industries. Industry > Other > Manufacturing > Pulp Paper Print",
+            "sector_path": "Industry > Other > Manufacturing > Pulp Paper Print",
+            "acts_on_labels": [
+              "natural gas usage within pulp paper and print industries"
+            ],
+            "shifts_to_labels": [
+              "hydrogen usage within pulp paper and print industries"
+            ],
+            "score": 0.4409
+          },
+          {
+            "stable_id": "shift_to_electricity_in_lead_industries",
+            "short_label": "T-2C5-TE-3 - Shift to electricity in lead industries",
+            "description": "Shift to electricity in lead industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within lead industries, oil usage within lead industries, natural gas usage within lead industries. to: electricity usage within lead industries. Industry > Metals > Lead",
+            "sector_path": "Industry > Metals > Lead",
+            "acts_on_labels": [
+              "coal usage within lead industries",
+              "oil usage within lead industries",
+              "natural gas usage within lead industries"
+            ],
+            "shifts_to_labels": ["electricity usage within lead industries"],
+            "score": 0.4384
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_glass_industries",
+            "short_label": "T-2A3-TE-1 - Shift to biogas energy in glass industries",
+            "description": "Shift to biogas energy in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within glass industries. to: biogas usage within glass industries. Industry > Minerals > Glass Production",
+            "sector_path": "Industry > Minerals > Glass Production",
+            "acts_on_labels": ["natural gas usage within glass industries"],
+            "shifts_to_labels": ["biogas usage within glass industries"],
+            "score": 0.3346
+          },
+          {
+            "stable_id": "biogas_in_methane_reforming_for_ammonia_production",
+            "short_label": "T-2B1-TE-1 - Biogas in methane reforming for ammonia production",
+            "description": "Biogas in methane reforming for ammonia production. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: reforming of methane for ammonia production. Industry > Chemicals > Ammonia Production",
+            "sector_path": "Industry > Chemicals > Ammonia Production",
+            "acts_on_labels": ["reforming of methane for ammonia production"],
+            "shifts_to_labels": [],
+            "score": 0.332
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_pulp_paper_and_print_industries",
+            "short_label": "T-2D1b-TE-1 - Shift to biogas energy in pulp, paper and print industries",
+            "description": "Shift to biogas energy in pulp, paper and print industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within pulp paper and print industries. to: biogas usage within pulp paper and print industries. Industry > Other > Manufacturing > Pulp Paper Print",
+            "sector_path": "Industry > Other > Manufacturing > Pulp Paper Print",
+            "acts_on_labels": [
+              "natural gas usage within pulp paper and print industries"
+            ],
+            "shifts_to_labels": [
+              "biogas usage within pulp paper and print industries"
+            ],
+            "score": 0.3312
+          },
+          {
+            "stable_id": "shift_to_electricity_in_pulp_paper_and_print_industries",
+            "short_label": "T-2D1b-TE-3 - Shift to electricity in pulp, paper and print industries",
+            "description": "Shift to electricity in pulp, paper and print industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within pulp paper and print industries, oil usage within pulp paper and print industries, natural gas usage within pulp paper and print industries. to: electricity usage within pulp paper and print industries. Industry > Other > Manufacturing > Pulp Paper Print",
+            "sector_path": "Industry > Other > Manufacturing > Pulp Paper Print",
+            "acts_on_labels": [
+              "coal usage within pulp paper and print industries",
+              "oil usage within pulp paper and print industries",
+              "natural gas usage within pulp paper and print industries"
+            ],
+            "shifts_to_labels": [
+              "electricity usage within pulp paper and print industries"
+            ],
+            "score": 0.3289
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_magnesium_industries",
+            "short_label": "T-2C4-TE-2 - Shift to biogas energy in magnesium industries",
+            "description": "Shift to biogas energy in magnesium industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within magnesium industries. to: biogas usage within magnesium industries. Industry > Metals > Magnesium",
+            "sector_path": "Industry > Metals > Magnesium",
+            "acts_on_labels": ["natural gas usage within magnesium industries"],
+            "shifts_to_labels": ["biogas usage within magnesium industries"],
+            "score": 0.3282
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_hydrogen_refinement",
+            "short_label": "T-5B4-TE-3 - Shift to biogas energy in hydrogen refinement",
+            "description": "Shift to biogas energy in hydrogen refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within hydrogen refinement. to: biogas usage within hydrogen refinement. Energy > Energy Transformation > Hydrogen Refinement",
+            "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
+            "acts_on_labels": ["natural gas usage within hydrogen refinement"],
+            "shifts_to_labels": ["biogas usage within hydrogen refinement"],
+            "score": 0.3255
+          }
+        ]
+      }
+    ],
+    "intervention_who": "kommunen",
+    "intervention_when": "none",
+    "intervention_what": "reduce chemical emissions",
+    "intervention_how": "none",
+    "intervention_score": 3,
+    "intervention_reasoning": "Who and what are present, but when and how are not specified.",
+    "intervention_type": "indirect"
+  },
+  {
+    "measure_text": "136.Förorenade områden är åtgärdade i sådan omfattning att det inte utgör något hot mot människors hälsa eller miljö. De mest förorenade områdena utifrån utförd GIS-analys ska undersökas.",
+    "activity": "none",
+    "activity_shift_score": 1,
+    "activity_shifts": [],
+    "intervention_who": "none",
+    "intervention_when": "none",
+    "intervention_what": "undersöka de mest förorenade områdena",
+    "intervention_how": "none",
+    "intervention_score": 2,
+    "intervention_reasoning": "The measure specifies a 'what' (undersöka de mest förorenade områdena) but lacks a 'who', 'when', and 'how'.",
+    "intervention_type": "none"
+  },
+  {
+    "measure_text": "137.Naturen i Jönköpings kommun behöver bevaras och utvecklas. Det innebär att inga av de områden i kommunens naturvårdsprogram som är mest värdefulla (klass 1 eller 2) eller värdefulla miljöer för rödlistade arter, ska exploateras.",
+    "activity": "none",
+    "activity_shift_score": 1,
+    "activity_shifts": [],
+    "intervention_who": "none",
+    "intervention_when": "none",
+    "intervention_what": "förhindra exploatering av värdefulla områden",
+    "intervention_how": "none",
+    "intervention_score": 2,
+    "intervention_reasoning": "The measure specifies a 'what' (förhindra exploatering av värdefulla områden) but lacks a 'who', 'when', and 'how'.",
+    "intervention_type": "none"
+  },
+  {
+    "measure_text": "138.Rutiner för att arbeta med ekosystemtjänstanalys, kompensation av ekosystemtjänster och gröna stråk i detaljplanearbetet ska finnas och följas.",
+    "activity": "none",
+    "activity_shift_score": 1,
+    "activity_shifts": [],
+    "intervention_who": "none",
+    "intervention_when": "none",
+    "intervention_what": "implementera rutiner för ekosystemtjänstanalys och kompensation",
+    "intervention_how": "none",
+    "intervention_score": 2,
+    "intervention_reasoning": "The measure specifies a 'what' (implementera rutiner för ekosystemtjänstanalys och kompensation) but lacks a 'who', 'when', and 'how'.",
+    "intervention_type": "none"
+  },
+  {
+    "measure_text": "139.Skyddet av värdefull natur behöver stärkas för att långsiktigt säkra naturvärdena. Minst nio naturreservat, biotopskydd eller naturvårdsavtal ska inrättas, varav fem i sjöar eller vattendrag.",
+    "activity": "none",
+    "activity_shift_score": 1,
+    "activity_shifts": [],
+    "intervention_who": "none",
+    "intervention_when": "none",
+    "intervention_what": "inrätta naturreservat, biotopskydd eller naturvårdsavtal",
+    "intervention_how": "none",
+    "intervention_score": 2,
+    "intervention_reasoning": "The measure specifies a 'what' (inrätta naturreservat, biotopskydd eller naturvårdsavtal) but lacks a 'who', 'when', and 'how'.",
+    "intervention_type": "none"
+  },
+  {
+    "measure_text": "140.Kommunens värdefulla våtmarker (de som når upp till klassen mycket höga naturvärden eller klassen höga naturvärden i den nationella våtmarksinventeringen) ska vara restaurerade, både avseende vattenförhållanden och biologisk mångfald.",
+    "activity": "none",
+    "activity_shift_score": 1,
+    "activity_shifts": [],
+    "intervention_who": "none",
+    "intervention_when": "none",
+    "intervention_what": "restaurera värdefulla våtmarker",
+    "intervention_how": "none",
+    "intervention_score": 2,
+    "intervention_reasoning": "The measure specifies a 'what' (restaurera värdefulla våtmarker) but lacks a 'who', 'when', and 'how'.",
+    "intervention_type": "none"
+  },
+  {
+    "measure_text": "141.Alla kommunägda skogar och annan kommunägd naturmark ska fortsatt skötas med naturvårdsinriktad skötsel.",
+    "activity": "none",
+    "activity_shift_score": 1,
+    "activity_shifts": [],
+    "intervention_who": "none",
+    "intervention_when": "none",
+    "intervention_what": "sköta kommunägda skogar med naturvårdsinriktad skötsel",
+    "intervention_how": "none",
+    "intervention_score": 2,
+    "intervention_reasoning": "The measure specifies a 'what' (sköta kommunägda skogar med naturvårdsinriktad skötsel) but lacks a 'who', 'when', and 'how'.",
+    "intervention_type": "none"
+  },
+  {
+    "measure_text": "142.Bäckar och övriga vatten med höga naturvärden ska restaureras i tillräcklig omfattning för att långsiktigt bevara och utveckla de biologiska värdena.",
+    "activity": "none",
+    "activity_shift_score": 1,
+    "activity_shifts": [],
+    "intervention_who": "none",
+    "intervention_when": "none",
+    "intervention_what": "restaurera bäckar och vatten med höga naturvärden",
+    "intervention_how": "none",
+    "intervention_score": 2,
+    "intervention_reasoning": "The measure specifies a 'what' (restaurera bäckar och vatten med höga naturvärden) but lacks a 'who', 'when', and 'how'.",
+    "intervention_type": "none"
+  },
+  {
+    "measure_text": "143.Vägpassager över vattendrag i det kommunala vägnätet ska inte vara ett vandringshinder för vattenlevande arter eller försvåra en säker passage för utter.",
+    "activity": "none",
+    "activity_shift_score": 1,
+    "activity_shifts": [],
+    "intervention_who": "none",
+    "intervention_when": "none",
+    "intervention_what": "säkerställa att vägpassager inte är vandringshinder",
+    "intervention_how": "none",
+    "intervention_score": 2,
+    "intervention_reasoning": "The measure specifies a 'what' (säkerställa att vägpassager inte är vandringshinder) but lacks a 'who', 'when', and 'how'.",
+    "intervention_type": "none"
+  },
+  {
+    "measure_text": "144.Utgångspunkten är att exploatering av brukningsvärd jordbruksmark inte får ske för att klara framtida livsmedelsförsörjning.",
+    "activity": "none",
+    "activity_shift_score": 1,
+    "activity_shifts": [],
+    "intervention_who": "none",
+    "intervention_when": "none",
+    "intervention_what": "förhindra exploatering av jordbruksmark",
+    "intervention_how": "none",
+    "intervention_score": 2,
+    "intervention_reasoning": "The measure specifies a 'what' (förhindra exploatering av jordbruksmark) but lacks a 'who', 'when', and 'how'.",
+    "intervention_type": "none"
+  },
+  {
+    "measure_text": "145.Hanterings- eller åtgärdsplan för samtliga i kommunen förekommande invasiva arter finns och ett aktivt åtgärdsarbete ska bedrivas på kommunägd mark.",
+    "activity": "none",
+    "activity_shift_score": 1,
+    "activity_shifts": [],
+    "intervention_who": "none",
+    "intervention_when": "none",
+    "intervention_what": "bedriva åtgärdsarbete mot invasiva arter",
+    "intervention_how": "none",
+    "intervention_score": 2,
+    "intervention_reasoning": "The measure specifies a 'what' (bedriva åtgärdsarbete mot invasiva arter) but lacks a 'who', 'when', and 'how'.",
+    "intervention_type": "none"
+  },
+  {
+    "measure_text": "146.Kommunen ska arbeta med att informera privata fastighetsägare och privatpersoner om invasiva arter. Entreprenörer ska informeras så att invasiva arter inte sprids vidare.",
+    "activity": "none",
+    "activity_shift_score": 1,
+    "activity_shifts": [],
+    "intervention_who": "Kommunen",
+    "intervention_when": "none",
+    "intervention_what": "informera om invasiva arter",
+    "intervention_how": "none",
+    "intervention_score": 3,
+    "intervention_reasoning": "The measure specifies a 'who' (Kommunen) and a 'what' (informera om invasiva arter) but lacks a 'when' and 'how'.",
+    "intervention_type": "none"
+  },
+  {
+    "measure_text": "149.Kommunen ska arbeta för ett ökat internt delade av resurser, med en fungerande organisation för lager, logistik och beställning av återbrukade produkter.",
+    "activity": "resource sharing",
+    "activity_shift_score": 3,
+    "activity_shifts": [
+      {
+        "activity": "resource sharing",
+        "shift_from": "none",
+        "shift_to": "ökat internt delade av resurser",
+        "need": "none",
+        "type": "Utilisation Shift",
+        "type_reasoning": "The measure implies a shift towards increased sharing of resources within the municipality.",
+        "score": 3,
+        "reasoning": "The activity (resource sharing) and shift_to (ökat internt delade av resurser) are identifiable, but shift_from and need are not clearly defined.",
+        "transition_element_matches": [],
+        "transition_element_suggested_new": {
+          "short_label": "Increased Internal Resource Sharing",
+          "description": "Promote and implement systems for increased sharing and reuse of resources within municipal operations, including logistics and inventory management for reused products."
+        },
+        "transition_element_candidates": [
+          {
+            "stable_id": "increased_proportion_of_non_travel_meetings_and_services",
+            "short_label": "T-1A1a-TE-7 - Shift to online meetings and services",
+            "description": "Shift to online meetings and services. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to e-meetings in hours to fulfill the need of business trips. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: e meetings. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": [
+              "petrol vehicles",
+              "diesel vehicles",
+              "lpg vehicles",
+              "gas vehicles"
+            ],
+            "shifts_to_labels": ["e meetings"],
+            "score": 0.3074
+          },
+          {
+            "stable_id": "shift_to_electric_passenger_rail",
+            "short_label": "T-1A2-TE-2 - Shift to travel by electric rail",
+            "description": "Shift to travel by electric rail. Shift person kilometer from diesel passenger rail to electric passenger rail in person kilometer to fulfill the need of mobility. from: diesel passenger rail. to: electric rail. Transport > Mobility > Rail",
+            "sector_path": "Transport > Mobility > Rail",
+            "acts_on_labels": ["diesel passenger rail"],
+            "shifts_to_labels": ["electric rail"],
+            "score": 0.2968
+          },
+          {
+            "stable_id": "shift_to_residual_heat_in_district_heating",
+            "short_label": "T-5A2-TE-6 - Shift to Residual Heat in district heating",
+            "description": "Shift to Residual Heat in district heating. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: chp coal, chp natural gas, chp oil. to: district heating residual heat. Energy > Energy Supply > Heat",
+            "sector_path": "Energy > Energy Supply > Heat",
+            "acts_on_labels": ["chp coal", "chp natural gas", "chp oil"],
+            "shifts_to_labels": ["district heating residual heat"],
+            "score": 0.2914
+          },
+          {
+            "stable_id": "shift_from_passenger_air_transport_to_railway",
+            "short_label": "T-1A3-TE-4 - Shift from air travel to railway",
+            "description": "Shift from air travel to railway. Shift person kilometer from passenger transportation by air to electric rail in person kilometer to fulfill the need of mobility. from: passenger transportation by air. to: electric rail. Transport > Mobility > Aviation",
+            "sector_path": "Transport > Mobility > Aviation",
+            "acts_on_labels": ["passenger transportation by air"],
+            "shifts_to_labels": ["electric rail"],
+            "score": 0.2889
+          },
+          {
+            "stable_id": "transfer_from_car_to_remote_working",
+            "short_label": "T-1A1a-TE-8 - Shift from car to remote working",
+            "description": "Shift from car to remote working. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to remote working. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: remote working. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": [
+              "petrol vehicles",
+              "diesel vehicles",
+              "lpg vehicles",
+              "gas vehicles"
+            ],
+            "shifts_to_labels": ["remote working"],
+            "score": 0.2839
+          },
+          {
+            "stable_id": "electrification_of_domestic_sea_passenger_transport",
+            "short_label": "T-1A4-TE-5 - Shift to electric marine passenger transportion",
+            "description": "Shift to electric marine passenger transportion. Shift person kilometer from ship passenger to electric shipping passenger in person kilometer to fulfill the need of mobility. from: ship passenger, gas oil shipping passenger. to: electric shipping passenger. Transport > Mobility > Waterborne",
+            "sector_path": "Transport > Mobility > Waterborne",
+            "acts_on_labels": ["ship passenger", "gas oil shipping passenger"],
+            "shifts_to_labels": ["electric shipping passenger"],
+            "score": 0.28
+          },
+          {
+            "stable_id": "shift_to_heat_pumps_in_district_heating",
+            "short_label": "T-5A2-TE-5 - Shift to heat pumps in district heating",
+            "description": "Shift to heat pumps in district heating. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: chp coal, chp natural gas, chp oil. to: district heating heat pumps. Energy > Energy Supply > Heat",
+            "sector_path": "Energy > Energy Supply > Heat",
+            "acts_on_labels": ["chp coal", "chp natural gas", "chp oil"],
+            "shifts_to_labels": ["district heating heat pumps"],
+            "score": 0.2798
+          },
+          {
+            "stable_id": "shift_to_biofuel_in_district_heating",
+            "short_label": "T-5A3-TE-7 - Shift to biofuel in district heating",
+            "description": "Shift to biofuel in district heating. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: chp coal, chp natural gas, chp oil. to: chp biofuels. Energy > Energy Supply > Combined Heat Power",
+            "sector_path": "Energy > Energy Supply > Combined Heat Power",
+            "acts_on_labels": ["chp coal", "chp natural gas", "chp oil"],
+            "shifts_to_labels": ["chp biofuels"],
+            "score": 0.2767
+          },
+          {
+            "stable_id": "increased_energy_recovery_from_waste",
+            "short_label": "T-5A3-TE-6 - Increased energy recovery from waste",
+            "description": "Increased energy recovery from waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to CHP waste incineration in tonne to fulfill the need of warm premisses. from: incineration and open burning of waste. to: chp waste incineration. Energy > Energy Supply > Combined Heat Power",
+            "sector_path": "Energy > Energy Supply > Combined Heat Power",
+            "acts_on_labels": ["incineration and open burning of waste"],
+            "shifts_to_labels": ["chp waste incineration"],
+            "score": 0.2731
+          },
+          {
+            "stable_id": "increased_proportion_of_public_transport_by_diesel_bus",
+            "short_label": "T-1A1a-TE-17 - Shift to travel by diesel bus",
+            "description": "Shift to travel by diesel bus. Shift vehicle kilometer from petrol and diesel vehicles to diesel buses. from: petrol vehicles, diesel vehicles. to: diesel buses. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": ["petrol vehicles", "diesel vehicles"],
+            "shifts_to_labels": ["diesel buses"],
+            "score": 0.2676
+          },
+          {
+            "stable_id": "district_heating_residual_heat",
+            "short_label": "T-5A2-TE-3 - District heating by residual heat",
+            "description": "District heating by residual heat. Alter the amount of district heat produced by residual heat. from: district heating residual heat. Energy > Energy Supply > Heat",
+            "sector_path": "Energy > Energy Supply > Heat",
+            "acts_on_labels": ["district heating residual heat"],
+            "shifts_to_labels": [],
+            "score": 0.2645
+          },
+          {
+            "stable_id": "more_efficient_commuting_by_car",
+            "short_label": "T-1A1a-TE-5 - Increase journey sharing",
+            "description": "Increase journey sharing. Reduce the number of vehicle kilometers from petrol, diesel, lpg and natural gas vehicles to fulfill the need of commuting through more efficient commuting by car. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles, battery electric vehicles, hydrogen vehicles. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": [
+              "petrol vehicles",
+              "diesel vehicles",
+              "lpg vehicles",
+              "gas vehicles",
+              "battery electric vehicles",
+              "hydrogen vehicles"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.2532
+          },
+          {
+            "stable_id": "district_heating_heat_pumps",
+            "short_label": "T-5A2-TE-4 - District heating by heat pump",
+            "description": "District heating by heat pump. Alter the amount of district heat produced by heat pumps. from: district heating heat pumps. Energy > Energy Supply > Heat",
+            "sector_path": "Energy > Energy Supply > Heat",
+            "acts_on_labels": ["district heating heat pumps"],
+            "shifts_to_labels": [],
+            "score": 0.2501
+          },
+          {
+            "stable_id": "biofuel_for_diesel_rail_passenger",
+            "short_label": "T-1A2-TE-1 - Biofuel for rail passenger transport",
+            "description": "Biofuel for rail passenger transport. Increase the proportion of HVO biodiesel in diesel. from: diesel passenger rail. Transport > Mobility > Rail",
+            "sector_path": "Transport > Mobility > Rail",
+            "acts_on_labels": ["diesel passenger rail"],
+            "shifts_to_labels": [],
+            "score": 0.236
+          },
+          {
+            "stable_id": "biofuel_for_gas_buses",
+            "short_label": "T-1A1c-TE-2 - Biofuel for gas buses",
+            "description": "Biofuel for gas buses. Increase the proportion of biogas in gas mix. from: gas buses. Transport > Mobility > Road > Buses",
+            "sector_path": "Transport > Mobility > Road > Buses",
+            "acts_on_labels": ["gas buses"],
+            "shifts_to_labels": [],
+            "score": 0.2268
+          },
+          {
+            "stable_id": "shift_to_district_cooling_in_public_buildings",
+            "short_label": "T-4B1b-TE-2 - Shift to district cooling in public buildings",
+            "description": "Shift to district cooling in public buildings. Shift square meter from industrial building cooling with AC to industrial building cooling with district cooling in square meter to fulfill the need of comfortable premises. from: public building cooling with ac. to: public building cooling with district cooling. Buildings > Non Residential > Hvac > Institutional Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
+            "acts_on_labels": ["public building cooling with ac"],
+            "shifts_to_labels": [
+              "public building cooling with district cooling"
+            ],
+            "score": 0.2219
+          },
+          {
+            "stable_id": "energy_efficient_other_institutional_electric_appliances",
+            "short_label": "T-4B2c-TE-3 - Energy efficient public electrical appliances",
+            "description": "Energy efficient public electrical appliances. Reduce the amount of energy required to operate institutional electrical appliances. from: institutional unregulated electricity use. Buildings > Non Residential > Other Energy Usage > Other",
+            "sector_path": "Buildings > Non Residential > Other Energy Usage > Other",
+            "acts_on_labels": ["institutional unregulated electricity use"],
+            "shifts_to_labels": [],
+            "score": 0.2214
+          },
+          {
+            "stable_id": "improved_urban_planning",
+            "short_label": "T-1A1a-TE-22 - Improved urban planning",
+            "description": "Improved urban planning. Reduce the amount of vehicle kilometer from cars to fulfill the need of mobility through improved urban planning. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles, lng vehicles, hydrogen vehicles, battery electric vehicles. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": [
+              "petrol vehicles",
+              "diesel vehicles",
+              "lpg vehicles",
+              "gas vehicles",
+              "lng vehicles",
+              "hydrogen vehicles",
+              "battery electric vehicles"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.2095
+          },
+          {
+            "stable_id": "biofuels_for_sea_passenger_transport",
+            "short_label": "T-1A4-TE-4 - Biofuel for marine passenger transport",
+            "description": "Biofuel for marine passenger transport. Increase the proportion of marine biodiesel in marine diesel. from: ship passenger. Transport > Mobility > Waterborne",
+            "sector_path": "Transport > Mobility > Waterborne",
+            "acts_on_labels": ["ship passenger"],
+            "shifts_to_labels": [],
+            "score": 0.2088
+          }
+        ]
+      }
+    ],
+    "intervention_who": "Kommunen",
+    "intervention_when": "none",
+    "intervention_what": "arbeta för ökat delade av resurser",
+    "intervention_how": "none",
+    "intervention_score": 3,
+    "intervention_reasoning": "The measure specifies a 'who' (Kommunen) and a 'what' (arbeta för ökat delade av resurser) but lacks a 'when' and 'how'.",
+    "intervention_type": "none"
+  },
+  {
+    "measure_text": "150.Verka för fler cirkulära initiativ inom kommunen mot invånarna.",
+    "activity": "none",
+    "activity_shift_score": 1,
+    "activity_shifts": [],
+    "intervention_who": "none",
+    "intervention_when": "none",
+    "intervention_what": "verka för fler cirkulära initiativ",
+    "intervention_how": "none",
+    "intervention_score": 2,
+    "intervention_reasoning": "The measure specifies a 'what' (verka för fler cirkulära initiativ) but lacks a 'who', 'when', and 'how'.",
+    "intervention_type": "none"
+  },
+  {
+    "measure_text": "151.Kommunen ska arbeta för att öka medvetenheten om en hållbar livsstil hos flickor och pojkar och kvinnor och män som lever i eller besöker vår kommun.",
+    "activity": "none",
+    "activity_shift_score": 1,
+    "activity_shifts": [],
+    "intervention_who": "Kommunen",
+    "intervention_when": "none",
+    "intervention_what": "öka medvetenheten om en hållbar livsstil",
+    "intervention_how": "none",
+    "intervention_score": 3,
+    "intervention_reasoning": "The measure specifies a 'who' (Kommunen) and a 'what' (öka medvetenheten om en hållbar livsstil) but lacks a 'when' and 'how'.",
+    "intervention_type": "none"
+  },
+  {
+    "measure_text": "152.Minst 70 procent av maten som köps in till kommunens verksamheter ska ha råvaruland Sverige.",
+    "activity": "food procurement",
+    "activity_shift_score": 3,
+    "activity_shifts": [
+      {
+        "activity": "food procurement",
+        "shift_from": "none",
+        "shift_to": "köpa in mat med råvaruland Sverige",
+        "need": "food provision",
+        "type": "Resource Shift",
+        "type_reasoning": "The measure implies a shift in the source of food resources, focusing on procuring food from Sweden.",
+        "score": 3,
+        "reasoning": "The activity (food procurement) and shift_to (köpa in mat med råvaruland Sverige) are identifiable, but shift_from is not clearly defined, and the need is inferable as food provision.",
+        "transition_element_matches": [],
+        "transition_element_suggested_new": {
+          "short_label": "Shift to Local Food Procurement",
+          "description": "Increase the procurement of food with ingredients sourced from Sweden to at least 70% in municipal operations."
+        },
+        "transition_element_candidates": [
+          {
+            "stable_id": "shift_to_sustainable_healthy_diet",
+            "short_label": "T-3A1-TE-1 - Shift to Sustainable Healthy Diets",
+            "description": "Shift to Sustainable Healthy Diets. This Transition Element is the shift from animal based diets to plant based diets.. from: enteric fermentation cattle, enteric fermentation sheep, enteric fermentation swine, enteric fermentation other livestock. Afolu > Livestock > Enteric Fermentation",
+            "sector_path": "Afolu > Livestock > Enteric Fermentation",
+            "acts_on_labels": [
+              "enteric fermentation cattle",
+              "enteric fermentation sheep",
+              "enteric fermentation swine",
+              "enteric fermentation other livestock"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.4118
+          },
+          {
+            "stable_id": "shift_to_electric_cargo_bikes",
+            "short_label": "T-1B1a-TE-10 - Shift to electric cargo bikes",
+            "description": "Shift to electric cargo bikes. Shift vehicle kilometer from diesel and petrol light truck to electric carg bikes in vehicle kilometer to fulfill the need of logistics. from: diesel light trucks, petrol light trucks. to: electric cargo bikes. Transport > Freight > Road > Light Duty Trucks",
+            "sector_path": "Transport > Freight > Road > Light Duty Trucks",
+            "acts_on_labels": ["diesel light trucks", "petrol light trucks"],
+            "shifts_to_labels": ["electric cargo bikes"],
+            "score": 0.3506
+          },
+          {
+            "stable_id": "shift_to_biofuel_in_district_heating",
+            "short_label": "T-5A3-TE-7 - Shift to biofuel in district heating",
+            "description": "Shift to biofuel in district heating. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: chp coal, chp natural gas, chp oil. to: chp biofuels. Energy > Energy Supply > Combined Heat Power",
+            "sector_path": "Energy > Energy Supply > Combined Heat Power",
+            "acts_on_labels": ["chp coal", "chp natural gas", "chp oil"],
+            "shifts_to_labels": ["chp biofuels"],
+            "score": 0.3433
+          },
+          {
+            "stable_id": "shift_to_gas_vehicles",
+            "short_label": "T-1A1a-TE-19 - Shift to gas cars",
+            "description": "Shift to gas cars. Shift vehicle kilometer from petrol and diesel vehicles to gas vehicles in vehicle kilometer to fulfill the need of mobility. from: petrol vehicles, diesel vehicles. to: gas vehicles. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": ["petrol vehicles", "diesel vehicles"],
+            "shifts_to_labels": ["gas vehicles"],
+            "score": 0.3231
+          },
+          {
+            "stable_id": "increased_proportion_of_public_transport_by_diesel_bus",
+            "short_label": "T-1A1a-TE-17 - Shift to travel by diesel bus",
+            "description": "Shift to travel by diesel bus. Shift vehicle kilometer from petrol and diesel vehicles to diesel buses. from: petrol vehicles, diesel vehicles. to: diesel buses. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": ["petrol vehicles", "diesel vehicles"],
+            "shifts_to_labels": ["diesel buses"],
+            "score": 0.3163
+          },
+          {
+            "stable_id": "increased_proportion_of_walking_and_cycling",
+            "short_label": "T-1A1a-TE-10 - Shift to walking and cycling",
+            "description": "Shift to walking and cycling. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to walking cycling. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: walking cycling. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": [
+              "petrol vehicles",
+              "diesel vehicles",
+              "lpg vehicles",
+              "gas vehicles"
+            ],
+            "shifts_to_labels": ["walking cycling"],
+            "score": 0.3162
+          },
+          {
+            "stable_id": "increased_proportion_of_public_transport_by_petrol_bus",
+            "short_label": "T-1A1a-TE-16 - Shift to travel by petrol bus",
+            "description": "Shift to travel by petrol bus. Shift vehicle kilometer from petrol and diesel vehicles to petrol buses. from: petrol vehicles, diesel vehicles. to: petrol buses. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": ["petrol vehicles", "diesel vehicles"],
+            "shifts_to_labels": ["petrol buses"],
+            "score": 0.3148
+          },
+          {
+            "stable_id": "shift_to_electric_bikes",
+            "short_label": "T-1A1a-TE-11 - Shift to electric bikes",
+            "description": "Shift to electric bikes. Shift vehicle kilometer from petrol,diesel and LPG vehicles to electric bike in vehicle kilometer to fulfill the need of mobility. from: petrol vehicles, diesel vehicles, lpg vehicles. to: electric bikes. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": [
+              "petrol vehicles",
+              "diesel vehicles",
+              "lpg vehicles"
+            ],
+            "shifts_to_labels": ["electric bikes"],
+            "score": 0.3142
+          },
+          {
+            "stable_id": "mobile_machinery_using_biofuels",
+            "short_label": "T-2D4-TE-1 - Shift to biofuel for mobile machinery",
+            "description": "Shift to biofuel for mobile machinery. Shift kilowatt-hours from mobile machinery diesel to mobile machinery biofuel in kilowatt-hour to fulfill the need of productivity. from: mobile machinery diesel, mobile machinery petrol. to: mobile machinery biofuel. Industry > Other > Mobile Machinery",
+            "sector_path": "Industry > Other > Mobile Machinery",
+            "acts_on_labels": [
+              "mobile machinery diesel",
+              "mobile machinery petrol"
+            ],
+            "shifts_to_labels": ["mobile machinery biofuel"],
+            "score": 0.3134
+          },
+          {
+            "stable_id": "gas_light_trucks",
+            "short_label": "T-1B1a-TE-1 - Shift to gas light trucks",
+            "description": "Shift to gas light trucks. Shift vehicle kilometer from diesel light trucks to gas light trucks  in vehicle kilometer to fulfill the need of logistics. from: diesel light trucks, petrol light trucks. to: gas light trucks. Transport > Freight > Road > Light Duty Trucks",
+            "sector_path": "Transport > Freight > Road > Light Duty Trucks",
+            "acts_on_labels": ["diesel light trucks", "petrol light trucks"],
+            "shifts_to_labels": ["gas light trucks"],
+            "score": 0.313
+          },
+          {
+            "stable_id": "biofuels_for_sea_freight_transport",
+            "short_label": "T-1B4b-TE-4 - Biofuel for marine freight transport",
+            "description": "Biofuel for marine freight transport. Increase the proportion of marine biodiesel in marine diesel. from: ship freight. Transport > Freight > Shipping > Navigation",
+            "sector_path": "Transport > Freight > Shipping > Navigation",
+            "acts_on_labels": ["ship freight"],
+            "shifts_to_labels": [],
+            "score": 0.2817
+          },
+          {
+            "stable_id": "biofuel_for_diesel_rail_passenger",
+            "short_label": "T-1A2-TE-1 - Biofuel for rail passenger transport",
+            "description": "Biofuel for rail passenger transport. Increase the proportion of HVO biodiesel in diesel. from: diesel passenger rail. Transport > Mobility > Rail",
+            "sector_path": "Transport > Mobility > Rail",
+            "acts_on_labels": ["diesel passenger rail"],
+            "shifts_to_labels": [],
+            "score": 0.28
+          },
+          {
+            "stable_id": "biofuel_for_heavy_trucks",
+            "short_label": "T-1B1b-TE-2 - Biofuel for diesel heavy trucks",
+            "description": "Biofuel for diesel heavy trucks. Increase the proportion of HVO biodiesel in diesel. from: diesel heavy trucks. Transport > Freight > Road > Heavy Duty Trucks",
+            "sector_path": "Transport > Freight > Road > Heavy Duty Trucks",
+            "acts_on_labels": ["diesel heavy trucks"],
+            "shifts_to_labels": [],
+            "score": 0.2791
+          },
+          {
+            "stable_id": "energy_efficient_other_agriculture_forestry_fishing_electric_appliances",
+            "short_label": "T-3C6-TE-1 - Energy efficient agriculture, forestry and fishing electrical appliances",
+            "description": "Energy efficient agriculture, forestry and fishing electrical appliances. Reduce the amount of energy required to operate agriculture, forestry and fishing electrical appliances. from: agriculture forestry fishing unregulated electricity use. Afolu > Aggregate Sources Other > Other",
+            "sector_path": "Afolu > Aggregate Sources Other > Other",
+            "acts_on_labels": [
+              "agriculture forestry fishing unregulated electricity use"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.2776
+          },
+          {
+            "stable_id": "biofuels_for_freight_air_transport",
+            "short_label": "T-1B3-TE-1 - Biofuel for kerosene air freight transport",
+            "description": "Biofuel for kerosene air freight transport. Increase the proportion of aviation biofuel in aviation turbine fuel. from: freight transportation by air. Transport > Freight > Aviation",
+            "sector_path": "Transport > Freight > Aviation",
+            "acts_on_labels": ["freight transportation by air"],
+            "shifts_to_labels": [],
+            "score": 0.272
+          },
+          {
+            "stable_id": "biofuel_for_diesel_rail_freight",
+            "short_label": "T-1B2-TE-1 - Biofuel for rail freight transport",
+            "description": "Biofuel for rail freight transport. Increase the proportion of HVO biodiesel in diesel. from: diesel rail freight. Transport > Freight > Rail",
+            "sector_path": "Transport > Freight > Rail",
+            "acts_on_labels": ["diesel rail freight"],
+            "shifts_to_labels": [],
+            "score": 0.2717
+          },
+          {
+            "stable_id": "biofuel_for_light_trucks",
+            "short_label": "T-1B1a-TE-2 - Biofuel for diesel light trucks",
+            "description": "Biofuel for diesel light trucks. Increase the proportion of HVO biodiesel in diesel. from: diesel light trucks. Transport > Freight > Road > Light Duty Trucks",
+            "sector_path": "Transport > Freight > Road > Light Duty Trucks",
+            "acts_on_labels": ["diesel light trucks"],
+            "shifts_to_labels": [],
+            "score": 0.2682
+          },
+          {
+            "stable_id": "shift_to_exported_composting_of_organic_waste",
+            "short_label": "T-6A1-TE-3 - Shift to exported composting of organic waste",
+            "description": "Shift to exported composting of organic waste. Shift tonne from solid waste disposal in landfills to exported composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: waste exported for composting. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc",
+              "incineration and open burning of waste",
+              "open burning of waste",
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "shifts_to_labels": ["waste exported for composting"],
+            "score": 0.2547
+          },
+          {
+            "stable_id": "biofuel_for_gas_buses",
+            "short_label": "T-1A1c-TE-2 - Biofuel for gas buses",
+            "description": "Biofuel for gas buses. Increase the proportion of biogas in gas mix. from: gas buses. Transport > Mobility > Road > Buses",
+            "sector_path": "Transport > Mobility > Road > Buses",
+            "acts_on_labels": ["gas buses"],
+            "shifts_to_labels": [],
+            "score": 0.2519
+          },
+          {
+            "stable_id": "biofuels_for_sea_passenger_transport",
+            "short_label": "T-1A4-TE-4 - Biofuel for marine passenger transport",
+            "description": "Biofuel for marine passenger transport. Increase the proportion of marine biodiesel in marine diesel. from: ship passenger. Transport > Mobility > Waterborne",
+            "sector_path": "Transport > Mobility > Waterborne",
+            "acts_on_labels": ["ship passenger"],
+            "shifts_to_labels": [],
+            "score": 0.2508
+          },
+          {
+            "stable_id": "biofuels_for_air_transport",
+            "short_label": "T-1A3-TE-1 - Biofuel for air passenger transport",
+            "description": "Biofuel for air passenger transport. Increase the proportion of aviation biofuel in aviation turbine fuel. from: passenger transportation by air. Transport > Mobility > Aviation",
+            "sector_path": "Transport > Mobility > Aviation",
+            "acts_on_labels": ["passenger transportation by air"],
+            "shifts_to_labels": [],
+            "score": 0.2482
+          },
+          {
+            "stable_id": "imported_grid_district_heat",
+            "short_label": "T-5A2-TE-1 - District heat from imported grid",
+            "description": "District heat from imported grid. Alter the amount of district heat produced by imported grid district heat. from: imported grid district heat. Energy > Energy Supply > Heat",
+            "sector_path": "Energy > Energy Supply > Heat",
+            "acts_on_labels": ["imported grid district heat"],
+            "shifts_to_labels": [],
+            "score": 0.2467
+          },
+          {
+            "stable_id": "increase_renewable_proportion_in_diesel",
+            "short_label": "T-1A1a-TE-21 - Biofuel for diesel cars",
+            "description": "Biofuel for diesel cars. Increase the proportion of HVO biodiesel in diesel. from: diesel vehicles. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": ["diesel vehicles"],
+            "shifts_to_labels": [],
+            "score": 0.2447
+          }
+        ]
+      }
+    ],
+    "intervention_who": "none",
+    "intervention_when": "none",
+    "intervention_what": "köpa in mat med råvaruland Sverige",
+    "intervention_how": "none",
+    "intervention_score": 2,
+    "intervention_reasoning": "The measure specifies a 'what' (köpa in mat med råvaruland Sverige) but lacks a 'who', 'when', and 'how'.",
+    "intervention_type": "none"
+  },
+  {
+    "measure_text": "153.Minst 80 procent av maten som köps in till kommunens verksamheter ska vara tillverkad i Sverige.",
+    "activity": "food procurement",
+    "activity_shift_score": 1,
+    "activity_shifts": [],
+    "intervention_who": "kommunens verksamheter",
+    "intervention_when": "none",
+    "intervention_what": "purchase food produced in Sweden",
+    "intervention_how": "none",
+    "intervention_score": 3,
+    "intervention_reasoning": "WHO and WHAT are present. The measure specifies that 80% of food should be produced in Sweden, but lacks a clear HOW or WHEN.",
+    "intervention_type": "indirect"
+  },
+  {
+    "measure_text": "154.Sträva efter att 60 procent av livsmedlen som serveras i kommunal verksamhet ska vara ekologiska.",
+    "activity": "food procurement",
+    "activity_shift_score": 1,
+    "activity_shifts": [],
+    "intervention_who": "kommunal verksamhet",
+    "intervention_when": "none",
+    "intervention_what": "aim for 60% of food to be organic",
+    "intervention_how": "none",
+    "intervention_score": 3,
+    "intervention_reasoning": "WHO and WHAT are present. The measure aims for 60% of food to be organic but lacks a clear HOW or WHEN.",
+    "intervention_type": "indirect"
+  },
+  {
+    "measure_text": "155.Klimatpåverkan från livsmedel som används i kommunal verksamhet ska minska. Målet är att klimatbelastningen ska vara max 1,25 kg CO2-ekv. per",
+    "activity": "food consumption",
+    "activity_shift_score": 2,
+    "activity_shifts": [
+      {
+        "activity": "consuming food",
+        "shift_from": "none",
+        "shift_to": "none",
+        "need": "food provision",
+        "type": "Resource Efficiency Shift",
+        "type_reasoning": "The measure aims to reduce the climate impact of food consumption, implying more efficient use of resources to achieve the same nutritional outcome.",
+        "score": 2,
+        "reasoning": "The measure implies a shift towards more efficient food consumption with lower climate impact, but FROM and TO are not clearly identifiable.",
+        "transition_element_matches": [],
+        "transition_element_suggested_new": {
+          "short_label": "Shift to Low-Carbon Food Provision",
+          "description": "This measure focuses on reducing the climate impact of food used in municipal operations by targeting a maximum of 1.25 kg CO2-equivalent per unit, promoting sustainable and low-carbon food choices."
+        },
+        "transition_element_candidates": [
+          {
+            "stable_id": "shift_to_sustainable_healthy_diet",
+            "short_label": "T-3A1-TE-1 - Shift to Sustainable Healthy Diets",
+            "description": "Shift to Sustainable Healthy Diets. This Transition Element is the shift from animal based diets to plant based diets.. from: enteric fermentation cattle, enteric fermentation sheep, enteric fermentation swine, enteric fermentation other livestock. Afolu > Livestock > Enteric Fermentation",
+            "sector_path": "Afolu > Livestock > Enteric Fermentation",
+            "acts_on_labels": [
+              "enteric fermentation cattle",
+              "enteric fermentation sheep",
+              "enteric fermentation swine",
+              "enteric fermentation other livestock"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.3506
+          },
+          {
+            "stable_id": "energy_efficient_other_agriculture_forestry_fishing_electric_appliances",
+            "short_label": "T-3C6-TE-1 - Energy efficient agriculture, forestry and fishing electrical appliances",
+            "description": "Energy efficient agriculture, forestry and fishing electrical appliances. Reduce the amount of energy required to operate agriculture, forestry and fishing electrical appliances. from: agriculture forestry fishing unregulated electricity use. Afolu > Aggregate Sources Other > Other",
+            "sector_path": "Afolu > Aggregate Sources Other > Other",
+            "acts_on_labels": [
+              "agriculture forestry fishing unregulated electricity use"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.2722
+          },
+          {
+            "stable_id": "shift_to_biomass_energy_in_petroleum_refinement",
+            "short_label": "T-5B1-TE-1 - Shift to biomass energy in petroleum refinement",
+            "description": "Shift to biomass energy in petroleum refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: crude oil usage within petroleum refinement. to: biomass usage within petroleum refinement. Energy > Energy Transformation > Petroleum Refinement",
+            "sector_path": "Energy > Energy Transformation > Petroleum Refinement",
+            "acts_on_labels": ["crude oil usage within petroleum refinement"],
+            "shifts_to_labels": ["biomass usage within petroleum refinement"],
+            "score": 0.251
+          },
+          {
+            "stable_id": "shift_to_residential_electric_cooking_stoves",
+            "short_label": "T-4A2d-TE-2 - Shift to residential electric cooking stoves",
+            "description": "Shift to residential electric cooking stoves. Shift kWh from residential cooking gas stoves to residential electric cooking stoves in kWh to fullfill the need for cooking. from: residential gas cooking stoves. to: residential electric cooking stoves. Buildings > Residential > Other Energy Usage > Unregulated",
+            "sector_path": "Buildings > Residential > Other Energy Usage > Unregulated",
+            "acts_on_labels": ["residential gas cooking stoves"],
+            "shifts_to_labels": ["residential electric cooking stoves"],
+            "score": 0.2438
+          },
+          {
+            "stable_id": "shift_to_commercial_electric_cooking_stoves",
+            "short_label": "T-4B2b-TE-1 - Shift to commercial electric cooking stoves",
+            "description": "Shift to commercial electric cooking stoves. Shift kWh from commercial cooking gas stoves to commercial electric cooking stoves in kWh to fullfill the need for cooking. from: commercial gas cooking stoves. to: commercial electric cooking stoves. Buildings > Non Residential > Other Energy Usage > Equipment Appliances",
+            "sector_path": "Buildings > Non Residential > Other Energy Usage > Equipment Appliances",
+            "acts_on_labels": ["commercial gas cooking stoves"],
+            "shifts_to_labels": ["commercial electric cooking stoves"],
+            "score": 0.2401
+          },
+          {
+            "stable_id": "shift_to_biomass_energy_in_hydrogen_refinement",
+            "short_label": "T-5B4-TE-4 - Shift to biomass energy in hydrogen refinement",
+            "description": "Shift to biomass energy in hydrogen refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within hydrogen refinement. to: biomass usage within hydrogen refinement. Energy > Energy Transformation > Hydrogen Refinement",
+            "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
+            "acts_on_labels": ["coal usage within hydrogen refinement"],
+            "shifts_to_labels": ["biomass usage within hydrogen refinement"],
+            "score": 0.239
+          },
+          {
+            "stable_id": "shift_to_biomass_energy_in_other_industries",
+            "short_label": "T-2D5-TE-1 - Shift to biomass energy in other industries",
+            "description": "Shift to biomass energy in other industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: industrial unregulated coal use. to: industrial unregulated biomass use. Industry > Other > Other",
+            "sector_path": "Industry > Other > Other",
+            "acts_on_labels": ["industrial unregulated coal use"],
+            "shifts_to_labels": ["industrial unregulated biomass use"],
+            "score": 0.2351
+          },
+          {
+            "stable_id": "biogas_in_methane_reforming_for_hydrogen_production",
+            "short_label": "T-5B4-TE-1 - Biogas in methane reforming for hydrogen production",
+            "description": "Biogas in methane reforming for hydrogen production. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: reforming of methane for hydrogen production. Energy > Energy Transformation > Hydrogen Refinement",
+            "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
+            "acts_on_labels": ["reforming of methane for hydrogen production"],
+            "shifts_to_labels": [],
+            "score": 0.2348
+          },
+          {
+            "stable_id": "shift_to_composting_of_organic_waste",
+            "short_label": "T-6A1-TE-2 - Shift to composting of organic waste",
+            "description": "Shift to composting of organic waste. Shift tonne from solid waste disposal in landfills to composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: composting of organic waste. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc",
+              "incineration and open burning of waste",
+              "open burning of waste",
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "shifts_to_labels": ["composting of organic waste"],
+            "score": 0.2337
+          },
+          {
+            "stable_id": "biomass_in_carbon_gasification_for_hydrogen_production",
+            "short_label": "T-5B4-TE-2 - Biomass in carbon gasification for hydrogen production",
+            "description": "Biomass in carbon gasification for hydrogen production. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: gasification of carbon for hydrogen production. Energy > Energy Transformation > Hydrogen Refinement",
+            "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
+            "acts_on_labels": [
+              "gasification of carbon for hydrogen production"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.2324
+          },
+          {
+            "stable_id": "biofuels_for_air_transport",
+            "short_label": "T-1A3-TE-1 - Biofuel for air passenger transport",
+            "description": "Biofuel for air passenger transport. Increase the proportion of aviation biofuel in aviation turbine fuel. from: passenger transportation by air. Transport > Mobility > Aviation",
+            "sector_path": "Transport > Mobility > Aviation",
+            "acts_on_labels": ["passenger transportation by air"],
+            "shifts_to_labels": [],
+            "score": 0.2307
+          },
+          {
+            "stable_id": "biogas_in_methane_reforming_for_ammonia_production",
+            "short_label": "T-2B1-TE-1 - Biogas in methane reforming for ammonia production",
+            "description": "Biogas in methane reforming for ammonia production. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: reforming of methane for ammonia production. Industry > Chemicals > Ammonia Production",
+            "sector_path": "Industry > Chemicals > Ammonia Production",
+            "acts_on_labels": ["reforming of methane for ammonia production"],
+            "shifts_to_labels": [],
+            "score": 0.227
+          },
+          {
+            "stable_id": "biofuels_for_freight_air_transport",
+            "short_label": "T-1B3-TE-1 - Biofuel for kerosene air freight transport",
+            "description": "Biofuel for kerosene air freight transport. Increase the proportion of aviation biofuel in aviation turbine fuel. from: freight transportation by air. Transport > Freight > Aviation",
+            "sector_path": "Transport > Freight > Aviation",
+            "acts_on_labels": ["freight transportation by air"],
+            "shifts_to_labels": [],
+            "score": 0.2269
+          },
+          {
+            "stable_id": "biofuels_for_cement_and_mineral_industry",
+            "short_label": "T-2A1-TE-1 - Shift to use biofuel in cement and mineral industry",
+            "description": "Shift to use biofuel in cement and mineral industry. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: cement mineral industries coal usage. to: cement mineral industries biomass usage. Industry > Minerals > Cement",
+            "sector_path": "Industry > Minerals > Cement",
+            "acts_on_labels": ["cement mineral industries coal usage"],
+            "shifts_to_labels": ["cement mineral industries biomass usage"],
+            "score": 0.2262
+          },
+          {
+            "stable_id": "shift_to_biomass_energy_in_iron_and_steel_industries",
+            "short_label": "T-2C1-TE-2 - Shift to biomass energy in iron and steel industries",
+            "description": "Shift to biomass energy in iron and steel industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within iron and steel industries. to: biomass usage within iron and steel industries. Industry > Metals > Iron Steel",
+            "sector_path": "Industry > Metals > Iron Steel",
+            "acts_on_labels": ["coal usage within iron and steel industries"],
+            "shifts_to_labels": [
+              "biomass usage within iron and steel industries"
+            ],
+            "score": 0.226
+          }
+        ]
+      }
+    ],
+    "intervention_who": "kommunal verksamhet",
+    "intervention_when": "none",
+    "intervention_what": "reduce climate impact of food",
+    "intervention_how": "none",
+    "intervention_score": 2,
+    "intervention_reasoning": "WHO is present, but lacks clear WHAT, HOW, or WHEN.",
+    "intervention_type": "indirect"
+  },
+  {
+    "measure_text": "156.Matsvinnet i kommunen ska minska. Det gäller både kökssvinn, serveringssvinn och tallrikssvinn. Målvärdet är att det sammanlagda svinnet per serverad portion ska uppgå till max 25 gram.",
+    "activity": "food waste management",
+    "activity_shift_score": 6,
+    "activity_shifts": [
+      {
+        "activity": "managing food waste",
+        "shift_from": "high food waste",
+        "shift_to": "reduced food waste",
+        "need": "waste management",
+        "type": "Utilisation Shift",
+        "type_reasoning": "The measure focuses on reducing food waste, which is a change in utilisation of food resources.",
+        "score": 6,
+        "reasoning": "The measure clearly identifies the activity (managing food waste), the shift from high to reduced waste, and the need (waste management).",
+        "transition_element_matches": [],
+        "transition_element_suggested_new": {
+          "short_label": "Reduction in Food Waste",
+          "description": "Implement measures to reduce food waste in municipal kitchens, focusing on minimizing kitchen, serving, and plate waste to achieve a target of no more than 25 grams of waste per served portion."
+        },
+        "transition_element_candidates": [
+          {
+            "stable_id": "shift_to_composting_of_organic_waste",
+            "short_label": "T-6A1-TE-2 - Shift to composting of organic waste",
+            "description": "Shift to composting of organic waste. Shift tonne from solid waste disposal in landfills to composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: composting of organic waste. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc",
+              "incineration and open burning of waste",
+              "open burning of waste",
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "shifts_to_labels": ["composting of organic waste"],
+            "score": 0.5855
+          },
+          {
+            "stable_id": "increased_recycling",
+            "short_label": "T-6A1-TE-1 - Shift to recycling of solid waste",
+            "description": "Shift to recycling of solid waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to recycling of solid waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: recycling of solid waste. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc",
+              "incineration and open burning of waste",
+              "open burning of waste",
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "shifts_to_labels": ["recycling of solid waste"],
+            "score": 0.577
+          },
+          {
+            "stable_id": "shift_to_exported_composting_of_organic_waste",
+            "short_label": "T-6A1-TE-3 - Shift to exported composting of organic waste",
+            "description": "Shift to exported composting of organic waste. Shift tonne from solid waste disposal in landfills to exported composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: waste exported for composting. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc",
+              "incineration and open burning of waste",
+              "open burning of waste",
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "shifts_to_labels": ["waste exported for composting"],
+            "score": 0.5569
+          },
+          {
+            "stable_id": "shift_to_landfill_gas_recovery",
+            "short_label": "T-6A1-TE-4 - Shift to landfill gas recovery",
+            "description": "Shift to landfill gas recovery. Shift tonne from solid waste disposal in landfills without gas recovery to solid waste disposal in landfills with landfill gas recovery in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc. to: solid waste disposal landfill with gas recovery. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc"
+            ],
+            "shifts_to_labels": [
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "score": 0.5346
+          },
+          {
+            "stable_id": "increased_energy_recovery_from_waste",
+            "short_label": "T-5A3-TE-6 - Increased energy recovery from waste",
+            "description": "Increased energy recovery from waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to CHP waste incineration in tonne to fulfill the need of warm premisses. from: incineration and open burning of waste. to: chp waste incineration. Energy > Energy Supply > Combined Heat Power",
+            "sector_path": "Energy > Energy Supply > Combined Heat Power",
+            "acts_on_labels": ["incineration and open burning of waste"],
+            "shifts_to_labels": ["chp waste incineration"],
+            "score": 0.4879
+          },
+          {
+            "stable_id": "shift_to_sustainable_healthy_diet",
+            "short_label": "T-3A1-TE-1 - Shift to Sustainable Healthy Diets",
+            "description": "Shift to Sustainable Healthy Diets. This Transition Element is the shift from animal based diets to plant based diets.. from: enteric fermentation cattle, enteric fermentation sheep, enteric fermentation swine, enteric fermentation other livestock. Afolu > Livestock > Enteric Fermentation",
+            "sector_path": "Afolu > Livestock > Enteric Fermentation",
+            "acts_on_labels": [
+              "enteric fermentation cattle",
+              "enteric fermentation sheep",
+              "enteric fermentation swine",
+              "enteric fermentation other livestock"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.4509
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_chemical_industries",
+            "short_label": "T-2B9-TE-1 - Shift to biogas energy in chemical industries",
+            "description": "Shift to biogas energy in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within chemical industries. to: biogas usage within chemical industries. Industry > Chemicals > Other",
+            "sector_path": "Industry > Chemicals > Other",
+            "acts_on_labels": ["natural gas usage within chemical industries"],
+            "shifts_to_labels": ["biogas usage within chemical industries"],
+            "score": 0.4078
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_lead_industries",
+            "short_label": "T-2C5-TE-1 - Shift to biogas energy in lead industries",
+            "description": "Shift to biogas energy in lead industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within lead industries. to: biogas usage within lead industries. Industry > Metals > Lead",
+            "sector_path": "Industry > Metals > Lead",
+            "acts_on_labels": ["natural gas usage within lead industries"],
+            "shifts_to_labels": ["biogas usage within lead industries"],
+            "score": 0.4048
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_glass_industries",
+            "short_label": "T-2A3-TE-1 - Shift to biogas energy in glass industries",
+            "description": "Shift to biogas energy in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within glass industries. to: biogas usage within glass industries. Industry > Minerals > Glass Production",
+            "sector_path": "Industry > Minerals > Glass Production",
+            "acts_on_labels": ["natural gas usage within glass industries"],
+            "shifts_to_labels": ["biogas usage within glass industries"],
+            "score": 0.4041
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_pulp_paper_and_print_industries",
+            "short_label": "T-2D1b-TE-1 - Shift to biogas energy in pulp, paper and print industries",
+            "description": "Shift to biogas energy in pulp, paper and print industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within pulp paper and print industries. to: biogas usage within pulp paper and print industries. Industry > Other > Manufacturing > Pulp Paper Print",
+            "sector_path": "Industry > Other > Manufacturing > Pulp Paper Print",
+            "acts_on_labels": [
+              "natural gas usage within pulp paper and print industries"
+            ],
+            "shifts_to_labels": [
+              "biogas usage within pulp paper and print industries"
+            ],
+            "score": 0.4033
+          },
+          {
+            "stable_id": "chp_waste_incineration",
+            "short_label": "T-5A3-TE-4 - CHP from waste incineration",
+            "description": "CHP from waste incineration. Alter the amount of district heat and electricity produced by CHP waste incineration. from: chp waste incineration. Energy > Energy Supply > Combined Heat Power",
+            "sector_path": "Energy > Energy Supply > Combined Heat Power",
+            "acts_on_labels": ["chp waste incineration"],
+            "shifts_to_labels": [],
+            "score": 0.3735
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_hydrogen_refinement",
+            "short_label": "T-5B4-TE-3 - Shift to biogas energy in hydrogen refinement",
+            "description": "Shift to biogas energy in hydrogen refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within hydrogen refinement. to: biogas usage within hydrogen refinement. Energy > Energy Transformation > Hydrogen Refinement",
+            "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
+            "acts_on_labels": ["natural gas usage within hydrogen refinement"],
+            "shifts_to_labels": ["biogas usage within hydrogen refinement"],
+            "score": 0.3469
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_other_industries",
+            "short_label": "T-2D5-TE-2 - Shift to biogas energy in other industries",
+            "description": "Shift to biogas energy in other industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: industrial unregulated gas use. to: industrial unregulated biogas use. Industry > Other > Other",
+            "sector_path": "Industry > Other > Other",
+            "acts_on_labels": ["industrial unregulated gas use"],
+            "shifts_to_labels": ["industrial unregulated biogas use"],
+            "score": 0.3306
+          },
+          {
+            "stable_id": "biogas_in_methane_reforming_for_hydrogen_production",
+            "short_label": "T-5B4-TE-1 - Biogas in methane reforming for hydrogen production",
+            "description": "Biogas in methane reforming for hydrogen production. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: reforming of methane for hydrogen production. Energy > Energy Transformation > Hydrogen Refinement",
+            "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
+            "acts_on_labels": ["reforming of methane for hydrogen production"],
+            "shifts_to_labels": [],
+            "score": 0.3233
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_magnesium_industries",
+            "short_label": "T-2C4-TE-2 - Shift to biogas energy in magnesium industries",
+            "description": "Shift to biogas energy in magnesium industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within magnesium industries. to: biogas usage within magnesium industries. Industry > Metals > Magnesium",
+            "sector_path": "Industry > Metals > Magnesium",
+            "acts_on_labels": ["natural gas usage within magnesium industries"],
+            "shifts_to_labels": ["biogas usage within magnesium industries"],
+            "score": 0.3194
+          }
+        ]
+      }
+    ],
+    "intervention_who": "none",
+    "intervention_when": "none",
+    "intervention_what": "reduce food waste",
+    "intervention_how": "none",
+    "intervention_score": 2,
+    "intervention_reasoning": "WHAT is present, but lacks WHO, HOW, or WHEN.",
+    "intervention_type": "indirect"
+  },
+  {
+    "measure_text": "157.Lokala initiativ till livsmedelsförsörjning utanför traditionell jordbruksmark ska uppmuntras och främjas. Det kan till exempel vara kolonilotter, odlingslådor, hydroponik (odla med vatten istället för jord) eller akvaponik (ett hållbart matproduktionssystem som kombinerar t.ex. fiskodling och växtodling).",
+    "activity": "food production",
+    "activity_shift_score": 5,
+    "activity_shifts": [
+      {
+        "activity": "producing food",
+        "shift_from": "traditional agriculture",
+        "shift_to": "urban agriculture",
+        "need": "food provision",
+        "type": "Type Shift",
+        "type_reasoning": "The measure encourages a shift from traditional agriculture to alternative methods like hydroponics and aquaponics.",
+        "score": 5,
+        "reasoning": "The measure implies a shift from traditional agriculture to alternative methods, with the need for food provision clear, but FROM and TO are not explicitly named.",
+        "transition_element_matches": [],
+        "transition_element_suggested_new": {
+          "short_label": "Shift to Urban Agriculture",
+          "description": "Encouraging local food production initiatives such as community gardens, hydroponics, and aquaponics to enhance food provision outside traditional agricultural lands."
+        },
+        "transition_element_candidates": [
+          {
+            "stable_id": "shift_to_sustainable_healthy_diet",
+            "short_label": "T-3A1-TE-1 - Shift to Sustainable Healthy Diets",
+            "description": "Shift to Sustainable Healthy Diets. This Transition Element is the shift from animal based diets to plant based diets.. from: enteric fermentation cattle, enteric fermentation sheep, enteric fermentation swine, enteric fermentation other livestock. Afolu > Livestock > Enteric Fermentation",
+            "sector_path": "Afolu > Livestock > Enteric Fermentation",
+            "acts_on_labels": [
+              "enteric fermentation cattle",
+              "enteric fermentation sheep",
+              "enteric fermentation swine",
+              "enteric fermentation other livestock"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.4742
+          },
+          {
+            "stable_id": "shift_to_composting_of_organic_waste",
+            "short_label": "T-6A1-TE-2 - Shift to composting of organic waste",
+            "description": "Shift to composting of organic waste. Shift tonne from solid waste disposal in landfills to composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: composting of organic waste. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc",
+              "incineration and open burning of waste",
+              "open burning of waste",
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "shifts_to_labels": ["composting of organic waste"],
+            "score": 0.3733
+          },
+          {
+            "stable_id": "shift_to_residential_electric_cooking_stoves",
+            "short_label": "T-4A2d-TE-2 - Shift to residential electric cooking stoves",
+            "description": "Shift to residential electric cooking stoves. Shift kWh from residential cooking gas stoves to residential electric cooking stoves in kWh to fullfill the need for cooking. from: residential gas cooking stoves. to: residential electric cooking stoves. Buildings > Residential > Other Energy Usage > Unregulated",
+            "sector_path": "Buildings > Residential > Other Energy Usage > Unregulated",
+            "acts_on_labels": ["residential gas cooking stoves"],
+            "shifts_to_labels": ["residential electric cooking stoves"],
+            "score": 0.3716
+          },
+          {
+            "stable_id": "increased_proportion_of_walking_and_cycling",
+            "short_label": "T-1A1a-TE-10 - Shift to walking and cycling",
+            "description": "Shift to walking and cycling. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to walking cycling. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: walking cycling. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": [
+              "petrol vehicles",
+              "diesel vehicles",
+              "lpg vehicles",
+              "gas vehicles"
+            ],
+            "shifts_to_labels": ["walking cycling"],
+            "score": 0.3656
+          },
+          {
+            "stable_id": "shift_from_passenger_air_transport_to_railway",
+            "short_label": "T-1A3-TE-4 - Shift from air travel to railway",
+            "description": "Shift from air travel to railway. Shift person kilometer from passenger transportation by air to electric rail in person kilometer to fulfill the need of mobility. from: passenger transportation by air. to: electric rail. Transport > Mobility > Aviation",
+            "sector_path": "Transport > Mobility > Aviation",
+            "acts_on_labels": ["passenger transportation by air"],
+            "shifts_to_labels": ["electric rail"],
+            "score": 0.3646
+          },
+          {
+            "stable_id": "shift_to_electric_bikes",
+            "short_label": "T-1A1a-TE-11 - Shift to electric bikes",
+            "description": "Shift to electric bikes. Shift vehicle kilometer from petrol,diesel and LPG vehicles to electric bike in vehicle kilometer to fulfill the need of mobility. from: petrol vehicles, diesel vehicles, lpg vehicles. to: electric bikes. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": [
+              "petrol vehicles",
+              "diesel vehicles",
+              "lpg vehicles"
+            ],
+            "shifts_to_labels": ["electric bikes"],
+            "score": 0.3641
+          },
+          {
+            "stable_id": "shift_to_electric_cargo_bikes",
+            "short_label": "T-1B1a-TE-10 - Shift to electric cargo bikes",
+            "description": "Shift to electric cargo bikes. Shift vehicle kilometer from diesel and petrol light truck to electric carg bikes in vehicle kilometer to fulfill the need of logistics. from: diesel light trucks, petrol light trucks. to: electric cargo bikes. Transport > Freight > Road > Light Duty Trucks",
+            "sector_path": "Transport > Freight > Road > Light Duty Trucks",
+            "acts_on_labels": ["diesel light trucks", "petrol light trucks"],
+            "shifts_to_labels": ["electric cargo bikes"],
+            "score": 0.3553
+          },
+          {
+            "stable_id": "shift_to_commercial_electric_cooking_stoves",
+            "short_label": "T-4B2b-TE-1 - Shift to commercial electric cooking stoves",
+            "description": "Shift to commercial electric cooking stoves. Shift kWh from commercial cooking gas stoves to commercial electric cooking stoves in kWh to fullfill the need for cooking. from: commercial gas cooking stoves. to: commercial electric cooking stoves. Buildings > Non Residential > Other Energy Usage > Equipment Appliances",
+            "sector_path": "Buildings > Non Residential > Other Energy Usage > Equipment Appliances",
+            "acts_on_labels": ["commercial gas cooking stoves"],
+            "shifts_to_labels": ["commercial electric cooking stoves"],
+            "score": 0.355
+          },
+          {
+            "stable_id": "transfer_from_car_to_remote_working",
+            "short_label": "T-1A1a-TE-8 - Shift from car to remote working",
+            "description": "Shift from car to remote working. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to remote working. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: remote working. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": [
+              "petrol vehicles",
+              "diesel vehicles",
+              "lpg vehicles",
+              "gas vehicles"
+            ],
+            "shifts_to_labels": ["remote working"],
+            "score": 0.3462
+          },
+          {
+            "stable_id": "increased_recycling",
+            "short_label": "T-6A1-TE-1 - Shift to recycling of solid waste",
+            "description": "Shift to recycling of solid waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to recycling of solid waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: recycling of solid waste. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc",
+              "incineration and open burning of waste",
+              "open burning of waste",
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "shifts_to_labels": ["recycling of solid waste"],
+            "score": 0.3461
+          },
+          {
+            "stable_id": "energy_efficient_other_agriculture_forestry_fishing_electric_appliances",
+            "short_label": "T-3C6-TE-1 - Energy efficient agriculture, forestry and fishing electrical appliances",
+            "description": "Energy efficient agriculture, forestry and fishing electrical appliances. Reduce the amount of energy required to operate agriculture, forestry and fishing electrical appliances. from: agriculture forestry fishing unregulated electricity use. Afolu > Aggregate Sources Other > Other",
+            "sector_path": "Afolu > Aggregate Sources Other > Other",
+            "acts_on_labels": [
+              "agriculture forestry fishing unregulated electricity use"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.3269
+          },
+          {
+            "stable_id": "biogas_in_methane_reforming_for_ammonia_production",
+            "short_label": "T-2B1-TE-1 - Biogas in methane reforming for ammonia production",
+            "description": "Biogas in methane reforming for ammonia production. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: reforming of methane for ammonia production. Industry > Chemicals > Ammonia Production",
+            "sector_path": "Industry > Chemicals > Ammonia Production",
+            "acts_on_labels": ["reforming of methane for ammonia production"],
+            "shifts_to_labels": [],
+            "score": 0.302
+          },
+          {
+            "stable_id": "biogas_in_methane_reforming_for_hydrogen_production",
+            "short_label": "T-5B4-TE-1 - Biogas in methane reforming for hydrogen production",
+            "description": "Biogas in methane reforming for hydrogen production. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: reforming of methane for hydrogen production. Energy > Energy Transformation > Hydrogen Refinement",
+            "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
+            "acts_on_labels": ["reforming of methane for hydrogen production"],
+            "shifts_to_labels": [],
+            "score": 0.291
+          },
+          {
+            "stable_id": "shift_to_exported_composting_of_organic_waste",
+            "short_label": "T-6A1-TE-3 - Shift to exported composting of organic waste",
+            "description": "Shift to exported composting of organic waste. Shift tonne from solid waste disposal in landfills to exported composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: waste exported for composting. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc",
+              "incineration and open burning of waste",
+              "open burning of waste",
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "shifts_to_labels": ["waste exported for composting"],
+            "score": 0.2819
+          },
+          {
+            "stable_id": "chp_biofuels",
+            "short_label": "T-5A3-TE-5 - CHP from biomass",
+            "description": "CHP from biomass. Alter the amount of district heat and electricity produced by CHP biofuels. from: chp biofuels. Energy > Energy Supply > Combined Heat Power",
+            "sector_path": "Energy > Energy Supply > Combined Heat Power",
+            "acts_on_labels": ["chp biofuels"],
+            "shifts_to_labels": [],
+            "score": 0.2811
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_other_industries",
+            "short_label": "T-2D5-TE-2 - Shift to biogas energy in other industries",
+            "description": "Shift to biogas energy in other industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: industrial unregulated gas use. to: industrial unregulated biogas use. Industry > Other > Other",
+            "sector_path": "Industry > Other > Other",
+            "acts_on_labels": ["industrial unregulated gas use"],
+            "shifts_to_labels": ["industrial unregulated biogas use"],
+            "score": 0.2809
+          },
+          {
+            "stable_id": "shift_to_biofuel_in_district_heating",
+            "short_label": "T-5A3-TE-7 - Shift to biofuel in district heating",
+            "description": "Shift to biofuel in district heating. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: chp coal, chp natural gas, chp oil. to: chp biofuels. Energy > Energy Supply > Combined Heat Power",
+            "sector_path": "Energy > Energy Supply > Combined Heat Power",
+            "acts_on_labels": ["chp coal", "chp natural gas", "chp oil"],
+            "shifts_to_labels": ["chp biofuels"],
+            "score": 0.2736
+          },
+          {
+            "stable_id": "shift_to_electrolysis_of_water_for_hydrogen_production",
+            "short_label": "T-5B4-TE-6 - Shift to electrolysis of water for hydrogen production",
+            "description": "Shift to electrolysis of water for hydrogen production. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: reforming of methane for hydrogen production, gasification of carbon for hydrogen production. to: electrolysis of water for hydrogen production. Energy > Energy Transformation > Hydrogen Refinement",
+            "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
+            "acts_on_labels": [
+              "reforming of methane for hydrogen production",
+              "gasification of carbon for hydrogen production"
+            ],
+            "shifts_to_labels": [
+              "electrolysis of water for hydrogen production"
+            ],
+            "score": 0.2723
+          },
+          {
+            "stable_id": "shift_to_biomass_energy_in_other_industries",
+            "short_label": "T-2D5-TE-1 - Shift to biomass energy in other industries",
+            "description": "Shift to biomass energy in other industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: industrial unregulated coal use. to: industrial unregulated biomass use. Industry > Other > Other",
+            "sector_path": "Industry > Other > Other",
+            "acts_on_labels": ["industrial unregulated coal use"],
+            "shifts_to_labels": ["industrial unregulated biomass use"],
+            "score": 0.2645
+          },
+          {
+            "stable_id": "biofuel_for_gas_vehicles",
+            "short_label": "T-1A1a-TE-20 - Biofuel for gas cars",
+            "description": "Biofuel for gas cars. Increase the proportion of biogas in gas mix. from: gas vehicles. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": ["gas vehicles"],
+            "shifts_to_labels": [],
+            "score": 0.2622
+          },
+          {
+            "stable_id": "increased_energy_recovery_from_waste",
+            "short_label": "T-5A3-TE-6 - Increased energy recovery from waste",
+            "description": "Increased energy recovery from waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to CHP waste incineration in tonne to fulfill the need of warm premisses. from: incineration and open burning of waste. to: chp waste incineration. Energy > Energy Supply > Combined Heat Power",
+            "sector_path": "Energy > Energy Supply > Combined Heat Power",
+            "acts_on_labels": ["incineration and open burning of waste"],
+            "shifts_to_labels": ["chp waste incineration"],
+            "score": 0.2619
+          }
+        ]
+      }
+    ],
+    "intervention_who": "none",
+    "intervention_when": "none",
+    "intervention_what": "encourage local food initiatives",
+    "intervention_how": "none",
+    "intervention_score": 2,
+    "intervention_reasoning": "WHAT is present, but lacks WHO, HOW, or WHEN.",
+    "intervention_type": "enabling"
+  },
+  {
+    "measure_text": "158.Den sammanlagda exponeringen för kemiska ämnen via alla exponeringsvägar behöver vara så låg att den inte är skadlig för människor eller den biologiska mångfalden.",
+    "activity": "chemical exposure management",
+    "activity_shift_score": 1,
+    "activity_shifts": [],
+    "intervention_who": "none",
+    "intervention_when": "none",
+    "intervention_what": "reduce chemical exposure",
+    "intervention_how": "none",
+    "intervention_score": 1,
+    "intervention_reasoning": "No specific WHO, WHEN, WHAT, or HOW is provided.",
+    "intervention_type": "none"
+  },
+  {
+    "measure_text": "159.Antalet produkter och material innehållande utfasningsämnen (enligt Kemikalieinspektionens kriterier) ska minska.",
+    "activity": "product management",
+    "activity_shift_score": 2,
+    "activity_shifts": [
+      {
+        "activity": "using products",
+        "shift_from": "using products with phased-out substances",
+        "shift_to": "using products without phased-out substances",
+        "need": "product safety",
+        "type": "Resource Shift",
+        "type_reasoning": "The measure aims to reduce the use of products containing phased-out substances, shifting to safer alternatives.",
+        "score": 2,
+        "reasoning": "The measure implies a shift but lacks clear FROM and TO details.",
+        "transition_element_matches": [],
+        "transition_element_suggested_new": {
+          "short_label": "Shift to safer chemical products",
+          "description": "Transition from using products containing phased-out substances to those without, enhancing product safety and compliance with chemical regulations."
+        },
+        "transition_element_candidates": [
+          {
+            "stable_id": "shift_to_electricity_in_chemical_industries",
+            "short_label": "T-2B9-TE-3 - Shift to electricity in chemical industries",
+            "description": "Shift to electricity in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within chemical industries, natural gas usage within chemical industries. to: electricity usage within chemical industries. Industry > Chemicals > Other",
+            "sector_path": "Industry > Chemicals > Other",
+            "acts_on_labels": [
+              "coal usage within chemical industries",
+              "natural gas usage within chemical industries"
+            ],
+            "shifts_to_labels": [
+              "electricity usage within chemical industries"
+            ],
+            "score": 0.399
+          },
+          {
+            "stable_id": "shift_to_hydrogen_energy_in_chemical_industries",
+            "short_label": "T-2B9-TE-4 - Shift to hydrogen energy in chemical industries",
+            "description": "Shift to hydrogen energy in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within chemical industries. to: hydrogen usage within chemical industries. Industry > Chemicals > Other",
+            "sector_path": "Industry > Chemicals > Other",
+            "acts_on_labels": ["natural gas usage within chemical industries"],
+            "shifts_to_labels": ["hydrogen usage within chemical industries"],
+            "score": 0.3821
+          },
+          {
+            "stable_id": "shift_to_biomass_energy_in_chemical_industries",
+            "short_label": "T-2B9-TE-2 - Shift to biomass energy in chemical industries",
+            "description": "Shift to biomass energy in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within chemical industries. to: biomass usage within chemical industries. Industry > Chemicals > Other",
+            "sector_path": "Industry > Chemicals > Other",
+            "acts_on_labels": ["coal usage within chemical industries"],
+            "shifts_to_labels": ["biomass usage within chemical industries"],
+            "score": 0.3768
+          },
+          {
+            "stable_id": "shift_to_electricity_in_lead_industries",
+            "short_label": "T-2C5-TE-3 - Shift to electricity in lead industries",
+            "description": "Shift to electricity in lead industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within lead industries, oil usage within lead industries, natural gas usage within lead industries. to: electricity usage within lead industries. Industry > Metals > Lead",
+            "sector_path": "Industry > Metals > Lead",
+            "acts_on_labels": [
+              "coal usage within lead industries",
+              "oil usage within lead industries",
+              "natural gas usage within lead industries"
+            ],
+            "shifts_to_labels": ["electricity usage within lead industries"],
+            "score": 0.3749
+          },
+          {
+            "stable_id": "increased_proportion_of_non_travel_meetings_and_services",
+            "short_label": "T-1A1a-TE-7 - Shift to online meetings and services",
+            "description": "Shift to online meetings and services. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to e-meetings in hours to fulfill the need of business trips. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: e meetings. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": [
+              "petrol vehicles",
+              "diesel vehicles",
+              "lpg vehicles",
+              "gas vehicles"
+            ],
+            "shifts_to_labels": ["e meetings"],
+            "score": 0.373
+          },
+          {
+            "stable_id": "increased_proportion_of_walking_and_cycling",
+            "short_label": "T-1A1a-TE-10 - Shift to walking and cycling",
+            "description": "Shift to walking and cycling. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to walking cycling. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: walking cycling. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": [
+              "petrol vehicles",
+              "diesel vehicles",
+              "lpg vehicles",
+              "gas vehicles"
+            ],
+            "shifts_to_labels": ["walking cycling"],
+            "score": 0.3684
+          },
+          {
+            "stable_id": "shift_to_gas_vehicles",
+            "short_label": "T-1A1a-TE-19 - Shift to gas cars",
+            "description": "Shift to gas cars. Shift vehicle kilometer from petrol and diesel vehicles to gas vehicles in vehicle kilometer to fulfill the need of mobility. from: petrol vehicles, diesel vehicles. to: gas vehicles. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": ["petrol vehicles", "diesel vehicles"],
+            "shifts_to_labels": ["gas vehicles"],
+            "score": 0.3681
+          },
+          {
+            "stable_id": "shift_to_electric_vehicles",
+            "short_label": "T-1A1a-TE-1 - Shift to electric cars",
+            "description": "Shift to electric cars. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to battery electric vehicles in vehicle kilometer to fulfill the need of mobility. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: battery electric vehicles. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": [
+              "petrol vehicles",
+              "diesel vehicles",
+              "lpg vehicles",
+              "gas vehicles"
+            ],
+            "shifts_to_labels": ["battery electric vehicles"],
+            "score": 0.367
+          },
+          {
+            "stable_id": "shift_to_sustainable_healthy_diet",
+            "short_label": "T-3A1-TE-1 - Shift to Sustainable Healthy Diets",
+            "description": "Shift to Sustainable Healthy Diets. This Transition Element is the shift from animal based diets to plant based diets.. from: enteric fermentation cattle, enteric fermentation sheep, enteric fermentation swine, enteric fermentation other livestock. Afolu > Livestock > Enteric Fermentation",
+            "sector_path": "Afolu > Livestock > Enteric Fermentation",
+            "acts_on_labels": [
+              "enteric fermentation cattle",
+              "enteric fermentation sheep",
+              "enteric fermentation swine",
+              "enteric fermentation other livestock"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.3639
+          },
+          {
+            "stable_id": "shift_to_hydrogen_vehicles",
+            "short_label": "T-1A1a-TE-2 - Shift to hydrogen cars",
+            "description": "Shift to hydrogen cars. Shift vehicle kilometer from petrol and diesel vehicles to hydrogen vehicles in vehicle kilometer to fulfill the need of mobility. from: petrol vehicles, diesel vehicles. to: hydrogen vehicles. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": ["petrol vehicles", "diesel vehicles"],
+            "shifts_to_labels": ["hydrogen vehicles"],
+            "score": 0.363
+          },
+          {
+            "stable_id": "increased_recycling",
+            "short_label": "T-6A1-TE-1 - Shift to recycling of solid waste",
+            "description": "Shift to recycling of solid waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to recycling of solid waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: recycling of solid waste. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc",
+              "incineration and open burning of waste",
+              "open burning of waste",
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "shifts_to_labels": ["recycling of solid waste"],
+            "score": 0.3135
+          },
+          {
+            "stable_id": "shift_to_exported_composting_of_organic_waste",
+            "short_label": "T-6A1-TE-3 - Shift to exported composting of organic waste",
+            "description": "Shift to exported composting of organic waste. Shift tonne from solid waste disposal in landfills to exported composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: waste exported for composting. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc",
+              "incineration and open burning of waste",
+              "open burning of waste",
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "shifts_to_labels": ["waste exported for composting"],
+            "score": 0.3097
+          },
+          {
+            "stable_id": "shift_to_biomass_energy_in_lead_industries",
+            "short_label": "T-2C5-TE-2 - Shift to biomass energy in lead industries",
+            "description": "Shift to biomass energy in lead industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within lead industries. to: biomass usage within lead industries. Industry > Metals > Lead",
+            "sector_path": "Industry > Metals > Lead",
+            "acts_on_labels": ["coal usage within lead industries"],
+            "shifts_to_labels": ["biomass usage within lead industries"],
+            "score": 0.3077
+          },
+          {
+            "stable_id": "shift_to_composting_of_organic_waste",
+            "short_label": "T-6A1-TE-2 - Shift to composting of organic waste",
+            "description": "Shift to composting of organic waste. Shift tonne from solid waste disposal in landfills to composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: composting of organic waste. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc",
+              "incineration and open burning of waste",
+              "open burning of waste",
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "shifts_to_labels": ["composting of organic waste"],
+            "score": 0.3033
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_chemical_industries",
+            "short_label": "T-2B9-TE-1 - Shift to biogas energy in chemical industries",
+            "description": "Shift to biogas energy in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within chemical industries. to: biogas usage within chemical industries. Industry > Chemicals > Other",
+            "sector_path": "Industry > Chemicals > Other",
+            "acts_on_labels": ["natural gas usage within chemical industries"],
+            "shifts_to_labels": ["biogas usage within chemical industries"],
+            "score": 0.301
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_lead_industries",
+            "short_label": "T-2C5-TE-1 - Shift to biogas energy in lead industries",
+            "description": "Shift to biogas energy in lead industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within lead industries. to: biogas usage within lead industries. Industry > Metals > Lead",
+            "sector_path": "Industry > Metals > Lead",
+            "acts_on_labels": ["natural gas usage within lead industries"],
+            "shifts_to_labels": ["biogas usage within lead industries"],
+            "score": 0.2984
+          },
+          {
+            "stable_id": "shift_to_electricity_in_other_industries",
+            "short_label": "T-2D5-TE-3 - Shift to electricity in other industries",
+            "description": "Shift to electricity in other industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: industrial unregulated coal use, industrial unregulated oil use, industrial unregulated gas use. to: industrial unregulated electricity use. Industry > Other > Other",
+            "sector_path": "Industry > Other > Other",
+            "acts_on_labels": [
+              "industrial unregulated coal use",
+              "industrial unregulated oil use",
+              "industrial unregulated gas use"
+            ],
+            "shifts_to_labels": ["industrial unregulated electricity use"],
+            "score": 0.2946
+          }
+        ]
+      }
+    ],
+    "intervention_who": "none",
+    "intervention_when": "none",
+    "intervention_what": "reduce products with phased-out substances",
+    "intervention_how": "none",
+    "intervention_score": 2,
+    "intervention_reasoning": "WHAT is present, but lacks WHO, HOW, or WHEN.",
+    "intervention_type": "indirect"
+  },
+  {
+    "measure_text": "160.Hantera kemiska produkter och övriga kemiska riskkällor i enlighet med 'Rutin för kemikaliehantering'. Det vill säga att inventera och riskbedöma",
+    "activity": "chemical risk management",
+    "activity_shift_score": 1,
+    "activity_shifts": [],
+    "intervention_who": "none",
+    "intervention_when": "none",
+    "intervention_what": "manage chemical products and risks",
+    "intervention_how": "in accordance with 'Rutin för kemikaliehantering'",
+    "intervention_score": 3,
+    "intervention_reasoning": "WHAT and HOW are present, but lacks WHO or WHEN.",
+    "intervention_type": "indirect"
+  },
+  {
+    "measure_text": "161.Förutsättningar för längre och smartare resursutnyttjande ska skapas genom att upprätta cirkulära processer, vid nybyggnation och underhåll.",
+    "activity": "resource utilisation",
+    "activity_shift_score": 4,
+    "activity_shifts": [
+      {
+        "activity": "utilising resources",
+        "shift_from": "linear resource use",
+        "shift_to": "circular resource use",
+        "need": "resource efficiency",
+        "type": "Resource Efficiency Shift",
+        "type_reasoning": "The measure aims to shift from linear to circular resource use, improving efficiency.",
+        "score": 4,
+        "reasoning": "The measure implies a shift towards circular resource use, but FROM and TO are not explicitly named.",
+        "transition_element_matches": [],
+        "transition_element_candidates": [
+          {
+            "stable_id": "increased_recycling",
+            "short_label": "T-6A1-TE-1 - Shift to recycling of solid waste",
+            "description": "Shift to recycling of solid waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to recycling of solid waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: recycling of solid waste. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc",
+              "incineration and open burning of waste",
+              "open burning of waste",
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "shifts_to_labels": ["recycling of solid waste"],
+            "score": 0.4426
+          },
+          {
+            "stable_id": "shift_to_sustainable_healthy_diet",
+            "short_label": "T-3A1-TE-1 - Shift to Sustainable Healthy Diets",
+            "description": "Shift to Sustainable Healthy Diets. This Transition Element is the shift from animal based diets to plant based diets.. from: enteric fermentation cattle, enteric fermentation sheep, enteric fermentation swine, enteric fermentation other livestock. Afolu > Livestock > Enteric Fermentation",
+            "sector_path": "Afolu > Livestock > Enteric Fermentation",
+            "acts_on_labels": [
+              "enteric fermentation cattle",
+              "enteric fermentation sheep",
+              "enteric fermentation swine",
+              "enteric fermentation other livestock"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.4411
+          },
+          {
+            "stable_id": "increased_proportion_of_walking_and_cycling",
+            "short_label": "T-1A1a-TE-10 - Shift to walking and cycling",
+            "description": "Shift to walking and cycling. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to walking cycling. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: walking cycling. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": [
+              "petrol vehicles",
+              "diesel vehicles",
+              "lpg vehicles",
+              "gas vehicles"
+            ],
+            "shifts_to_labels": ["walking cycling"],
+            "score": 0.4198
+          },
+          {
+            "stable_id": "shift_to_biomass_energy_in_iron_and_steel_industries",
+            "short_label": "T-2C1-TE-2 - Shift to biomass energy in iron and steel industries",
+            "description": "Shift to biomass energy in iron and steel industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within iron and steel industries. to: biomass usage within iron and steel industries. Industry > Metals > Iron Steel",
+            "sector_path": "Industry > Metals > Iron Steel",
+            "acts_on_labels": ["coal usage within iron and steel industries"],
+            "shifts_to_labels": [
+              "biomass usage within iron and steel industries"
+            ],
+            "score": 0.4128
+          },
+          {
+            "stable_id": "shift_to_biomass_energy_in_lead_industries",
+            "short_label": "T-2C5-TE-2 - Shift to biomass energy in lead industries",
+            "description": "Shift to biomass energy in lead industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within lead industries. to: biomass usage within lead industries. Industry > Metals > Lead",
+            "sector_path": "Industry > Metals > Lead",
+            "acts_on_labels": ["coal usage within lead industries"],
+            "shifts_to_labels": ["biomass usage within lead industries"],
+            "score": 0.4082
+          },
+          {
+            "stable_id": "biofuels_for_cement_and_mineral_industry",
+            "short_label": "T-2A1-TE-1 - Shift to use biofuel in cement and mineral industry",
+            "description": "Shift to use biofuel in cement and mineral industry. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: cement mineral industries coal usage. to: cement mineral industries biomass usage. Industry > Minerals > Cement",
+            "sector_path": "Industry > Minerals > Cement",
+            "acts_on_labels": ["cement mineral industries coal usage"],
+            "shifts_to_labels": ["cement mineral industries biomass usage"],
+            "score": 0.4081
+          },
+          {
+            "stable_id": "shift_to_biomass_energy_in_glass_industries",
+            "short_label": "T-2A3-TE-2 - Shift to biomass energy in glass industries",
+            "description": "Shift to biomass energy in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within glass industries. to: biomass usage within glass industries. Industry > Minerals > Glass Production",
+            "sector_path": "Industry > Minerals > Glass Production",
+            "acts_on_labels": ["coal usage within glass industries"],
+            "shifts_to_labels": ["biomass usage within glass industries"],
+            "score": 0.4074
+          },
+          {
+            "stable_id": "increased_energy_recovery_from_waste",
+            "short_label": "T-5A3-TE-6 - Increased energy recovery from waste",
+            "description": "Increased energy recovery from waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to CHP waste incineration in tonne to fulfill the need of warm premisses. from: incineration and open burning of waste. to: chp waste incineration. Energy > Energy Supply > Combined Heat Power",
+            "sector_path": "Energy > Energy Supply > Combined Heat Power",
+            "acts_on_labels": ["incineration and open burning of waste"],
+            "shifts_to_labels": ["chp waste incineration"],
+            "score": 0.4064
+          },
+          {
+            "stable_id": "shift_to_biomass_energy_in_petroleum_refinement",
+            "short_label": "T-5B1-TE-1 - Shift to biomass energy in petroleum refinement",
+            "description": "Shift to biomass energy in petroleum refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: crude oil usage within petroleum refinement. to: biomass usage within petroleum refinement. Energy > Energy Transformation > Petroleum Refinement",
+            "sector_path": "Energy > Energy Transformation > Petroleum Refinement",
+            "acts_on_labels": ["crude oil usage within petroleum refinement"],
+            "shifts_to_labels": ["biomass usage within petroleum refinement"],
+            "score": 0.4062
+          },
+          {
+            "stable_id": "shift_to_biomass_energy_in_hydrogen_refinement",
+            "short_label": "T-5B4-TE-4 - Shift to biomass energy in hydrogen refinement",
+            "description": "Shift to biomass energy in hydrogen refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within hydrogen refinement. to: biomass usage within hydrogen refinement. Energy > Energy Transformation > Hydrogen Refinement",
+            "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
+            "acts_on_labels": ["coal usage within hydrogen refinement"],
+            "shifts_to_labels": ["biomass usage within hydrogen refinement"],
+            "score": 0.4057
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_iron_and_steel_industries",
+            "short_label": "T-2C1-TE-1 - Shift to biogas energy in iron and steel industries",
+            "description": "Shift to biogas energy in iron and steel industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within iron and steel industries. to: biogas usage within iron and steel industries. Industry > Metals > Iron Steel",
+            "sector_path": "Industry > Metals > Iron Steel",
+            "acts_on_labels": [
+              "natural gas usage within iron and steel industries"
+            ],
+            "shifts_to_labels": [
+              "biogas usage within iron and steel industries"
+            ],
+            "score": 0.363
+          },
+          {
+            "stable_id": "shift_to_biomass_energy_in_chemical_industries",
+            "short_label": "T-2B9-TE-2 - Shift to biomass energy in chemical industries",
+            "description": "Shift to biomass energy in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within chemical industries. to: biomass usage within chemical industries. Industry > Chemicals > Other",
+            "sector_path": "Industry > Chemicals > Other",
+            "acts_on_labels": ["coal usage within chemical industries"],
+            "shifts_to_labels": ["biomass usage within chemical industries"],
+            "score": 0.3591
+          },
+          {
+            "stable_id": "shift_to_biomass_energy_in_magnesium_industries",
+            "short_label": "T-2C4-TE-3 - Shift to biomass energy in magnesium industries",
+            "description": "Shift to biomass energy in magnesium industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within magnesium industries. to: biomass usage within magnesium industries. Industry > Metals > Magnesium",
+            "sector_path": "Industry > Metals > Magnesium",
+            "acts_on_labels": ["coal usage within magnesium industries"],
+            "shifts_to_labels": ["biomass usage within magnesium industries"],
+            "score": 0.3586
+          },
+          {
+            "stable_id": "shift_to_biomass_energy_in_pulp_paper_and_print_industries",
+            "short_label": "T-2D1b-TE-2 - Shift to biomass energy in pulp, paper and print industries",
+            "description": "Shift to biomass energy in pulp, paper and print industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within pulp paper and print industries. to: biomass usage within pulp paper and print industries. Industry > Other > Manufacturing > Pulp Paper Print",
+            "sector_path": "Industry > Other > Manufacturing > Pulp Paper Print",
+            "acts_on_labels": [
+              "coal usage within pulp paper and print industries"
+            ],
+            "shifts_to_labels": [
+              "biomass usage within pulp paper and print industries"
+            ],
+            "score": 0.358
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_lead_industries",
+            "short_label": "T-2C5-TE-1 - Shift to biogas energy in lead industries",
+            "description": "Shift to biogas energy in lead industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within lead industries. to: biogas usage within lead industries. Industry > Metals > Lead",
+            "sector_path": "Industry > Metals > Lead",
+            "acts_on_labels": ["natural gas usage within lead industries"],
+            "shifts_to_labels": ["biogas usage within lead industries"],
+            "score": 0.3562
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_pulp_paper_and_print_industries",
+            "short_label": "T-2D1b-TE-1 - Shift to biogas energy in pulp, paper and print industries",
+            "description": "Shift to biogas energy in pulp, paper and print industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within pulp paper and print industries. to: biogas usage within pulp paper and print industries. Industry > Other > Manufacturing > Pulp Paper Print",
+            "sector_path": "Industry > Other > Manufacturing > Pulp Paper Print",
+            "acts_on_labels": [
+              "natural gas usage within pulp paper and print industries"
+            ],
+            "shifts_to_labels": [
+              "biogas usage within pulp paper and print industries"
+            ],
+            "score": 0.3545
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_glass_industries",
+            "short_label": "T-2A3-TE-1 - Shift to biogas energy in glass industries",
+            "description": "Shift to biogas energy in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within glass industries. to: biogas usage within glass industries. Industry > Minerals > Glass Production",
+            "sector_path": "Industry > Minerals > Glass Production",
+            "acts_on_labels": ["natural gas usage within glass industries"],
+            "shifts_to_labels": ["biogas usage within glass industries"],
+            "score": 0.3517
+          }
+        ]
+      }
+    ],
+    "intervention_who": "none",
+    "intervention_when": "none",
+    "intervention_what": "establish circular processes",
+    "intervention_how": "none",
+    "intervention_score": 2,
+    "intervention_reasoning": "WHAT is present, but lacks WHO, HOW, or WHEN.",
+    "intervention_type": "enabling"
+  },
+  {
+    "measure_text": "162.Kommunen ska i dialog med byggentreprenörer arbeta för hållbart byggande i samband med exploateringsavtal, både sett till materialval, energiförbrukning, produktion och ekosystemtjänster.",
+    "activity": "construction",
+    "activity_shift_score": 3,
+    "activity_shifts": [
+      {
+        "activity": "constructing buildings",
+        "shift_from": "traditional construction methods",
+        "shift_to": "sustainable construction methods",
+        "need": "sustainable development",
+        "type": "Type Shift",
+        "type_reasoning": "The measure aims to shift construction practices to more sustainable methods.",
+        "score": 3,
+        "reasoning": "The measure implies a shift towards sustainable construction, but FROM and TO are not clearly defined.",
+        "transition_element_matches": [],
+        "transition_element_suggested_new": {
+          "short_label": "Sustainable Construction Practices",
+          "description": "Transition from traditional to sustainable construction methods focusing on material choice, energy consumption, production, and ecosystem services."
+        },
+        "transition_element_candidates": [
+          {
+            "stable_id": "low_carbon_construction_of_multi_family_residential_housing",
+            "short_label": "T-4C1-TE-2 - Low carbon construction of multi-family buildings",
+            "description": "Low carbon construction of multi-family buildings. Shift square meter from residential multi family standard construction to residential multi family low carbon construction in square meter to fulfill the need of housing. from: residential multi family standard construction. to: residential multi family low carbon construction. Buildings > Building Stocks > Construction",
+            "sector_path": "Buildings > Building Stocks > Construction",
+            "acts_on_labels": [
+              "residential multi family standard construction"
+            ],
+            "shifts_to_labels": [
+              "residential multi family low carbon construction"
+            ],
+            "score": 0.5077
+          },
+          {
+            "stable_id": "low_carbon_construction_of_non_residential_commercial_buildings",
+            "short_label": "T-4C1-TE-3 - Low carbon construction of commercial buildings",
+            "description": "Low carbon construction of commercial buildings. Shift square meter from non residential commercial standard construction to non residential commercial low carbon construction in square meter to fulfill the need of housing. from: non residential commercial standard construction. to: non residential commercial low carbon construction. Buildings > Building Stocks > Construction",
+            "sector_path": "Buildings > Building Stocks > Construction",
+            "acts_on_labels": [
+              "non residential commercial standard construction"
+            ],
+            "shifts_to_labels": [
+              "non residential commercial low carbon construction"
+            ],
+            "score": 0.5043
+          },
+          {
+            "stable_id": "low_carbon_construction_of_buildings",
+            "short_label": "T-4C1-TE-1 - Low carbon construction of buildings",
+            "description": "Low carbon construction of buildings. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: non residential commercial standard construction. to: non residential commercial low carbon construction. Buildings > Building Stocks > Construction",
+            "sector_path": "Buildings > Building Stocks > Construction",
+            "acts_on_labels": [
+              "non residential commercial standard construction"
+            ],
+            "shifts_to_labels": [
+              "non residential commercial low carbon construction"
+            ],
+            "score": 0.4863
+          },
+          {
+            "stable_id": "shift_to_sustainable_healthy_diet",
+            "short_label": "T-3A1-TE-1 - Shift to Sustainable Healthy Diets",
+            "description": "Shift to Sustainable Healthy Diets. This Transition Element is the shift from animal based diets to plant based diets.. from: enteric fermentation cattle, enteric fermentation sheep, enteric fermentation swine, enteric fermentation other livestock. Afolu > Livestock > Enteric Fermentation",
+            "sector_path": "Afolu > Livestock > Enteric Fermentation",
+            "acts_on_labels": [
+              "enteric fermentation cattle",
+              "enteric fermentation sheep",
+              "enteric fermentation swine",
+              "enteric fermentation other livestock"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.4624
+          },
+          {
+            "stable_id": "biofuels_for_cement_and_mineral_industry",
+            "short_label": "T-2A1-TE-1 - Shift to use biofuel in cement and mineral industry",
+            "description": "Shift to use biofuel in cement and mineral industry. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: cement mineral industries coal usage. to: cement mineral industries biomass usage. Industry > Minerals > Cement",
+            "sector_path": "Industry > Minerals > Cement",
+            "acts_on_labels": ["cement mineral industries coal usage"],
+            "shifts_to_labels": ["cement mineral industries biomass usage"],
+            "score": 0.4358
+          },
+          {
+            "stable_id": "shift_to_biomass_energy_in_glass_industries",
+            "short_label": "T-2A3-TE-2 - Shift to biomass energy in glass industries",
+            "description": "Shift to biomass energy in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within glass industries. to: biomass usage within glass industries. Industry > Minerals > Glass Production",
+            "sector_path": "Industry > Minerals > Glass Production",
+            "acts_on_labels": ["coal usage within glass industries"],
+            "shifts_to_labels": ["biomass usage within glass industries"],
+            "score": 0.4193
+          },
+          {
+            "stable_id": "shift_to_biomass_energy_in_lead_industries",
+            "short_label": "T-2C5-TE-2 - Shift to biomass energy in lead industries",
+            "description": "Shift to biomass energy in lead industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within lead industries. to: biomass usage within lead industries. Industry > Metals > Lead",
+            "sector_path": "Industry > Metals > Lead",
+            "acts_on_labels": ["coal usage within lead industries"],
+            "shifts_to_labels": ["biomass usage within lead industries"],
+            "score": 0.4115
+          },
+          {
+            "stable_id": "shift_to_solar_thermal_in_industrial_buildings",
+            "short_label": "T-4B1c-TE-5 - Shift to solar thermal in industrial buildings",
+            "description": "Shift to solar thermal in industrial buildings. Shift square meter from industrial building heated with gas, oil, direct. from: industrial building heating with gas, industrial building heating with oil, industrial building heating with direct electric heaters, industrial building heating with lpg, industrial building heating with coal, industrial building heating with gas oil. to: industrial building heating with solar thermal. Buildings > Non Residential > Hvac > Other Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Other Hvac",
+            "acts_on_labels": [
+              "industrial building heating with gas",
+              "industrial building heating with oil",
+              "industrial building heating with direct electric heaters",
+              "industrial building heating with lpg",
+              "industrial building heating with coal",
+              "industrial building heating with gas oil"
+            ],
+            "shifts_to_labels": [
+              "industrial building heating with solar thermal"
+            ],
+            "score": 0.4081
+          },
+          {
+            "stable_id": "shift_to_hydrogen_energy_in_glass_industries",
+            "short_label": "T-2A3-TE-4 - Shift to hydrogen energy in glass industries",
+            "description": "Shift to hydrogen energy in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within glass industries. to: hydrogen usage within glass industries. Industry > Minerals > Glass Production",
+            "sector_path": "Industry > Minerals > Glass Production",
+            "acts_on_labels": ["natural gas usage within glass industries"],
+            "shifts_to_labels": ["hydrogen usage within glass industries"],
+            "score": 0.4055
+          },
+          {
+            "stable_id": "shift_to_biomass_energy_in_magnesium_industries",
+            "short_label": "T-2C4-TE-3 - Shift to biomass energy in magnesium industries",
+            "description": "Shift to biomass energy in magnesium industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within magnesium industries. to: biomass usage within magnesium industries. Industry > Metals > Magnesium",
+            "sector_path": "Industry > Metals > Magnesium",
+            "acts_on_labels": ["coal usage within magnesium industries"],
+            "shifts_to_labels": ["biomass usage within magnesium industries"],
+            "score": 0.4051
+          },
+          {
+            "stable_id": "energy_efficient_new_commercial_buildings",
+            "short_label": "T-4B1a-TE-9 - Energy efficient new Commercial Buildings",
+            "description": "Energy efficient new Commercial Buildings. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: heating of new public buildings, heating of new commercial buildings, heating of new industrial buildings. Buildings > Non Residential > Hvac > Commercial Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Commercial Hvac",
+            "acts_on_labels": [
+              "heating of new public buildings",
+              "heating of new commercial buildings",
+              "heating of new industrial buildings"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.3852
+          },
+          {
+            "stable_id": "energy_efficient_new_housing",
+            "short_label": "T-4A1-TE-1 - Energy efficient new Housing",
+            "description": "Energy efficient new Housing. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: heating of new residential single family buildings, heating of new residential multi family buildings. Buildings > Residential > Hvac",
+            "sector_path": "Buildings > Residential > Hvac",
+            "acts_on_labels": [
+              "heating of new residential single family buildings",
+              "heating of new residential multi family buildings"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.3852
+          },
+          {
+            "stable_id": "energy_efficient_non_residential_public_buildings_retrofitting",
+            "short_label": "T-4B1b-TE-6 - Retrofitting public buildings for efficient heating",
+            "description": "Retrofitting public buildings for efficient heating. Reduce the amount of energy required to heat public building heating. from: public building heating with solid biofuels, public building heating with direct electric heaters, public building heating with gas, public building heating with propane, public building heating with oil, public building heating with heatpump, public building heating with district heating, public building heating with coal, public building heating with solar thermal, public building heating with lpg, public building heating with hydrogen, public building heating with gas oil. Buildings > Non Residential > Hvac > Institutional Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
+            "acts_on_labels": [
+              "public building heating with solid biofuels",
+              "public building heating with direct electric heaters",
+              "public building heating with gas",
+              "public building heating with propane",
+              "public building heating with oil",
+              "public building heating with heatpump",
+              "public building heating with district heating",
+              "public building heating with coal",
+              "public building heating with solar thermal",
+              "public building heating with lpg",
+              "public building heating with hydrogen",
+              "public building heating with gas oil"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.3846
+          },
+          {
+            "stable_id": "energy_efficient_non_residential_industrial_buildings_retrofitting",
+            "short_label": "T-4B1c-TE-6 - Retrofitting industrial buildings for efficient heating",
+            "description": "Retrofitting industrial buildings for efficient heating. Reduce the amount of energy required to heat industrial building with. from: industrial building heating with solid biofuels, industrial building heating with direct electric heaters, industrial building heating with district heating, industrial building heating with heatpump, industrial building heating with oil, industrial building heating with gas, industrial building heating with lpg, industrial building heating with coal, industrial building heating with hydrogen, industrial building heating with solar thermal, industrial building heating with gas oil. Buildings > Non Residential > Hvac > Other Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Other Hvac",
+            "acts_on_labels": [
+              "industrial building heating with solid biofuels",
+              "industrial building heating with direct electric heaters",
+              "industrial building heating with district heating",
+              "industrial building heating with heatpump",
+              "industrial building heating with oil",
+              "industrial building heating with gas",
+              "industrial building heating with lpg",
+              "industrial building heating with coal",
+              "industrial building heating with hydrogen",
+              "industrial building heating with solar thermal",
+              "industrial building heating with gas oil"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.3758
+          },
+          {
+            "stable_id": "shift_to_solar_thermal_in_public_buildings",
+            "short_label": "T-4B1b-TE-5 - Shift to solar thermal in public buildings",
+            "description": "Shift to solar thermal in public buildings. Shift square meter from public building heated with oil, gas, direct. from: public building heating with oil, public building heating with gas, public building heating with propane, public building heating with direct electric heaters, public building heating with coal, public building heating with lpg, public building heating with gas oil. to: public building heating with solar thermal. Buildings > Non Residential > Hvac > Institutional Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
+            "acts_on_labels": [
+              "public building heating with oil",
+              "public building heating with gas",
+              "public building heating with propane",
+              "public building heating with direct electric heaters",
+              "public building heating with coal",
+              "public building heating with lpg",
+              "public building heating with gas oil"
+            ],
+            "shifts_to_labels": ["public building heating with solar thermal"],
+            "score": 0.3662
+          },
+          {
+            "stable_id": "shift_to_solar_thermal_in_commercial_buildings",
+            "short_label": "T-4B1a-TE-5 - Shift to solar thermal in commercial buildings",
+            "description": "Shift to solar thermal in commercial buildings. Shift square meter from commercial building heated with gas, oil, direct. from: commercial building heating with gas, commercial building heating with propane, commercial building heating with oil, commercial building heating with direct electric heaters, commercial building heating with coal, commercial building heating with lpg, commercial building heating with gas oil. to: commercial building heating with solar thermal. Buildings > Non Residential > Hvac > Commercial Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Commercial Hvac",
+            "acts_on_labels": [
+              "commercial building heating with gas",
+              "commercial building heating with propane",
+              "commercial building heating with oil",
+              "commercial building heating with direct electric heaters",
+              "commercial building heating with coal",
+              "commercial building heating with lpg",
+              "commercial building heating with gas oil"
+            ],
+            "shifts_to_labels": [
+              "commercial building heating with solar thermal"
+            ],
+            "score": 0.3646
+          },
+          {
+            "stable_id": "heating_non_residential_commercial_buildings_with_renewable_solid_biofuels",
+            "short_label": "T-4B1a-TE-4 - Shift to biofuel in commercial buildings",
+            "description": "Shift to biofuel in commercial buildings. Shift square meter from commercial buildings heated with gas, oil, direct. from: commercial building heating with gas, commercial building heating with propane, commercial building heating with oil, commercial building heating with direct electric heaters, commercial building heating with coal, commercial building heating with lpg, commercial building heating with gas oil. to: commercial building heating with solid biofuels. Buildings > Non Residential > Hvac > Commercial Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Commercial Hvac",
+            "acts_on_labels": [
+              "commercial building heating with gas",
+              "commercial building heating with propane",
+              "commercial building heating with oil",
+              "commercial building heating with direct electric heaters",
+              "commercial building heating with coal",
+              "commercial building heating with lpg",
+              "commercial building heating with gas oil"
+            ],
+            "shifts_to_labels": [
+              "commercial building heating with solid biofuels"
+            ],
+            "score": 0.3593
+          },
+          {
+            "stable_id": "heating_non_residential_public_buildings_with_renewable_solid_biofuels",
+            "short_label": "T-4B1b-TE-4 - Shift to biofuel in public buildings",
+            "description": "Shift to biofuel in public buildings. Shift square meter from public buildings heated with oil, gas, direct. from: public building heating with oil, public building heating with gas, public building heating with propane, public building heating with direct electric heaters, public building heating with coal, public building heating with lpg, public building heating with gas oil. to: public building heating with solid biofuels. Buildings > Non Residential > Hvac > Institutional Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
+            "acts_on_labels": [
+              "public building heating with oil",
+              "public building heating with gas",
+              "public building heating with propane",
+              "public building heating with direct electric heaters",
+              "public building heating with coal",
+              "public building heating with lpg",
+              "public building heating with gas oil"
+            ],
+            "shifts_to_labels": ["public building heating with solid biofuels"],
+            "score": 0.3591
+          },
+          {
+            "stable_id": "energy_efficient_non_residential_public_buildings_retrofitting_cooling",
+            "short_label": "T-4B1b-TE-7 - Retrofitting public buildings for efficient cooling",
+            "description": "Retrofitting public buildings for efficient cooling. Reduce the amount of energy required to cool public building with AC and disitrct cooling through retrofitting. from: public building cooling with ac, public building cooling with district cooling. Buildings > Non Residential > Hvac > Institutional Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
+            "acts_on_labels": [
+              "public building cooling with ac",
+              "public building cooling with district cooling"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.3588
+          },
+          {
+            "stable_id": "shift_to_biogas_heating_of_non_residential_commercial_buildings",
+            "short_label": "T-4B1a-TE-10 - Shift to biogas in commercial buildings",
+            "description": "Shift to biogas in commercial buildings. Shift square meter from commercial building heating with gas to commercial building heating with biogas in square meter to fulfill the need of comfortable premises. from: commercial building heating with gas. to: commercial building heating with biogas. Buildings > Non Residential > Hvac > Commercial Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Commercial Hvac",
+            "acts_on_labels": ["commercial building heating with gas"],
+            "shifts_to_labels": ["commercial building heating with biogas"],
+            "score": 0.3552
+          },
+          {
+            "stable_id": "energy_efficient_non_residential_industrial_buildings_retrofitting_cooling",
+            "short_label": "T-4B1c-TE-7 - Retrofitting industrial buildings for efficient cooling",
+            "description": "Retrofitting industrial buildings for efficient cooling. Reduce the amount of energy required to cool industrial building with AC and disitrct cooling through retrofitting. from: industrial building cooling with ac, industrial building cooling with district cooling. Buildings > Non Residential > Hvac > Other Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Other Hvac",
+            "acts_on_labels": [
+              "industrial building cooling with ac",
+              "industrial building cooling with district cooling"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.3549
+          }
+        ]
+      }
+    ],
+    "intervention_who": "kommunen",
+    "intervention_when": "none",
+    "intervention_what": "work for sustainable construction",
+    "intervention_how": "in dialogue with builders",
+    "intervention_score": 4,
+    "intervention_reasoning": "WHO, WHAT, and HOW are present, but lacks WHEN.",
+    "intervention_type": "indirect"
+  },
+  {
+    "measure_text": "163.Kommunala lokaler och anläggningar ska öka i nyttjandegrad och i högre utsträckning vara tillgängliga för användande.",
+    "activity": "facility utilisation",
+    "activity_shift_score": 3,
+    "activity_shifts": [
+      {
+        "activity": "using facilities",
+        "shift_from": "low utilisation",
+        "shift_to": "high utilisation",
+        "need": "space efficiency",
+        "type": "Utilisation Shift",
+        "type_reasoning": "The measure aims to increase the utilisation of municipal facilities.",
+        "score": 3,
+        "reasoning": "The measure implies a shift towards higher utilisation, but FROM and TO are not clearly defined.",
+        "transition_element_matches": [],
+        "transition_element_suggested_new": {
+          "short_label": "Increased Utilisation of Municipal Facilities",
+          "description": "Enhancing the utilisation rate of municipal buildings and facilities to improve space efficiency and reduce energy consumption per unit of use."
+        },
+        "transition_element_candidates": [
+          {
+            "stable_id": "energy_efficient_other_institutional_electric_appliances",
+            "short_label": "T-4B2c-TE-3 - Energy efficient public electrical appliances",
+            "description": "Energy efficient public electrical appliances. Reduce the amount of energy required to operate institutional electrical appliances. from: institutional unregulated electricity use. Buildings > Non Residential > Other Energy Usage > Other",
+            "sector_path": "Buildings > Non Residential > Other Energy Usage > Other",
+            "acts_on_labels": ["institutional unregulated electricity use"],
+            "shifts_to_labels": [],
+            "score": 0.4034
+          },
+          {
+            "stable_id": "shift_to_district_cooling_in_public_buildings",
+            "short_label": "T-4B1b-TE-2 - Shift to district cooling in public buildings",
+            "description": "Shift to district cooling in public buildings. Shift square meter from industrial building cooling with AC to industrial building cooling with district cooling in square meter to fulfill the need of comfortable premises. from: public building cooling with ac. to: public building cooling with district cooling. Buildings > Non Residential > Hvac > Institutional Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
+            "acts_on_labels": ["public building cooling with ac"],
+            "shifts_to_labels": [
+              "public building cooling with district cooling"
+            ],
+            "score": 0.3792
+          },
+          {
+            "stable_id": "efficient_use_multi_family_residential_buildings_cooling",
+            "short_label": "T-4A1a-TE-7 - Energy efficient use of ACs in multi-family buildings",
+            "description": "Energy efficient use of ACs in multi-family buildings. Reduce the amount of energy required to cool multi family buildings with AC through efficient use of AC units. from: multi family building cooling with ac. Buildings > Residential > Hvac > Multi Family Hvac",
+            "sector_path": "Buildings > Residential > Hvac > Multi Family Hvac",
+            "acts_on_labels": ["multi family building cooling with ac"],
+            "shifts_to_labels": [],
+            "score": 0.3731
+          },
+          {
+            "stable_id": "shift_to_district_cooling_in_multi_family_buildings",
+            "short_label": "T-4A1a-TE-3 - Shift to district cooling in multi-family buildings",
+            "description": "Shift to district cooling in multi-family buildings. Shift square meter from multi family building cooling with AC to multi family building cooling with district cooling in square meter to fulfill the need of comfortable premises. from: multi family building cooling with ac. to: multi family building cooling with district cooling. Buildings > Residential > Hvac > Multi Family Hvac",
+            "sector_path": "Buildings > Residential > Hvac > Multi Family Hvac",
+            "acts_on_labels": ["multi family building cooling with ac"],
+            "shifts_to_labels": [
+              "multi family building cooling with district cooling"
+            ],
+            "score": 0.3639
+          },
+          {
+            "stable_id": "energy_efficient_other_industrial_electric_appliances",
+            "short_label": "T-4B2c-TE-2 - Energy efficient industrial electrical appliances",
+            "description": "Energy efficient industrial electrical appliances. Reduce the amount of energy required to operate industrial electrical appliances. from: industrial unregulated electricity use. Buildings > Non Residential > Other Energy Usage > Other",
+            "sector_path": "Buildings > Non Residential > Other Energy Usage > Other",
+            "acts_on_labels": ["industrial unregulated electricity use"],
+            "shifts_to_labels": [],
+            "score": 0.3614
+          },
+          {
+            "stable_id": "shift_to_district_cooling_in_industrial_buildings",
+            "short_label": "T-4B1c-TE-2 - Shift to district cooling in industrial buildings",
+            "description": "Shift to district cooling in industrial buildings. Shift square meter from industrial building cooling with AC to industrial building cooling with district cooling in square meter to fulfill the need of comfortable premises. from: industrial building cooling with ac. to: industrial building cooling with district cooling. Buildings > Non Residential > Hvac > Other Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Other Hvac",
+            "acts_on_labels": ["industrial building cooling with ac"],
+            "shifts_to_labels": [
+              "industrial building cooling with district cooling"
+            ],
+            "score": 0.3613
+          },
+          {
+            "stable_id": "energy_efficient_multi_family_residential_buildings_cooling",
+            "short_label": "T-4A1a-TE-8 - Energy efficient AC in multi-family buildings",
+            "description": "Energy efficient AC in multi-family buildings. Reduce the amount of energy required to cool multi family buildings with AC through more efficient AC units. from: multi family building cooling with ac. Buildings > Residential > Hvac > Multi Family Hvac",
+            "sector_path": "Buildings > Residential > Hvac > Multi Family Hvac",
+            "acts_on_labels": ["multi family building cooling with ac"],
+            "shifts_to_labels": [],
+            "score": 0.3549
+          },
+          {
+            "stable_id": "energy_efficient_other_commercial_electric_appliances",
+            "short_label": "T-4B2c-TE-1 - Energy efficient commercial electrical appliances",
+            "description": "Energy efficient commercial electrical appliances. Reduce the amount of energy required to operate commercial electrical appliances. from: commercial unregulated electricity use. Buildings > Non Residential > Other Energy Usage > Other",
+            "sector_path": "Buildings > Non Residential > Other Energy Usage > Other",
+            "acts_on_labels": ["commercial unregulated electricity use"],
+            "shifts_to_labels": [],
+            "score": 0.3546
+          },
+          {
+            "stable_id": "energy_efficient_non_residential_public_buildings_retrofitting",
+            "short_label": "T-4B1b-TE-6 - Retrofitting public buildings for efficient heating",
+            "description": "Retrofitting public buildings for efficient heating. Reduce the amount of energy required to heat public building heating. from: public building heating with solid biofuels, public building heating with direct electric heaters, public building heating with gas, public building heating with propane, public building heating with oil, public building heating with heatpump, public building heating with district heating, public building heating with coal, public building heating with solar thermal, public building heating with lpg, public building heating with hydrogen, public building heating with gas oil. Buildings > Non Residential > Hvac > Institutional Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
+            "acts_on_labels": [
+              "public building heating with solid biofuels",
+              "public building heating with direct electric heaters",
+              "public building heating with gas",
+              "public building heating with propane",
+              "public building heating with oil",
+              "public building heating with heatpump",
+              "public building heating with district heating",
+              "public building heating with coal",
+              "public building heating with solar thermal",
+              "public building heating with lpg",
+              "public building heating with hydrogen",
+              "public building heating with gas oil"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.3531
+          },
+          {
+            "stable_id": "energy_efficient_non_residential_public_buildings_retrofitting_cooling",
+            "short_label": "T-4B1b-TE-7 - Retrofitting public buildings for efficient cooling",
+            "description": "Retrofitting public buildings for efficient cooling. Reduce the amount of energy required to cool public building with AC and disitrct cooling through retrofitting. from: public building cooling with ac, public building cooling with district cooling. Buildings > Non Residential > Hvac > Institutional Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Institutional Hvac",
+            "acts_on_labels": [
+              "public building cooling with ac",
+              "public building cooling with district cooling"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.3512
+          },
+          {
+            "stable_id": "shift_to_district_cooling_in_commercial_buildings",
+            "short_label": "T-4B1a-TE-2 - Shift to district cooling in commerical buildings",
+            "description": "Shift to district cooling in commerical buildings. Shift square meter from commerical building cooling with AC to commerical building cooling with district cooling in square meter to fulfill the need of comfortable premises. from: commercial building cooling with ac. to: commercial building cooling with district cooling. Buildings > Non Residential > Hvac > Commercial Hvac",
+            "sector_path": "Buildings > Non Residential > Hvac > Commercial Hvac",
+            "acts_on_labels": ["commercial building cooling with ac"],
+            "shifts_to_labels": [
+              "commercial building cooling with district cooling"
+            ],
+            "score": 0.3508
+          },
+          {
+            "stable_id": "efficient_use_single_family_residential_buildings_cooling",
+            "short_label": "T-4A1b-TE-7 - Energy efficient use of ACs in single-family buildings",
+            "description": "Energy efficient use of ACs in single-family buildings. Reduce the amount of energy required to cool single family buildings with AC through efficient use of AC units. from: single family building cooling with ac. Buildings > Residential > Hvac > Single Family Hvac",
+            "sector_path": "Buildings > Residential > Hvac > Single Family Hvac",
+            "acts_on_labels": ["single family building cooling with ac"],
+            "shifts_to_labels": [],
+            "score": 0.3491
+          },
+          {
+            "stable_id": "energy_efficient_street_lighting",
+            "short_label": "T-4B2a-TE-1 - Energy efficient street lighting",
+            "description": "Energy efficient street lighting. Reduce the amount of energy required to operate street lighting. from: institutional electric street lighting. Buildings > Non Residential > Other Energy Usage > Lighting",
+            "sector_path": "Buildings > Non Residential > Other Energy Usage > Lighting",
+            "acts_on_labels": ["institutional electric street lighting"],
+            "shifts_to_labels": [],
+            "score": 0.3473
+          },
+          {
+            "stable_id": "increased_energy_recovery_from_waste",
+            "short_label": "T-5A3-TE-6 - Increased energy recovery from waste",
+            "description": "Increased energy recovery from waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to CHP waste incineration in tonne to fulfill the need of warm premisses. from: incineration and open burning of waste. to: chp waste incineration. Energy > Energy Supply > Combined Heat Power",
+            "sector_path": "Energy > Energy Supply > Combined Heat Power",
+            "acts_on_labels": ["incineration and open burning of waste"],
+            "shifts_to_labels": ["chp waste incineration"],
+            "score": 0.3434
+          },
+          {
+            "stable_id": "low_carbon_construction_of_multi_family_residential_housing",
+            "short_label": "T-4C1-TE-2 - Low carbon construction of multi-family buildings",
+            "description": "Low carbon construction of multi-family buildings. Shift square meter from residential multi family standard construction to residential multi family low carbon construction in square meter to fulfill the need of housing. from: residential multi family standard construction. to: residential multi family low carbon construction. Buildings > Building Stocks > Construction",
+            "sector_path": "Buildings > Building Stocks > Construction",
+            "acts_on_labels": [
+              "residential multi family standard construction"
+            ],
+            "shifts_to_labels": [
+              "residential multi family low carbon construction"
+            ],
+            "score": 0.3421
+          },
+          {
+            "stable_id": "shift_to_commercial_electric_cooking_stoves",
+            "short_label": "T-4B2b-TE-1 - Shift to commercial electric cooking stoves",
+            "description": "Shift to commercial electric cooking stoves. Shift kWh from commercial cooking gas stoves to commercial electric cooking stoves in kWh to fullfill the need for cooking. from: commercial gas cooking stoves. to: commercial electric cooking stoves. Buildings > Non Residential > Other Energy Usage > Equipment Appliances",
+            "sector_path": "Buildings > Non Residential > Other Energy Usage > Equipment Appliances",
+            "acts_on_labels": ["commercial gas cooking stoves"],
+            "shifts_to_labels": ["commercial electric cooking stoves"],
+            "score": 0.3375
+          },
+          {
+            "stable_id": "improved_load_factor_heavy_trucks",
+            "short_label": "T-1B1b-TE-8 - Improved load factor for heavy trucks",
+            "description": "Improved load factor for heavy trucks. Reduce the amount of energy required to operate diesel heavy trucks through improved load factor. from: diesel heavy trucks, battery electric heavy trucks, hydrogen heavy trucks, gas heavy trucks, petrol heavy trucks. Transport > Freight > Road > Heavy Duty Trucks",
+            "sector_path": "Transport > Freight > Road > Heavy Duty Trucks",
+            "acts_on_labels": [
+              "diesel heavy trucks",
+              "battery electric heavy trucks",
+              "hydrogen heavy trucks",
+              "gas heavy trucks",
+              "petrol heavy trucks"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.3375
+          },
+          {
+            "stable_id": "shift_to_residential_electric_cooking_stoves",
+            "short_label": "T-4A2d-TE-2 - Shift to residential electric cooking stoves",
+            "description": "Shift to residential electric cooking stoves. Shift kWh from residential cooking gas stoves to residential electric cooking stoves in kWh to fullfill the need for cooking. from: residential gas cooking stoves. to: residential electric cooking stoves. Buildings > Residential > Other Energy Usage > Unregulated",
+            "sector_path": "Buildings > Residential > Other Energy Usage > Unregulated",
+            "acts_on_labels": ["residential gas cooking stoves"],
+            "shifts_to_labels": ["residential electric cooking stoves"],
+            "score": 0.3351
+          },
+          {
+            "stable_id": "transfer_from_car_to_remote_working",
+            "short_label": "T-1A1a-TE-8 - Shift from car to remote working",
+            "description": "Shift from car to remote working. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to remote working. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: remote working. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": [
+              "petrol vehicles",
+              "diesel vehicles",
+              "lpg vehicles",
+              "gas vehicles"
+            ],
+            "shifts_to_labels": ["remote working"],
+            "score": 0.3341
+          },
+          {
+            "stable_id": "shift_to_gas_vehicles",
+            "short_label": "T-1A1a-TE-19 - Shift to gas cars",
+            "description": "Shift to gas cars. Shift vehicle kilometer from petrol and diesel vehicles to gas vehicles in vehicle kilometer to fulfill the need of mobility. from: petrol vehicles, diesel vehicles. to: gas vehicles. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": ["petrol vehicles", "diesel vehicles"],
+            "shifts_to_labels": ["gas vehicles"],
+            "score": 0.3304
+          },
+          {
+            "stable_id": "shift_to_hydrogen_vehicles",
+            "short_label": "T-1A1a-TE-2 - Shift to hydrogen cars",
+            "description": "Shift to hydrogen cars. Shift vehicle kilometer from petrol and diesel vehicles to hydrogen vehicles in vehicle kilometer to fulfill the need of mobility. from: petrol vehicles, diesel vehicles. to: hydrogen vehicles. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": ["petrol vehicles", "diesel vehicles"],
+            "shifts_to_labels": ["hydrogen vehicles"],
+            "score": 0.3279
+          },
+          {
+            "stable_id": "transfer_from_heavy_truck_to_sea",
+            "short_label": "T-1B1b-TE-9 - Shift from heavy truck to sea",
+            "description": "Shift from heavy truck to sea. Shift tonne kilometer from diesel heavy trucks to ship freight in tonne kilometer to fulfill the need of logistics. from: diesel heavy trucks, petrol heavy trucks. to: ship freight. Transport > Freight > Road > Heavy Duty Trucks",
+            "sector_path": "Transport > Freight > Road > Heavy Duty Trucks",
+            "acts_on_labels": ["diesel heavy trucks", "petrol heavy trucks"],
+            "shifts_to_labels": ["ship freight"],
+            "score": 0.3268
+          },
+          {
+            "stable_id": "hydrogen_for_heavy_trucks",
+            "short_label": "T-1B1b-TE-4 - Shift to hydrogen for heavy trucks",
+            "description": "Shift to hydrogen for heavy trucks. Shift tonne kilometer from diesel heavy trucks to hydrogen heavy trucks in tonne kilometer to fulfill the need for logistics. from: diesel heavy trucks, petrol heavy trucks. to: hydrogen heavy trucks. Transport > Freight > Road > Heavy Duty Trucks",
+            "sector_path": "Transport > Freight > Road > Heavy Duty Trucks",
+            "acts_on_labels": ["diesel heavy trucks", "petrol heavy trucks"],
+            "shifts_to_labels": ["hydrogen heavy trucks"],
+            "score": 0.3257
+          },
+          {
+            "stable_id": "increased_proportion_of_non_travel_meetings_and_services",
+            "short_label": "T-1A1a-TE-7 - Shift to online meetings and services",
+            "description": "Shift to online meetings and services. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to e-meetings in hours to fulfill the need of business trips. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: e meetings. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": [
+              "petrol vehicles",
+              "diesel vehicles",
+              "lpg vehicles",
+              "gas vehicles"
+            ],
+            "shifts_to_labels": ["e meetings"],
+            "score": 0.3255
+          },
+          {
+            "stable_id": "gas_heavy_trucks",
+            "short_label": "T-1B1b-TE-1 - Shift to gas heavy trucks",
+            "description": "Shift to gas heavy trucks. Shift tonne kilometer from diesel heavy trucks to gas heavy trucks in tonne kilometer to fulfill the need of logistics. from: diesel heavy trucks, petrol heavy trucks. to: gas heavy trucks. Transport > Freight > Road > Heavy Duty Trucks",
+            "sector_path": "Transport > Freight > Road > Heavy Duty Trucks",
+            "acts_on_labels": ["diesel heavy trucks", "petrol heavy trucks"],
+            "shifts_to_labels": ["gas heavy trucks"],
+            "score": 0.3254
+          }
+        ]
+      }
+    ],
+    "intervention_who": "none",
+    "intervention_when": "none",
+    "intervention_what": "increase utilisation of facilities",
+    "intervention_how": "none",
+    "intervention_score": 2,
+    "intervention_reasoning": "WHAT is present, but lacks WHO, HOW, or WHEN.",
+    "intervention_type": "indirect"
+  },
+  {
+    "measure_text": "166.Kommunens samtliga verksamheter ska systematiskt arbeta för insatser som minimerar mängden avfall och ökar andelen återanvända produkter.",
+    "activity": "waste management",
+    "activity_shift_score": 5,
+    "activity_shifts": [
+      {
+        "activity": "managing waste",
+        "shift_from": "high waste generation",
+        "shift_to": "waste minimisation and reuse",
+        "need": "waste management",
+        "type": "Utilisation Shift",
+        "type_reasoning": "The measure focuses on reducing waste and increasing reuse, which is a change in utilisation of resources.",
+        "score": 5,
+        "reasoning": "The measure clearly identifies the activity (managing waste), the shift from high waste to minimisation and reuse, and the need (waste management).",
+        "transition_element_matches": [],
+        "transition_element_candidates": [
+          {
+            "stable_id": "increased_recycling",
+            "short_label": "T-6A1-TE-1 - Shift to recycling of solid waste",
+            "description": "Shift to recycling of solid waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to recycling of solid waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: recycling of solid waste. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc",
+              "incineration and open burning of waste",
+              "open burning of waste",
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "shifts_to_labels": ["recycling of solid waste"],
+            "score": 0.6177
+          },
+          {
+            "stable_id": "shift_to_composting_of_organic_waste",
+            "short_label": "T-6A1-TE-2 - Shift to composting of organic waste",
+            "description": "Shift to composting of organic waste. Shift tonne from solid waste disposal in landfills to composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: composting of organic waste. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc",
+              "incineration and open burning of waste",
+              "open burning of waste",
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "shifts_to_labels": ["composting of organic waste"],
+            "score": 0.5812
+          },
+          {
+            "stable_id": "shift_to_exported_composting_of_organic_waste",
+            "short_label": "T-6A1-TE-3 - Shift to exported composting of organic waste",
+            "description": "Shift to exported composting of organic waste. Shift tonne from solid waste disposal in landfills to exported composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: waste exported for composting. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc",
+              "incineration and open burning of waste",
+              "open burning of waste",
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "shifts_to_labels": ["waste exported for composting"],
+            "score": 0.5415
+          },
+          {
+            "stable_id": "shift_to_landfill_gas_recovery",
+            "short_label": "T-6A1-TE-4 - Shift to landfill gas recovery",
+            "description": "Shift to landfill gas recovery. Shift tonne from solid waste disposal in landfills without gas recovery to solid waste disposal in landfills with landfill gas recovery in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc. to: solid waste disposal landfill with gas recovery. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc"
+            ],
+            "shifts_to_labels": [
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "score": 0.5356
+          },
+          {
+            "stable_id": "increased_energy_recovery_from_waste",
+            "short_label": "T-5A3-TE-6 - Increased energy recovery from waste",
+            "description": "Increased energy recovery from waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to CHP waste incineration in tonne to fulfill the need of warm premisses. from: incineration and open burning of waste. to: chp waste incineration. Energy > Energy Supply > Combined Heat Power",
+            "sector_path": "Energy > Energy Supply > Combined Heat Power",
+            "acts_on_labels": ["incineration and open burning of waste"],
+            "shifts_to_labels": ["chp waste incineration"],
+            "score": 0.5094
+          },
+          {
+            "stable_id": "biofuels_for_cement_and_mineral_industry",
+            "short_label": "T-2A1-TE-1 - Shift to use biofuel in cement and mineral industry",
+            "description": "Shift to use biofuel in cement and mineral industry. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: cement mineral industries coal usage. to: cement mineral industries biomass usage. Industry > Minerals > Cement",
+            "sector_path": "Industry > Minerals > Cement",
+            "acts_on_labels": ["cement mineral industries coal usage"],
+            "shifts_to_labels": ["cement mineral industries biomass usage"],
+            "score": 0.4456
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_glass_industries",
+            "short_label": "T-2A3-TE-1 - Shift to biogas energy in glass industries",
+            "description": "Shift to biogas energy in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within glass industries. to: biogas usage within glass industries. Industry > Minerals > Glass Production",
+            "sector_path": "Industry > Minerals > Glass Production",
+            "acts_on_labels": ["natural gas usage within glass industries"],
+            "shifts_to_labels": ["biogas usage within glass industries"],
+            "score": 0.4404
+          },
+          {
+            "stable_id": "shift_to_biomass_energy_in_glass_industries",
+            "short_label": "T-2A3-TE-2 - Shift to biomass energy in glass industries",
+            "description": "Shift to biomass energy in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within glass industries. to: biomass usage within glass industries. Industry > Minerals > Glass Production",
+            "sector_path": "Industry > Minerals > Glass Production",
+            "acts_on_labels": ["coal usage within glass industries"],
+            "shifts_to_labels": ["biomass usage within glass industries"],
+            "score": 0.4337
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_lead_industries",
+            "short_label": "T-2C5-TE-1 - Shift to biogas energy in lead industries",
+            "description": "Shift to biogas energy in lead industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within lead industries. to: biogas usage within lead industries. Industry > Metals > Lead",
+            "sector_path": "Industry > Metals > Lead",
+            "acts_on_labels": ["natural gas usage within lead industries"],
+            "shifts_to_labels": ["biogas usage within lead industries"],
+            "score": 0.4282
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_chemical_industries",
+            "short_label": "T-2B9-TE-1 - Shift to biogas energy in chemical industries",
+            "description": "Shift to biogas energy in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within chemical industries. to: biogas usage within chemical industries. Industry > Chemicals > Other",
+            "sector_path": "Industry > Chemicals > Other",
+            "acts_on_labels": ["natural gas usage within chemical industries"],
+            "shifts_to_labels": ["biogas usage within chemical industries"],
+            "score": 0.426
+          },
+          {
+            "stable_id": "chp_waste_incineration",
+            "short_label": "T-5A3-TE-4 - CHP from waste incineration",
+            "description": "CHP from waste incineration. Alter the amount of district heat and electricity produced by CHP waste incineration. from: chp waste incineration. Energy > Energy Supply > Combined Heat Power",
+            "sector_path": "Energy > Energy Supply > Combined Heat Power",
+            "acts_on_labels": ["chp waste incineration"],
+            "shifts_to_labels": [],
+            "score": 0.4061
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_pulp_paper_and_print_industries",
+            "short_label": "T-2D1b-TE-1 - Shift to biogas energy in pulp, paper and print industries",
+            "description": "Shift to biogas energy in pulp, paper and print industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within pulp paper and print industries. to: biogas usage within pulp paper and print industries. Industry > Other > Manufacturing > Pulp Paper Print",
+            "sector_path": "Industry > Other > Manufacturing > Pulp Paper Print",
+            "acts_on_labels": [
+              "natural gas usage within pulp paper and print industries"
+            ],
+            "shifts_to_labels": [
+              "biogas usage within pulp paper and print industries"
+            ],
+            "score": 0.3677
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_hydrogen_refinement",
+            "short_label": "T-5B4-TE-3 - Shift to biogas energy in hydrogen refinement",
+            "description": "Shift to biogas energy in hydrogen refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within hydrogen refinement. to: biogas usage within hydrogen refinement. Energy > Energy Transformation > Hydrogen Refinement",
+            "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
+            "acts_on_labels": ["natural gas usage within hydrogen refinement"],
+            "shifts_to_labels": ["biogas usage within hydrogen refinement"],
+            "score": 0.3646
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_other_industries",
+            "short_label": "T-2D5-TE-2 - Shift to biogas energy in other industries",
+            "description": "Shift to biogas energy in other industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: industrial unregulated gas use. to: industrial unregulated biogas use. Industry > Other > Other",
+            "sector_path": "Industry > Other > Other",
+            "acts_on_labels": ["industrial unregulated gas use"],
+            "shifts_to_labels": ["industrial unregulated biogas use"],
+            "score": 0.358
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_magnesium_industries",
+            "short_label": "T-2C4-TE-2 - Shift to biogas energy in magnesium industries",
+            "description": "Shift to biogas energy in magnesium industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within magnesium industries. to: biogas usage within magnesium industries. Industry > Metals > Magnesium",
+            "sector_path": "Industry > Metals > Magnesium",
+            "acts_on_labels": ["natural gas usage within magnesium industries"],
+            "shifts_to_labels": ["biogas usage within magnesium industries"],
+            "score": 0.3525
+          }
+        ]
+      }
+    ],
+    "intervention_who": "kommunens samtliga verksamheter",
+    "intervention_when": "none",
+    "intervention_what": "systematically work to minimise waste",
+    "intervention_how": "none",
+    "intervention_score": 3,
+    "intervention_reasoning": "WHO and WHAT are present, but lacks HOW or WHEN.",
+    "intervention_type": "indirect"
+  },
+  {
+    "measure_text": "167.Nedskräpningen ska minska med 5 procent årligen.",
+    "activity": "litter management",
+    "activity_shift_score": 3,
+    "activity_shifts": [
+      {
+        "activity": "managing litter",
+        "shift_from": "current litter levels",
+        "shift_to": "reduced litter levels",
+        "need": "waste management",
+        "type": "Utilisation Shift",
+        "type_reasoning": "The measure aims to reduce litter, which is a change in utilisation of resources.",
+        "score": 3,
+        "reasoning": "The measure implies a shift towards reduced litter, but FROM and TO are not clearly defined.",
+        "transition_element_matches": [],
+        "transition_element_suggested_new": {
+          "short_label": "Improved Waste Management Practices",
+          "description": "Implement measures to reduce littering by enhancing waste management systems, increasing public awareness, and enforcing stricter regulations on littering."
+        },
+        "transition_element_candidates": [
+          {
+            "stable_id": "increased_recycling",
+            "short_label": "T-6A1-TE-1 - Shift to recycling of solid waste",
+            "description": "Shift to recycling of solid waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to recycling of solid waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: recycling of solid waste. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc",
+              "incineration and open burning of waste",
+              "open burning of waste",
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "shifts_to_labels": ["recycling of solid waste"],
+            "score": 0.5494
+          },
+          {
+            "stable_id": "shift_to_composting_of_organic_waste",
+            "short_label": "T-6A1-TE-2 - Shift to composting of organic waste",
+            "description": "Shift to composting of organic waste. Shift tonne from solid waste disposal in landfills to composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: composting of organic waste. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc",
+              "incineration and open burning of waste",
+              "open burning of waste",
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "shifts_to_labels": ["composting of organic waste"],
+            "score": 0.5401
+          },
+          {
+            "stable_id": "shift_to_landfill_gas_recovery",
+            "short_label": "T-6A1-TE-4 - Shift to landfill gas recovery",
+            "description": "Shift to landfill gas recovery. Shift tonne from solid waste disposal in landfills without gas recovery to solid waste disposal in landfills with landfill gas recovery in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc. to: solid waste disposal landfill with gas recovery. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc"
+            ],
+            "shifts_to_labels": [
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "score": 0.5231
+          },
+          {
+            "stable_id": "shift_to_exported_composting_of_organic_waste",
+            "short_label": "T-6A1-TE-3 - Shift to exported composting of organic waste",
+            "description": "Shift to exported composting of organic waste. Shift tonne from solid waste disposal in landfills to exported composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: waste exported for composting. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc",
+              "incineration and open burning of waste",
+              "open burning of waste",
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "shifts_to_labels": ["waste exported for composting"],
+            "score": 0.5139
+          },
+          {
+            "stable_id": "increased_energy_recovery_from_waste",
+            "short_label": "T-5A3-TE-6 - Increased energy recovery from waste",
+            "description": "Increased energy recovery from waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to CHP waste incineration in tonne to fulfill the need of warm premisses. from: incineration and open burning of waste. to: chp waste incineration. Energy > Energy Supply > Combined Heat Power",
+            "sector_path": "Energy > Energy Supply > Combined Heat Power",
+            "acts_on_labels": ["incineration and open burning of waste"],
+            "shifts_to_labels": ["chp waste incineration"],
+            "score": 0.4339
+          },
+          {
+            "stable_id": "increased_proportion_of_walking_and_cycling",
+            "short_label": "T-1A1a-TE-10 - Shift to walking and cycling",
+            "description": "Shift to walking and cycling. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to walking cycling. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: walking cycling. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": [
+              "petrol vehicles",
+              "diesel vehicles",
+              "lpg vehicles",
+              "gas vehicles"
+            ],
+            "shifts_to_labels": ["walking cycling"],
+            "score": 0.4102
+          },
+          {
+            "stable_id": "increased_proportion_of_public_transport_by_lpg_bus",
+            "short_label": "T-1A1a-TE-14 - Shift to travel by LPG bus",
+            "description": "Shift to travel by LPG bus. Shift vehicle kilometer from petrol and diesel vehicles to LPG buses. from: petrol vehicles, diesel vehicles. to: lpg buses. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": ["petrol vehicles", "diesel vehicles"],
+            "shifts_to_labels": ["lpg buses"],
+            "score": 0.3896
+          },
+          {
+            "stable_id": "shift_to_sustainable_healthy_diet",
+            "short_label": "T-3A1-TE-1 - Shift to Sustainable Healthy Diets",
+            "description": "Shift to Sustainable Healthy Diets. This Transition Element is the shift from animal based diets to plant based diets.. from: enteric fermentation cattle, enteric fermentation sheep, enteric fermentation swine, enteric fermentation other livestock. Afolu > Livestock > Enteric Fermentation",
+            "sector_path": "Afolu > Livestock > Enteric Fermentation",
+            "acts_on_labels": [
+              "enteric fermentation cattle",
+              "enteric fermentation sheep",
+              "enteric fermentation swine",
+              "enteric fermentation other livestock"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.3871
+          },
+          {
+            "stable_id": "transfer_from_car_to_remote_working",
+            "short_label": "T-1A1a-TE-8 - Shift from car to remote working",
+            "description": "Shift from car to remote working. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to remote working. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: remote working. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": [
+              "petrol vehicles",
+              "diesel vehicles",
+              "lpg vehicles",
+              "gas vehicles"
+            ],
+            "shifts_to_labels": ["remote working"],
+            "score": 0.386
+          },
+          {
+            "stable_id": "shift_to_electric_bikes",
+            "short_label": "T-1A1a-TE-11 - Shift to electric bikes",
+            "description": "Shift to electric bikes. Shift vehicle kilometer from petrol,diesel and LPG vehicles to electric bike in vehicle kilometer to fulfill the need of mobility. from: petrol vehicles, diesel vehicles, lpg vehicles. to: electric bikes. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": [
+              "petrol vehicles",
+              "diesel vehicles",
+              "lpg vehicles"
+            ],
+            "shifts_to_labels": ["electric bikes"],
+            "score": 0.3843
+          },
+          {
+            "stable_id": "chp_waste_incineration",
+            "short_label": "T-5A3-TE-4 - CHP from waste incineration",
+            "description": "CHP from waste incineration. Alter the amount of district heat and electricity produced by CHP waste incineration. from: chp waste incineration. Energy > Energy Supply > Combined Heat Power",
+            "sector_path": "Energy > Energy Supply > Combined Heat Power",
+            "acts_on_labels": ["chp waste incineration"],
+            "shifts_to_labels": [],
+            "score": 0.3153
+          },
+          {
+            "stable_id": "improved_urban_planning",
+            "short_label": "T-1A1a-TE-22 - Improved urban planning",
+            "description": "Improved urban planning. Reduce the amount of vehicle kilometer from cars to fulfill the need of mobility through improved urban planning. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles, lng vehicles, hydrogen vehicles, battery electric vehicles. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": [
+              "petrol vehicles",
+              "diesel vehicles",
+              "lpg vehicles",
+              "gas vehicles",
+              "lng vehicles",
+              "hydrogen vehicles",
+              "battery electric vehicles"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.3111
+          },
+          {
+            "stable_id": "energy_efficient_street_lighting",
+            "short_label": "T-4B2a-TE-1 - Energy efficient street lighting",
+            "description": "Energy efficient street lighting. Reduce the amount of energy required to operate street lighting. from: institutional electric street lighting. Buildings > Non Residential > Other Energy Usage > Lighting",
+            "sector_path": "Buildings > Non Residential > Other Energy Usage > Lighting",
+            "acts_on_labels": ["institutional electric street lighting"],
+            "shifts_to_labels": [],
+            "score": 0.2977
+          },
+          {
+            "stable_id": "improved_load_factor_light_trucks",
+            "short_label": "T-1B1a-TE-9 - Improved load factor for light trucks",
+            "description": "Improved load factor for light trucks. Reduce the amount of vehicle kilometer from diesel light trucks to fulfill the need of logistics through improving the load factor. from: diesel light trucks, hydrogen light trucks, battery electric light trucks, petrol light trucks, gas light trucks. Transport > Freight > Road > Light Duty Trucks",
+            "sector_path": "Transport > Freight > Road > Light Duty Trucks",
+            "acts_on_labels": [
+              "diesel light trucks",
+              "hydrogen light trucks",
+              "battery electric light trucks",
+              "petrol light trucks",
+              "gas light trucks"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.2969
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_lead_industries",
+            "short_label": "T-2C5-TE-1 - Shift to biogas energy in lead industries",
+            "description": "Shift to biogas energy in lead industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within lead industries. to: biogas usage within lead industries. Industry > Metals > Lead",
+            "sector_path": "Industry > Metals > Lead",
+            "acts_on_labels": ["natural gas usage within lead industries"],
+            "shifts_to_labels": ["biogas usage within lead industries"],
+            "score": 0.2959
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_glass_industries",
+            "short_label": "T-2A3-TE-1 - Shift to biogas energy in glass industries",
+            "description": "Shift to biogas energy in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within glass industries. to: biogas usage within glass industries. Industry > Minerals > Glass Production",
+            "sector_path": "Industry > Minerals > Glass Production",
+            "acts_on_labels": ["natural gas usage within glass industries"],
+            "shifts_to_labels": ["biogas usage within glass industries"],
+            "score": 0.282
+          },
+          {
+            "stable_id": "more_efficient_commuting_by_car",
+            "short_label": "T-1A1a-TE-5 - Increase journey sharing",
+            "description": "Increase journey sharing. Reduce the number of vehicle kilometers from petrol, diesel, lpg and natural gas vehicles to fulfill the need of commuting through more efficient commuting by car. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles, battery electric vehicles, hydrogen vehicles. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": [
+              "petrol vehicles",
+              "diesel vehicles",
+              "lpg vehicles",
+              "gas vehicles",
+              "battery electric vehicles",
+              "hydrogen vehicles"
+            ],
+            "shifts_to_labels": [],
+            "score": 0.2766
+          }
+        ]
+      }
+    ],
+    "intervention_who": "none",
+    "intervention_when": "annually",
+    "intervention_what": "reduce litter",
+    "intervention_how": "none",
+    "intervention_score": 3,
+    "intervention_reasoning": "WHAT and WHEN are present, but lacks WHO or HOW.",
+    "intervention_type": "indirect"
+  },
+  {
+    "measure_text": "168.65 procent avfall från hushåll ska materialåtervinnas eller förberedas för återanvändning.",
+    "activity": "waste management",
+    "activity_shift_score": 4,
+    "activity_shifts": [
+      {
+        "activity": "managing household waste",
+        "shift_from": "landfilling or incineration",
+        "shift_to": "recycling or reuse",
+        "need": "waste management",
+        "type": "Utilisation Shift",
+        "type_reasoning": "The measure focuses on increasing recycling and reuse, which is a change in utilisation of waste resources.",
+        "score": 4,
+        "reasoning": "The measure implies a shift towards recycling and reuse, but FROM and TO are not explicitly named.",
+        "transition_element_matches": [
+          {
+            "stable_id": "increased_recycling",
+            "short_label": "T-6A1-TE-1 - Shift to recycling of solid waste",
+            "description": "Shift to recycling of solid waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to recycling of solid waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: recycling of solid waste. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc",
+              "incineration and open burning of waste",
+              "open burning of waste",
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "shifts_to_labels": ["recycling of solid waste"],
+            "score": 0.6829,
+            "match_reasoning": "acts_on=yes, shifts_to=yes, confidence=high",
+            "match_confidence": "high"
+          },
+          {
+            "stable_id": "shift_to_composting_of_organic_waste",
+            "short_label": "T-6A1-TE-2 - Shift to composting of organic waste",
+            "description": "Shift to composting of organic waste. Shift tonne from solid waste disposal in landfills to composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: composting of organic waste. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc",
+              "incineration and open burning of waste",
+              "open burning of waste",
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "shifts_to_labels": ["composting of organic waste"],
+            "score": 0.5957,
+            "match_reasoning": "acts_on=yes, shifts_to=no, confidence=mid",
+            "match_confidence": "mid"
+          },
+          {
+            "stable_id": "shift_to_exported_composting_of_organic_waste",
+            "short_label": "T-6A1-TE-3 - Shift to exported composting of organic waste",
+            "description": "Shift to exported composting of organic waste. Shift tonne from solid waste disposal in landfills to exported composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: waste exported for composting. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc",
+              "incineration and open burning of waste",
+              "open burning of waste",
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "shifts_to_labels": ["waste exported for composting"],
+            "score": 0.5663,
+            "match_reasoning": "acts_on=yes, shifts_to=no, confidence=mid",
+            "match_confidence": "mid"
+          },
+          {
+            "stable_id": "shift_to_landfill_gas_recovery",
+            "short_label": "T-6A1-TE-4 - Shift to landfill gas recovery",
+            "description": "Shift to landfill gas recovery. Shift tonne from solid waste disposal in landfills without gas recovery to solid waste disposal in landfills with landfill gas recovery in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc. to: solid waste disposal landfill with gas recovery. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc"
+            ],
+            "shifts_to_labels": [
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "score": 0.565,
+            "match_reasoning": "acts_on=yes, shifts_to=no, confidence=mid",
+            "match_confidence": "mid"
+          },
+          {
+            "stable_id": "increased_energy_recovery_from_waste",
+            "short_label": "T-5A3-TE-6 - Increased energy recovery from waste",
+            "description": "Increased energy recovery from waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to CHP waste incineration in tonne to fulfill the need of warm premisses. from: incineration and open burning of waste. to: chp waste incineration. Energy > Energy Supply > Combined Heat Power",
+            "sector_path": "Energy > Energy Supply > Combined Heat Power",
+            "acts_on_labels": ["incineration and open burning of waste"],
+            "shifts_to_labels": ["chp waste incineration"],
+            "score": 0.5241,
+            "match_reasoning": "acts_on=yes, shifts_to=no, confidence=mid",
+            "match_confidence": "mid"
+          }
+        ],
+        "transition_element_candidates": [
+          {
+            "stable_id": "increased_recycling",
+            "short_label": "T-6A1-TE-1 - Shift to recycling of solid waste",
+            "description": "Shift to recycling of solid waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to recycling of solid waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: recycling of solid waste. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc",
+              "incineration and open burning of waste",
+              "open burning of waste",
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "shifts_to_labels": ["recycling of solid waste"],
+            "score": 0.6829
+          },
+          {
+            "stable_id": "shift_to_composting_of_organic_waste",
+            "short_label": "T-6A1-TE-2 - Shift to composting of organic waste",
+            "description": "Shift to composting of organic waste. Shift tonne from solid waste disposal in landfills to composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: composting of organic waste. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc",
+              "incineration and open burning of waste",
+              "open burning of waste",
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "shifts_to_labels": ["composting of organic waste"],
+            "score": 0.5957
+          },
+          {
+            "stable_id": "shift_to_exported_composting_of_organic_waste",
+            "short_label": "T-6A1-TE-3 - Shift to exported composting of organic waste",
+            "description": "Shift to exported composting of organic waste. Shift tonne from solid waste disposal in landfills to exported composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: waste exported for composting. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc",
+              "incineration and open burning of waste",
+              "open burning of waste",
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "shifts_to_labels": ["waste exported for composting"],
+            "score": 0.5663
+          },
+          {
+            "stable_id": "shift_to_landfill_gas_recovery",
+            "short_label": "T-6A1-TE-4 - Shift to landfill gas recovery",
+            "description": "Shift to landfill gas recovery. Shift tonne from solid waste disposal in landfills without gas recovery to solid waste disposal in landfills with landfill gas recovery in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc. to: solid waste disposal landfill with gas recovery. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc"
+            ],
+            "shifts_to_labels": [
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "score": 0.565
+          },
+          {
+            "stable_id": "increased_energy_recovery_from_waste",
+            "short_label": "T-5A3-TE-6 - Increased energy recovery from waste",
+            "description": "Increased energy recovery from waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to CHP waste incineration in tonne to fulfill the need of warm premisses. from: incineration and open burning of waste. to: chp waste incineration. Energy > Energy Supply > Combined Heat Power",
+            "sector_path": "Energy > Energy Supply > Combined Heat Power",
+            "acts_on_labels": ["incineration and open burning of waste"],
+            "shifts_to_labels": ["chp waste incineration"],
+            "score": 0.5241
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_lead_industries",
+            "short_label": "T-2C5-TE-1 - Shift to biogas energy in lead industries",
+            "description": "Shift to biogas energy in lead industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within lead industries. to: biogas usage within lead industries. Industry > Metals > Lead",
+            "sector_path": "Industry > Metals > Lead",
+            "acts_on_labels": ["natural gas usage within lead industries"],
+            "shifts_to_labels": ["biogas usage within lead industries"],
+            "score": 0.4489
+          },
+          {
+            "stable_id": "shift_to_biomass_energy_in_magnesium_industries",
+            "short_label": "T-2C4-TE-3 - Shift to biomass energy in magnesium industries",
+            "description": "Shift to biomass energy in magnesium industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within magnesium industries. to: biomass usage within magnesium industries. Industry > Metals > Magnesium",
+            "sector_path": "Industry > Metals > Magnesium",
+            "acts_on_labels": ["coal usage within magnesium industries"],
+            "shifts_to_labels": ["biomass usage within magnesium industries"],
+            "score": 0.4481
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_magnesium_industries",
+            "short_label": "T-2C4-TE-2 - Shift to biogas energy in magnesium industries",
+            "description": "Shift to biogas energy in magnesium industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within magnesium industries. to: biogas usage within magnesium industries. Industry > Metals > Magnesium",
+            "sector_path": "Industry > Metals > Magnesium",
+            "acts_on_labels": ["natural gas usage within magnesium industries"],
+            "shifts_to_labels": ["biogas usage within magnesium industries"],
+            "score": 0.4453
+          },
+          {
+            "stable_id": "shift_to_biomass_energy_in_glass_industries",
+            "short_label": "T-2A3-TE-2 - Shift to biomass energy in glass industries",
+            "description": "Shift to biomass energy in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within glass industries. to: biomass usage within glass industries. Industry > Minerals > Glass Production",
+            "sector_path": "Industry > Minerals > Glass Production",
+            "acts_on_labels": ["coal usage within glass industries"],
+            "shifts_to_labels": ["biomass usage within glass industries"],
+            "score": 0.4446
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_glass_industries",
+            "short_label": "T-2A3-TE-1 - Shift to biogas energy in glass industries",
+            "description": "Shift to biogas energy in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within glass industries. to: biogas usage within glass industries. Industry > Minerals > Glass Production",
+            "sector_path": "Industry > Minerals > Glass Production",
+            "acts_on_labels": ["natural gas usage within glass industries"],
+            "shifts_to_labels": ["biogas usage within glass industries"],
+            "score": 0.4437
+          },
+          {
+            "stable_id": "chp_waste_incineration",
+            "short_label": "T-5A3-TE-4 - CHP from waste incineration",
+            "description": "CHP from waste incineration. Alter the amount of district heat and electricity produced by CHP waste incineration. from: chp waste incineration. Energy > Energy Supply > Combined Heat Power",
+            "sector_path": "Energy > Energy Supply > Combined Heat Power",
+            "acts_on_labels": ["chp waste incineration"],
+            "shifts_to_labels": [],
+            "score": 0.4146
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_other_industries",
+            "short_label": "T-2D5-TE-2 - Shift to biogas energy in other industries",
+            "description": "Shift to biogas energy in other industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: industrial unregulated gas use. to: industrial unregulated biogas use. Industry > Other > Other",
+            "sector_path": "Industry > Other > Other",
+            "acts_on_labels": ["industrial unregulated gas use"],
+            "shifts_to_labels": ["industrial unregulated biogas use"],
+            "score": 0.3707
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_iron_and_steel_industries",
+            "short_label": "T-2C1-TE-1 - Shift to biogas energy in iron and steel industries",
+            "description": "Shift to biogas energy in iron and steel industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within iron and steel industries. to: biogas usage within iron and steel industries. Industry > Metals > Iron Steel",
+            "sector_path": "Industry > Metals > Iron Steel",
+            "acts_on_labels": [
+              "natural gas usage within iron and steel industries"
+            ],
+            "shifts_to_labels": [
+              "biogas usage within iron and steel industries"
+            ],
+            "score": 0.3583
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_pulp_paper_and_print_industries",
+            "short_label": "T-2D1b-TE-1 - Shift to biogas energy in pulp, paper and print industries",
+            "description": "Shift to biogas energy in pulp, paper and print industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within pulp paper and print industries. to: biogas usage within pulp paper and print industries. Industry > Other > Manufacturing > Pulp Paper Print",
+            "sector_path": "Industry > Other > Manufacturing > Pulp Paper Print",
+            "acts_on_labels": [
+              "natural gas usage within pulp paper and print industries"
+            ],
+            "shifts_to_labels": [
+              "biogas usage within pulp paper and print industries"
+            ],
+            "score": 0.3571
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_hydrogen_refinement",
+            "short_label": "T-5B4-TE-3 - Shift to biogas energy in hydrogen refinement",
+            "description": "Shift to biogas energy in hydrogen refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within hydrogen refinement. to: biogas usage within hydrogen refinement. Energy > Energy Transformation > Hydrogen Refinement",
+            "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
+            "acts_on_labels": ["natural gas usage within hydrogen refinement"],
+            "shifts_to_labels": ["biogas usage within hydrogen refinement"],
+            "score": 0.3549
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_chemical_industries",
+            "short_label": "T-2B9-TE-1 - Shift to biogas energy in chemical industries",
+            "description": "Shift to biogas energy in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within chemical industries. to: biogas usage within chemical industries. Industry > Chemicals > Other",
+            "sector_path": "Industry > Chemicals > Other",
+            "acts_on_labels": ["natural gas usage within chemical industries"],
+            "shifts_to_labels": ["biogas usage within chemical industries"],
+            "score": 0.3538
+          },
+          {
+            "stable_id": "biogas_in_methane_reforming_for_hydrogen_production",
+            "short_label": "T-5B4-TE-1 - Biogas in methane reforming for hydrogen production",
+            "description": "Biogas in methane reforming for hydrogen production. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: reforming of methane for hydrogen production. Energy > Energy Transformation > Hydrogen Refinement",
+            "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
+            "acts_on_labels": ["reforming of methane for hydrogen production"],
+            "shifts_to_labels": [],
+            "score": 0.3469
+          }
+        ]
+      }
+    ],
+    "intervention_who": "none",
+    "intervention_when": "none",
+    "intervention_what": "increase recycling and reuse",
+    "intervention_how": "none",
+    "intervention_score": 2,
+    "intervention_reasoning": "WHAT is present, but lacks WHO, HOW, or WHEN.",
+    "intervention_type": "indirect"
+  },
+  {
+    "measure_text": "169.Mat- och restavfallet ska vara max 130 kg per person och år.",
+    "activity": "waste management",
+    "activity_shift_score": 3,
+    "activity_shifts": [
+      {
+        "activity": "managing food and residual waste",
+        "shift_from": "high waste generation",
+        "shift_to": "reduced waste generation",
+        "need": "waste management",
+        "type": "Utilisation Shift",
+        "type_reasoning": "The measure focuses on reducing food and residual waste, which is a change in utilisation of resources.",
+        "score": 3,
+        "reasoning": "The measure implies a shift towards reduced waste, but FROM and TO are not clearly defined.",
+        "transition_element_matches": [
+          {
+            "stable_id": "increased_recycling",
+            "short_label": "T-6A1-TE-1 - Shift to recycling of solid waste",
+            "description": "Shift to recycling of solid waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to recycling of solid waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: recycling of solid waste. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc",
+              "incineration and open burning of waste",
+              "open burning of waste",
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "shifts_to_labels": ["recycling of solid waste"],
+            "score": 0.6143,
+            "match_reasoning": "acts_on=yes, shifts_to=no, confidence=mid",
+            "match_confidence": "mid"
+          },
+          {
+            "stable_id": "shift_to_composting_of_organic_waste",
+            "short_label": "T-6A1-TE-2 - Shift to composting of organic waste",
+            "description": "Shift to composting of organic waste. Shift tonne from solid waste disposal in landfills to composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: composting of organic waste. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc",
+              "incineration and open burning of waste",
+              "open burning of waste",
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "shifts_to_labels": ["composting of organic waste"],
+            "score": 0.5875,
+            "match_reasoning": "acts_on=yes, shifts_to=yes, confidence=high",
+            "match_confidence": "high"
+          },
+          {
+            "stable_id": "shift_to_landfill_gas_recovery",
+            "short_label": "T-6A1-TE-4 - Shift to landfill gas recovery",
+            "description": "Shift to landfill gas recovery. Shift tonne from solid waste disposal in landfills without gas recovery to solid waste disposal in landfills with landfill gas recovery in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc. to: solid waste disposal landfill with gas recovery. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc"
+            ],
+            "shifts_to_labels": [
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "score": 0.5632,
+            "match_reasoning": "acts_on=yes, shifts_to=no, confidence=mid",
+            "match_confidence": "mid"
+          },
+          {
+            "stable_id": "shift_to_exported_composting_of_organic_waste",
+            "short_label": "T-6A1-TE-3 - Shift to exported composting of organic waste",
+            "description": "Shift to exported composting of organic waste. Shift tonne from solid waste disposal in landfills to exported composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: waste exported for composting. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc",
+              "incineration and open burning of waste",
+              "open burning of waste",
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "shifts_to_labels": ["waste exported for composting"],
+            "score": 0.5574,
+            "match_reasoning": "acts_on=yes, shifts_to=yes, confidence=mid",
+            "match_confidence": "mid"
+          }
+        ],
+        "transition_element_candidates": [
+          {
+            "stable_id": "increased_recycling",
+            "short_label": "T-6A1-TE-1 - Shift to recycling of solid waste",
+            "description": "Shift to recycling of solid waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to recycling of solid waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: recycling of solid waste. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc",
+              "incineration and open burning of waste",
+              "open burning of waste",
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "shifts_to_labels": ["recycling of solid waste"],
+            "score": 0.6143
+          },
+          {
+            "stable_id": "shift_to_composting_of_organic_waste",
+            "short_label": "T-6A1-TE-2 - Shift to composting of organic waste",
+            "description": "Shift to composting of organic waste. Shift tonne from solid waste disposal in landfills to composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: composting of organic waste. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc",
+              "incineration and open burning of waste",
+              "open burning of waste",
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "shifts_to_labels": ["composting of organic waste"],
+            "score": 0.5875
+          },
+          {
+            "stable_id": "shift_to_landfill_gas_recovery",
+            "short_label": "T-6A1-TE-4 - Shift to landfill gas recovery",
+            "description": "Shift to landfill gas recovery. Shift tonne from solid waste disposal in landfills without gas recovery to solid waste disposal in landfills with landfill gas recovery in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc. to: solid waste disposal landfill with gas recovery. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc"
+            ],
+            "shifts_to_labels": [
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "score": 0.5632
+          },
+          {
+            "stable_id": "shift_to_exported_composting_of_organic_waste",
+            "short_label": "T-6A1-TE-3 - Shift to exported composting of organic waste",
+            "description": "Shift to exported composting of organic waste. Shift tonne from solid waste disposal in landfills to exported composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: waste exported for composting. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc",
+              "incineration and open burning of waste",
+              "open burning of waste",
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "shifts_to_labels": ["waste exported for composting"],
+            "score": 0.5574
+          },
+          {
+            "stable_id": "increased_energy_recovery_from_waste",
+            "short_label": "T-5A3-TE-6 - Increased energy recovery from waste",
+            "description": "Increased energy recovery from waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to CHP waste incineration in tonne to fulfill the need of warm premisses. from: incineration and open burning of waste. to: chp waste incineration. Energy > Energy Supply > Combined Heat Power",
+            "sector_path": "Energy > Energy Supply > Combined Heat Power",
+            "acts_on_labels": ["incineration and open burning of waste"],
+            "shifts_to_labels": ["chp waste incineration"],
+            "score": 0.5196
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_lead_industries",
+            "short_label": "T-2C5-TE-1 - Shift to biogas energy in lead industries",
+            "description": "Shift to biogas energy in lead industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within lead industries. to: biogas usage within lead industries. Industry > Metals > Lead",
+            "sector_path": "Industry > Metals > Lead",
+            "acts_on_labels": ["natural gas usage within lead industries"],
+            "shifts_to_labels": ["biogas usage within lead industries"],
+            "score": 0.4573
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_glass_industries",
+            "short_label": "T-2A3-TE-1 - Shift to biogas energy in glass industries",
+            "description": "Shift to biogas energy in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within glass industries. to: biogas usage within glass industries. Industry > Minerals > Glass Production",
+            "sector_path": "Industry > Minerals > Glass Production",
+            "acts_on_labels": ["natural gas usage within glass industries"],
+            "shifts_to_labels": ["biogas usage within glass industries"],
+            "score": 0.4443
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_chemical_industries",
+            "short_label": "T-2B9-TE-1 - Shift to biogas energy in chemical industries",
+            "description": "Shift to biogas energy in chemical industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within chemical industries. to: biogas usage within chemical industries. Industry > Chemicals > Other",
+            "sector_path": "Industry > Chemicals > Other",
+            "acts_on_labels": ["natural gas usage within chemical industries"],
+            "shifts_to_labels": ["biogas usage within chemical industries"],
+            "score": 0.439
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_magnesium_industries",
+            "short_label": "T-2C4-TE-2 - Shift to biogas energy in magnesium industries",
+            "description": "Shift to biogas energy in magnesium industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within magnesium industries. to: biogas usage within magnesium industries. Industry > Metals > Magnesium",
+            "sector_path": "Industry > Metals > Magnesium",
+            "acts_on_labels": ["natural gas usage within magnesium industries"],
+            "shifts_to_labels": ["biogas usage within magnesium industries"],
+            "score": 0.4359
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_pulp_paper_and_print_industries",
+            "short_label": "T-2D1b-TE-1 - Shift to biogas energy in pulp, paper and print industries",
+            "description": "Shift to biogas energy in pulp, paper and print industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within pulp paper and print industries. to: biogas usage within pulp paper and print industries. Industry > Other > Manufacturing > Pulp Paper Print",
+            "sector_path": "Industry > Other > Manufacturing > Pulp Paper Print",
+            "acts_on_labels": [
+              "natural gas usage within pulp paper and print industries"
+            ],
+            "shifts_to_labels": [
+              "biogas usage within pulp paper and print industries"
+            ],
+            "score": 0.4354
+          },
+          {
+            "stable_id": "chp_waste_incineration",
+            "short_label": "T-5A3-TE-4 - CHP from waste incineration",
+            "description": "CHP from waste incineration. Alter the amount of district heat and electricity produced by CHP waste incineration. from: chp waste incineration. Energy > Energy Supply > Combined Heat Power",
+            "sector_path": "Energy > Energy Supply > Combined Heat Power",
+            "acts_on_labels": ["chp waste incineration"],
+            "shifts_to_labels": [],
+            "score": 0.3957
+          },
+          {
+            "stable_id": "shift_to_residual_heat_in_district_heating",
+            "short_label": "T-5A2-TE-6 - Shift to Residual Heat in district heating",
+            "description": "Shift to Residual Heat in district heating. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: chp coal, chp natural gas, chp oil. to: district heating residual heat. Energy > Energy Supply > Heat",
+            "sector_path": "Energy > Energy Supply > Heat",
+            "acts_on_labels": ["chp coal", "chp natural gas", "chp oil"],
+            "shifts_to_labels": ["district heating residual heat"],
+            "score": 0.3596
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_hydrogen_refinement",
+            "short_label": "T-5B4-TE-3 - Shift to biogas energy in hydrogen refinement",
+            "description": "Shift to biogas energy in hydrogen refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within hydrogen refinement. to: biogas usage within hydrogen refinement. Energy > Energy Transformation > Hydrogen Refinement",
+            "sector_path": "Energy > Energy Transformation > Hydrogen Refinement",
+            "acts_on_labels": ["natural gas usage within hydrogen refinement"],
+            "shifts_to_labels": ["biogas usage within hydrogen refinement"],
+            "score": 0.3537
+          },
+          {
+            "stable_id": "district_heating_residual_heat",
+            "short_label": "T-5A2-TE-3 - District heating by residual heat",
+            "description": "District heating by residual heat. Alter the amount of district heat produced by residual heat. from: district heating residual heat. Energy > Energy Supply > Heat",
+            "sector_path": "Energy > Energy Supply > Heat",
+            "acts_on_labels": ["district heating residual heat"],
+            "shifts_to_labels": [],
+            "score": 0.3523
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_other_industries",
+            "short_label": "T-2D5-TE-2 - Shift to biogas energy in other industries",
+            "description": "Shift to biogas energy in other industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: industrial unregulated gas use. to: industrial unregulated biogas use. Industry > Other > Other",
+            "sector_path": "Industry > Other > Other",
+            "acts_on_labels": ["industrial unregulated gas use"],
+            "shifts_to_labels": ["industrial unregulated biogas use"],
+            "score": 0.3516
+          }
+        ]
+      }
+    ],
+    "intervention_who": "none",
+    "intervention_when": "annually",
+    "intervention_what": "reduce food and residual waste",
+    "intervention_how": "none",
+    "intervention_score": 3,
+    "intervention_reasoning": "WHAT and WHEN are present, but lacks WHO or HOW.",
+    "intervention_type": "indirect"
+  },
+  {
+    "measure_text": "170.Fler möjligheter för återbruk ska skapas, där även invånarna har möjlighet att lämna in och köpa begagnade produkter.",
+    "activity": "waste handling",
+    "activity_shift_score": 6,
+    "activity_shifts": [
+      {
+        "activity": "buying goods",
+        "shift_from": "buying new goods",
+        "shift_to": "buying reused goods",
+        "need": "consumption",
+        "type": "Utilisation Shift",
+        "type_reasoning": "The measure promotes the reuse of products, which implies a shift from buying new goods to buying reused goods.",
+        "score": 6,
+        "reasoning": "Activity (buying goods), shift_from (buying new goods), shift_to (buying reused goods), and need (consumption) are all identifiable.",
+        "transition_element_matches": [],
+        "transition_element_suggested_new": {
+          "short_label": "Shift to reuse of goods",
+          "description": "Transition from buying new goods to buying reused goods to promote sustainability and reduce waste."
+        },
+        "transition_element_candidates": [
+          {
+            "stable_id": "increased_recycling",
+            "short_label": "T-6A1-TE-1 - Shift to recycling of solid waste",
+            "description": "Shift to recycling of solid waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to recycling of solid waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: recycling of solid waste. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc",
+              "incineration and open burning of waste",
+              "open burning of waste",
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "shifts_to_labels": ["recycling of solid waste"],
+            "score": 0.4257
+          },
+          {
+            "stable_id": "shift_to_composting_of_organic_waste",
+            "short_label": "T-6A1-TE-2 - Shift to composting of organic waste",
+            "description": "Shift to composting of organic waste. Shift tonne from solid waste disposal in landfills to composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: composting of organic waste. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc",
+              "incineration and open burning of waste",
+              "open burning of waste",
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "shifts_to_labels": ["composting of organic waste"],
+            "score": 0.3752
+          },
+          {
+            "stable_id": "shift_to_electric_bikes",
+            "short_label": "T-1A1a-TE-11 - Shift to electric bikes",
+            "description": "Shift to electric bikes. Shift vehicle kilometer from petrol,diesel and LPG vehicles to electric bike in vehicle kilometer to fulfill the need of mobility. from: petrol vehicles, diesel vehicles, lpg vehicles. to: electric bikes. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": [
+              "petrol vehicles",
+              "diesel vehicles",
+              "lpg vehicles"
+            ],
+            "shifts_to_labels": ["electric bikes"],
+            "score": 0.3738
+          },
+          {
+            "stable_id": "shift_to_electric_cargo_bikes",
+            "short_label": "T-1B1a-TE-10 - Shift to electric cargo bikes",
+            "description": "Shift to electric cargo bikes. Shift vehicle kilometer from diesel and petrol light truck to electric carg bikes in vehicle kilometer to fulfill the need of logistics. from: diesel light trucks, petrol light trucks. to: electric cargo bikes. Transport > Freight > Road > Light Duty Trucks",
+            "sector_path": "Transport > Freight > Road > Light Duty Trucks",
+            "acts_on_labels": ["diesel light trucks", "petrol light trucks"],
+            "shifts_to_labels": ["electric cargo bikes"],
+            "score": 0.3662
+          },
+          {
+            "stable_id": "shift_to_exported_composting_of_organic_waste",
+            "short_label": "T-6A1-TE-3 - Shift to exported composting of organic waste",
+            "description": "Shift to exported composting of organic waste. Shift tonne from solid waste disposal in landfills to exported composting of organic waste in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc, incineration and open burning of waste, open burning of waste, solid waste disposal landfill with gas recovery. to: waste exported for composting. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc",
+              "incineration and open burning of waste",
+              "open burning of waste",
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "shifts_to_labels": ["waste exported for composting"],
+            "score": 0.3651
+          },
+          {
+            "stable_id": "increased_proportion_of_non_travel_meetings_and_services",
+            "short_label": "T-1A1a-TE-7 - Shift to online meetings and services",
+            "description": "Shift to online meetings and services. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to e-meetings in hours to fulfill the need of business trips. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: e meetings. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": [
+              "petrol vehicles",
+              "diesel vehicles",
+              "lpg vehicles",
+              "gas vehicles"
+            ],
+            "shifts_to_labels": ["e meetings"],
+            "score": 0.3636
+          },
+          {
+            "stable_id": "shift_to_landfill_gas_recovery",
+            "short_label": "T-6A1-TE-4 - Shift to landfill gas recovery",
+            "description": "Shift to landfill gas recovery. Shift tonne from solid waste disposal in landfills without gas recovery to solid waste disposal in landfills with landfill gas recovery in tonne to fulfill the need of waste handling. from: solid waste disposal in landfills and open dumps etc. to: solid waste disposal landfill with gas recovery. Waste > Solids > Solid Waste Disposal",
+            "sector_path": "Waste > Solids > Solid Waste Disposal",
+            "acts_on_labels": [
+              "solid waste disposal in landfills and open dumps etc"
+            ],
+            "shifts_to_labels": [
+              "solid waste disposal landfill with gas recovery"
+            ],
+            "score": 0.3619
+          },
+          {
+            "stable_id": "shift_to_residential_electric_cooking_stoves",
+            "short_label": "T-4A2d-TE-2 - Shift to residential electric cooking stoves",
+            "description": "Shift to residential electric cooking stoves. Shift kWh from residential cooking gas stoves to residential electric cooking stoves in kWh to fullfill the need for cooking. from: residential gas cooking stoves. to: residential electric cooking stoves. Buildings > Residential > Other Energy Usage > Unregulated",
+            "sector_path": "Buildings > Residential > Other Energy Usage > Unregulated",
+            "acts_on_labels": ["residential gas cooking stoves"],
+            "shifts_to_labels": ["residential electric cooking stoves"],
+            "score": 0.3602
+          },
+          {
+            "stable_id": "increased_proportion_of_walking_and_cycling",
+            "short_label": "T-1A1a-TE-10 - Shift to walking and cycling",
+            "description": "Shift to walking and cycling. Shift vehicle kilometer from petrol, diesel, LPG and gas vehicles to walking cycling. from: petrol vehicles, diesel vehicles, lpg vehicles, gas vehicles. to: walking cycling. Transport > Mobility > Road > Light Duty Vehicles",
+            "sector_path": "Transport > Mobility > Road > Light Duty Vehicles",
+            "acts_on_labels": [
+              "petrol vehicles",
+              "diesel vehicles",
+              "lpg vehicles",
+              "gas vehicles"
+            ],
+            "shifts_to_labels": ["walking cycling"],
+            "score": 0.3584
+          },
+          {
+            "stable_id": "shift_to_commercial_electric_cooking_stoves",
+            "short_label": "T-4B2b-TE-1 - Shift to commercial electric cooking stoves",
+            "description": "Shift to commercial electric cooking stoves. Shift kWh from commercial cooking gas stoves to commercial electric cooking stoves in kWh to fullfill the need for cooking. from: commercial gas cooking stoves. to: commercial electric cooking stoves. Buildings > Non Residential > Other Energy Usage > Equipment Appliances",
+            "sector_path": "Buildings > Non Residential > Other Energy Usage > Equipment Appliances",
+            "acts_on_labels": ["commercial gas cooking stoves"],
+            "shifts_to_labels": ["commercial electric cooking stoves"],
+            "score": 0.3556
+          },
+          {
+            "stable_id": "increased_energy_recovery_from_waste",
+            "short_label": "T-5A3-TE-6 - Increased energy recovery from waste",
+            "description": "Increased energy recovery from waste. Shift tonne from solid waste disposal in landfills and open dumps, incineration and open burning of waste to CHP waste incineration in tonne to fulfill the need of warm premisses. from: incineration and open burning of waste. to: chp waste incineration. Energy > Energy Supply > Combined Heat Power",
+            "sector_path": "Energy > Energy Supply > Combined Heat Power",
+            "acts_on_labels": ["incineration and open burning of waste"],
+            "shifts_to_labels": ["chp waste incineration"],
+            "score": 0.2867
+          },
+          {
+            "stable_id": "shift_to_biomass_energy_in_glass_industries",
+            "short_label": "T-2A3-TE-2 - Shift to biomass energy in glass industries",
+            "description": "Shift to biomass energy in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within glass industries. to: biomass usage within glass industries. Industry > Minerals > Glass Production",
+            "sector_path": "Industry > Minerals > Glass Production",
+            "acts_on_labels": ["coal usage within glass industries"],
+            "shifts_to_labels": ["biomass usage within glass industries"],
+            "score": 0.2788
+          },
+          {
+            "stable_id": "shift_to_electricity_in_glass_industries",
+            "short_label": "T-2A3-TE-3 - Shift to electricity in glass industries",
+            "description": "Shift to electricity in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within glass industries, oil usage within glass industries, natural gas usage within glass industries. to: electricity usage within glass industries. Industry > Minerals > Glass Production",
+            "sector_path": "Industry > Minerals > Glass Production",
+            "acts_on_labels": [
+              "coal usage within glass industries",
+              "oil usage within glass industries",
+              "natural gas usage within glass industries"
+            ],
+            "shifts_to_labels": ["electricity usage within glass industries"],
+            "score": 0.2772
+          },
+          {
+            "stable_id": "shift_to_biomass_energy_in_petroleum_refinement",
+            "short_label": "T-5B1-TE-1 - Shift to biomass energy in petroleum refinement",
+            "description": "Shift to biomass energy in petroleum refinement. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: crude oil usage within petroleum refinement. to: biomass usage within petroleum refinement. Energy > Energy Transformation > Petroleum Refinement",
+            "sector_path": "Energy > Energy Transformation > Petroleum Refinement",
+            "acts_on_labels": ["crude oil usage within petroleum refinement"],
+            "shifts_to_labels": ["biomass usage within petroleum refinement"],
+            "score": 0.273
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_glass_industries",
+            "short_label": "T-2A3-TE-1 - Shift to biogas energy in glass industries",
+            "description": "Shift to biogas energy in glass industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within glass industries. to: biogas usage within glass industries. Industry > Minerals > Glass Production",
+            "sector_path": "Industry > Minerals > Glass Production",
+            "acts_on_labels": ["natural gas usage within glass industries"],
+            "shifts_to_labels": ["biogas usage within glass industries"],
+            "score": 0.2714
+          },
+          {
+            "stable_id": "shift_to_electricity_in_pulp_paper_and_print_industries",
+            "short_label": "T-2D1b-TE-3 - Shift to electricity in pulp, paper and print industries",
+            "description": "Shift to electricity in pulp, paper and print industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within pulp paper and print industries, oil usage within pulp paper and print industries, natural gas usage within pulp paper and print industries. to: electricity usage within pulp paper and print industries. Industry > Other > Manufacturing > Pulp Paper Print",
+            "sector_path": "Industry > Other > Manufacturing > Pulp Paper Print",
+            "acts_on_labels": [
+              "coal usage within pulp paper and print industries",
+              "oil usage within pulp paper and print industries",
+              "natural gas usage within pulp paper and print industries"
+            ],
+            "shifts_to_labels": [
+              "electricity usage within pulp paper and print industries"
+            ],
+            "score": 0.2713
+          },
+          {
+            "stable_id": "shift_to_biomass_energy_in_pulp_paper_and_print_industries",
+            "short_label": "T-2D1b-TE-2 - Shift to biomass energy in pulp, paper and print industries",
+            "description": "Shift to biomass energy in pulp, paper and print industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within pulp paper and print industries. to: biomass usage within pulp paper and print industries. Industry > Other > Manufacturing > Pulp Paper Print",
+            "sector_path": "Industry > Other > Manufacturing > Pulp Paper Print",
+            "acts_on_labels": [
+              "coal usage within pulp paper and print industries"
+            ],
+            "shifts_to_labels": [
+              "biomass usage within pulp paper and print industries"
+            ],
+            "score": 0.27
+          },
+          {
+            "stable_id": "shift_to_biomass_energy_in_lead_industries",
+            "short_label": "T-2C5-TE-2 - Shift to biomass energy in lead industries",
+            "description": "Shift to biomass energy in lead industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: coal usage within lead industries. to: biomass usage within lead industries. Industry > Metals > Lead",
+            "sector_path": "Industry > Metals > Lead",
+            "acts_on_labels": ["coal usage within lead industries"],
+            "shifts_to_labels": ["biomass usage within lead industries"],
+            "score": 0.2697
+          },
+          {
+            "stable_id": "shift_to_biomass_energy_in_other_industries",
+            "short_label": "T-2D5-TE-1 - Shift to biomass energy in other industries",
+            "description": "Shift to biomass energy in other industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: industrial unregulated coal use. to: industrial unregulated biomass use. Industry > Other > Other",
+            "sector_path": "Industry > Other > Other",
+            "acts_on_labels": ["industrial unregulated coal use"],
+            "shifts_to_labels": ["industrial unregulated biomass use"],
+            "score": 0.2666
+          },
+          {
+            "stable_id": "shift_to_biogas_energy_in_pulp_paper_and_print_industries",
+            "short_label": "T-2D1b-TE-1 - Shift to biogas energy in pulp, paper and print industries",
+            "description": "Shift to biogas energy in pulp, paper and print industries. IPCC WG3 definition: {{ ipcc_mitigation_link() }}.. from: natural gas usage within pulp paper and print industries. to: biogas usage within pulp paper and print industries. Industry > Other > Manufacturing > Pulp Paper Print",
+            "sector_path": "Industry > Other > Manufacturing > Pulp Paper Print",
+            "acts_on_labels": [
+              "natural gas usage within pulp paper and print industries"
+            ],
+            "shifts_to_labels": [
+              "biogas usage within pulp paper and print industries"
+            ],
+            "score": 0.2643
+          }
+        ]
+      }
+    ],
+    "intervention_who": "none",
+    "intervention_when": "none",
+    "intervention_what": "creating more opportunities for reuse",
+    "intervention_how": "none",
+    "intervention_score": 3,
+    "intervention_reasoning": "The measure specifies what (creating more opportunities for reuse) but lacks a named actor, timeline, and mechanism.",
+    "intervention_type": "indirect"
+  }
+]

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -284,7 +284,16 @@
       "wikidataId": "Wikidata ID",
       "internalId": "Internal ID",
       "lei": "LEI",
-      "tags": "Tags"
+      "tags": "Tags",
+      "verified": "Verified",
+      "unverified": "Unverified",
+      "verifiedBy": "Verified by {{name}}",
+      "identifierType": {
+        "wikidata": "Wikidata",
+        "lei": "LEI",
+        "orgNumber": "Org number",
+        "isin": "ISIN"
+      }
     },
     "singleCompanyView": {
       "table": {
@@ -594,6 +603,7 @@
     "archiveShowing": "Showing {{from}}–{{to}} of {{total}} runs",
     "archiveEmpty": "No archived runs match your search.",
     "archiveWikidata": "Wikidata",
+    "archiveCompanyId": "Company ID",
     "archiveThread": "Thread",
     "archiveStatus": "Status",
     "archiveJobCount": "{{count}} jobs",
@@ -1468,6 +1478,7 @@
     "mustStartWithQ": "Wikidata ID must start with Q",
     "approved": "Approved",
     "pendingApproval": "Pending approval",
+    "autoApprovedUnverified": "Auto-approved (unverified)",
     "approveDescription": "Approve the suggested Wikidata ID. The job will be re-run with approval.",
     "approveButton": "Approve",
     "wikidataInfo": "Wikidata Information",
@@ -1490,6 +1501,7 @@
     "completed": "Completed",
     "failed": "Failed",
     "needs_approval": "Needs approval",
+    "wikidata_unverified": "Wikidata unverified",
     "processing": "Processing",
     "waiting": "Waiting",
     "processingNow": "Processing now"

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -119,7 +119,16 @@
       "wikidataId": "Wikidata-ID",
       "internalId": "Internt ID",
       "lei": "LEI",
-      "tags": "Taggar"
+      "tags": "Taggar",
+      "verified": "Verifierad",
+      "unverified": "Overifierad",
+      "verifiedBy": "Verifierad av {{name}}",
+      "identifierType": {
+        "wikidata": "Wikidata",
+        "lei": "LEI",
+        "orgNumber": "Org.nummer",
+        "isin": "ISIN"
+      }
     },
     "title": "Redigerare",
     "subtitle": "Redigera företagsdata i Garbo: enskilt företag för detaljer per bolag, massredigering främst för taggar över flera företag (tabeller per år är sekundära) och hantera taggalternativ för tillåtna taggar.",
@@ -594,6 +603,7 @@
     "archiveShowing": "Visar {{from}}–{{to}} av {{total}} körningar",
     "archiveEmpty": "Inga arkiverade körningar matchar sökningen.",
     "archiveWikidata": "Wikidata",
+    "archiveCompanyId": "Företags-ID",
     "archiveThread": "Tråd",
     "archiveStatus": "Status",
     "archiveJobCount": "{{count}} jobb",
@@ -1468,6 +1478,7 @@
     "mustStartWithQ": "Wikidata ID måste börja med Q",
     "approved": "Godkänd",
     "pendingApproval": "Väntar på godkännande",
+    "autoApprovedUnverified": "Auto-godkänd (overifierad)",
     "approveDescription": "Godkänn det föreslagna Wikidata ID:t. Jobbet kommer att köras om med godkännande.",
     "approveButton": "Godkänn",
     "wikidataInfo": "Wikidata-information",
@@ -1490,6 +1501,7 @@
     "completed": "Slutförd",
     "failed": "Misslyckad",
     "needs_approval": "Behöver godkännande",
+    "wikidata_unverified": "Wikidata overifierad",
     "processing": "Bearbetar",
     "waiting": "Väntar",
     "processingNow": "Bearbetar nu"

--- a/src/lib/status-config.tsx
+++ b/src/lib/status-config.tsx
@@ -4,6 +4,7 @@ import {
   HelpCircle,
   XCircle,
   RotateCw,
+  ShieldAlert,
 } from "lucide-react";
 import type { SwimlaneStatusType } from "./types";
 
@@ -54,6 +55,17 @@ export const STATUS_CONFIG = {
       background: "bg-orange-03/60",
       border: "border-transparent",
       icon: "text-orange-03",
+      iconCompact: "text-white",
+    },
+  },
+  wikidata_unverified: {
+    label: "Wikidata Unverified",
+    icon: ShieldAlert,
+    colors: {
+      text: "text-green-02",
+      background: "bg-green-02/70",
+      border: "border-green-02/80",
+      icon: "text-green-02",
       iconCompact: "text-white",
     },
   },
@@ -155,6 +167,7 @@ export function getStatusBackgroundColor(status: SwimlaneStatusType): string {
     failed: "bg-pink-03/20",
     processing: "bg-blue-03/20",
     needs_approval: "bg-orange-03/20",
+    wikidata_unverified: "bg-green-02/20",
     waiting: "bg-blue-01/20",
   };
   return backgroundMap[status];
@@ -208,7 +221,13 @@ export function getStatCardLabelColor(
  * Get step icon for pipeline step status
  */
 export function getStepIcon(
-  status: "completed" | "processing" | "failed" | "waiting" | "needs_approval",
+  status:
+    | "completed"
+    | "processing"
+    | "failed"
+    | "waiting"
+    | "needs_approval"
+    | "wikidata_unverified",
 ) {
   const config = getStatusConfig(status);
   const IconComponent = config.icon;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -192,6 +192,7 @@ export interface QueueStatsState {
 export type SwimlaneStatusType =
   | "completed"
   | "needs_approval"
+  | "wikidata_unverified"
   | "processing"
   | "waiting"
   | "failed";

--- a/src/lib/workflow-utils.test.ts
+++ b/src/lib/workflow-utils.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { getJobStatus } from "./workflow-utils";
+
+describe("getJobStatus wikidata", () => {
+  it("returns needs_approval when wikidata approval is pending", () => {
+    const status = getJobStatus({
+      queueId: "guessWikidata",
+      status: "delayed",
+      data: {
+        approval: {
+          type: "wikidata",
+          approved: false,
+          data: { newValue: { wikidata: { node: "Q1" } } },
+        },
+      },
+    });
+
+    expect(status).toBe("needs_approval");
+  });
+
+  it("returns wikidata_unverified when auto-approved without verifier", () => {
+    const status = getJobStatus({
+      queueId: "guessWikidata",
+      status: "completed",
+      finishedOn: Date.now(),
+      data: {
+        autoApprove: true,
+        approval: {
+          type: "wikidata",
+          approved: true,
+          data: { newValue: { wikidata: { node: "Q1" } } },
+        },
+      },
+    });
+
+    expect(status).toBe("wikidata_unverified");
+  });
+
+  it("returns completed when manually approved with verifier", () => {
+    const status = getJobStatus({
+      queueId: "guessWikidata",
+      status: "completed",
+      finishedOn: Date.now(),
+      data: {
+        autoApprove: false,
+        approval: {
+          type: "wikidata",
+          approved: true,
+          verifiedByUserId: "user-123",
+          data: { newValue: { wikidata: { node: "Q1" } } },
+        },
+      },
+    });
+
+    expect(status).toBe("completed");
+  });
+});

--- a/src/lib/workflow-utils.ts
+++ b/src/lib/workflow-utils.ts
@@ -17,6 +17,24 @@ import {
 } from "./workflow-config";
 
 /**
+ * guessWikidata completed via job autoApprove without a human verifier.
+ * Pipeline continues; identifier is stored as unverified in Garbo.
+ */
+function isWikidataAutoApprovedUnverified(job: any): boolean {
+  const queueId = job?.queueId ?? job?.queue;
+  if (queueId !== "guessWikidata") return false;
+
+  const approval = job.data?.approval || job?.approval;
+  if (!approval || typeof approval !== "object") return false;
+  if (approval.type !== "wikidata" || approval.approved !== true) return false;
+
+  const autoApprove = Boolean(job.data?.autoApprove ?? job?.autoApprove);
+  if (!autoApprove) return false;
+
+  return !approval.verifiedByUserId;
+}
+
+/**
  * Single source of truth for job status determination
  * Used by all views to ensure consistency
  */
@@ -46,8 +64,16 @@ export function getJobStatus(job: any): SwimlaneStatusType {
     return "processing";
   }
 
-  // For completed jobs, check if they need approval (fallback check)
+  // For completed jobs, distinguish auto-approved unverified Wikidata from fully done
   if (rawStatus === "completed" || job.finishedOn) {
+    if (isWikidataAutoApprovedUnverified(job)) {
+      return "wikidata_unverified";
+    }
+
+    if (hasApprovalObject && approval.approved === true) {
+      return "completed";
+    }
+
     const needsApproval = !job.data?.approved && !job.data?.autoApprove;
     return needsApproval ? "needs_approval" : "completed";
   }
@@ -305,6 +331,7 @@ export function calculateStepJobStats(
       init.total++;
       switch (agg.status) {
         case "completed":
+        case "wikidata_unverified":
           init.completed++;
           break;
         case "processing":
@@ -349,6 +376,10 @@ function hasJobBeenStarted(job: any): boolean {
     job.status === "completed" ||
     job.status === "failed"
   );
+}
+
+function isPipelineProgressStatus(status: SwimlaneStatusType): boolean {
+  return status === "completed" || status === "wikidata_unverified";
 }
 
 /**
@@ -459,11 +490,11 @@ export function calculatePipelineStepStatus(
     // Check statuses of started jobs only
     const startedStatuses = startedJobs.map((entry) => entry.status);
     const hasFailed = startedStatuses.some((status) => status === "failed");
-    const allCompleted = startedStatuses.every(
-      (status) => status === "completed",
+    const allCompleted = startedStatuses.every((status) =>
+      isPipelineProgressStatus(status),
     );
-    const hasCompleted = startedStatuses.some(
-      (status) => status === "completed",
+    const hasCompleted = startedStatuses.some((status) =>
+      isPipelineProgressStatus(status),
     );
 
     // If any started job failed, show failed
@@ -499,7 +530,9 @@ export function calculatePipelineStepStatus(
   }
 
   const fieldStatuses = jobsWithStatuses.map((entry) => entry.status);
-  const hasCompleted = fieldStatuses.some((status) => status === "completed");
+  const hasCompleted = fieldStatuses.some((status) =>
+    isPipelineProgressStatus(status),
+  );
   const hasWaiting = fieldStatuses.some((status) => status === "waiting");
   const hasFailed = fieldStatuses.some((status) => status === "failed");
 

--- a/src/tabs/editor/components/single-company/CompanyDetailTab.test.tsx
+++ b/src/tabs/editor/components/single-company/CompanyDetailTab.test.tsx
@@ -13,6 +13,7 @@ vi.mock("../../lib/companies-api", () => ({
   fetchIndustryGics: () => fetchIndustryGics(),
   updateCompanyIndustry: vi.fn(),
   updateCompanyBaseYear: vi.fn(),
+  deleteCompany: vi.fn(),
 }));
 
 vi.mock("sonner", () => ({
@@ -132,5 +133,30 @@ describe("CompanyDetailTab wikidataId", () => {
         wikidataId: undefined,
       }),
     );
+  });
+
+  it("shows verification badges for identifiers from API", async () => {
+    await renderTab({
+      ...mockCompany,
+      wikidataId: null,
+      identifiers: [
+        {
+          id: "id-w",
+          type: "WIKIDATA",
+          value: "Q12345",
+          metadata: { verifiedBy: null },
+        },
+        {
+          id: "id-l",
+          type: "LEI",
+          value: "5493001KJTIIGC8Y1R12",
+          metadata: { verifiedBy: { name: "Staff User" } },
+        },
+      ],
+    });
+
+    expect(screen.getByText("Unverified")).toBeInTheDocument();
+    expect(screen.getByText("Verified")).toBeInTheDocument();
+    expect(screen.getByText("5493001KJTIIGC8Y1R12")).toBeInTheDocument();
   });
 });

--- a/src/tabs/editor/components/single-company/CompanyDetailTab.tsx
+++ b/src/tabs/editor/components/single-company/CompanyDetailTab.tsx
@@ -518,8 +518,8 @@ export function CompanyDetailTab({
         size="md"
         title={t("editor.singleCompanyView.deleteCompany.title")}
         description={t("editor.singleCompanyView.deleteCompany.description", {
-          name: company.name ?? company.wikidataId,
-          wikidataId: company.wikidataId,
+          name: company.name ?? company.id,
+          wikidataId: wikidataFromIdentifiers(company) ?? t("common.placeholderDash"),
         })}
         footer={
           <>

--- a/src/tabs/editor/components/single-company/CompanyDetailTab.tsx
+++ b/src/tabs/editor/components/single-company/CompanyDetailTab.tsx
@@ -519,7 +519,8 @@ export function CompanyDetailTab({
         title={t("editor.singleCompanyView.deleteCompany.title")}
         description={t("editor.singleCompanyView.deleteCompany.description", {
           name: company.name ?? company.id,
-          wikidataId: wikidataFromIdentifiers(company) ?? t("common.placeholderDash"),
+          wikidataId:
+            wikidataFromIdentifiers(company) ?? t("common.placeholderDash"),
         })}
         footer={
           <>

--- a/src/tabs/editor/components/single-company/CompanyDetailTab.tsx
+++ b/src/tabs/editor/components/single-company/CompanyDetailTab.tsx
@@ -26,6 +26,11 @@ import {
 } from "../../lib/company-edit-utils";
 import { buildTagLabelBySlug } from "../../lib/editor-tag-and-payload-utils";
 import { editorPrimaryActionButtonClass } from "../../lib/editor-button-classes";
+import {
+  leiFromIdentifiers,
+  wikidataFromIdentifiers,
+} from "../../lib/company-identifiers";
+import { CompanyIdentifiersList } from "./CompanyIdentifiersList";
 import { ReviewerMetadataDialog } from "../ReviewerMetadataDialog";
 
 export function CompanyDetailTab({
@@ -53,8 +58,10 @@ export function CompanyDetailTab({
   const [descriptionSv, setDescriptionSv] = useState(() =>
     getDescriptionByLang(company, "SV"),
   );
-  const [wikidataId, setWikidataId] = useState(company.wikidataId ?? "");
-  const [lei, setLei] = useState(company.lei ?? "");
+  const [wikidataId, setWikidataId] = useState(
+    () => wikidataFromIdentifiers(company) ?? "",
+  );
+  const [lei, setLei] = useState(() => leiFromIdentifiers(company) ?? "");
   const [url, setUrl] = useState(company.url ?? "");
   const [internalComment, setInternalComment] = useState(
     company.internalComment ?? "",
@@ -86,8 +93,8 @@ export function CompanyDetailTab({
     setName(company.name ?? "");
     setDescriptionEn(getDescriptionByLang(company, "EN"));
     setDescriptionSv(getDescriptionByLang(company, "SV"));
-    setWikidataId(company.wikidataId ?? "");
-    setLei(company.lei ?? "");
+    setWikidataId(wikidataFromIdentifiers(company) ?? "");
+    setLei(leiFromIdentifiers(company) ?? "");
     setUrl(company.url ?? "");
     setInternalComment(company.internalComment ?? "");
     setSelectedTags(company.tags ?? []);
@@ -96,8 +103,7 @@ export function CompanyDetailTab({
   }, [
     company.id,
     company.name,
-    company.wikidataId,
-    company.lei,
+    company.identifiers,
     company.url,
     company.internalComment,
     company.tags,
@@ -216,7 +222,7 @@ export function CompanyDetailTab({
   const handleDeleteCompany = async () => {
     setDeletingCompany(true);
     try {
-      await deleteCompany(company.wikidataId);
+      await deleteCompany(company.id);
       toast.success(t("editor.singleCompanyView.deleteCompany.deleted"));
       setDeleteModalOpen(false);
       onDeleted?.();
@@ -321,7 +327,10 @@ export function CompanyDetailTab({
               <div className="text-xs font-semibold text-gray-02 uppercase tracking-wide mb-3">
                 {t("editor.companyDetail.identifiers")}
               </div>
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              {company.identifiers && company.identifiers.length > 0 ? (
+                <CompanyIdentifiersList identifiers={company.identifiers} />
+              ) : null}
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
                 <div>
                   <label className="block text-sm font-medium text-gray-01 mb-1">
                     {t("editor.companyDetail.wikidataId")}

--- a/src/tabs/editor/components/single-company/CompanyIdentifierVerificationBadge.tsx
+++ b/src/tabs/editor/components/single-company/CompanyIdentifierVerificationBadge.tsx
@@ -1,0 +1,37 @@
+import { CheckCircle2, HelpCircle } from "lucide-react";
+import { useI18n } from "@/contexts/I18nContext";
+import type { GarboCompanyIdentifier } from "../../lib/types";
+import { isIdentifierVerified } from "../../lib/company-identifiers";
+
+export function CompanyIdentifierVerificationBadge({
+  identifier,
+}: {
+  identifier: GarboCompanyIdentifier;
+}) {
+  const { t } = useI18n();
+  const verified = isIdentifierVerified(identifier);
+  const verifierName = identifier.metadata?.verifiedBy?.name?.trim();
+
+  if (verified) {
+    return (
+      <span
+        className="inline-flex items-center gap-1 text-xs font-medium text-green-03"
+        title={
+          verifierName
+            ? t("editor.companyDetail.verifiedBy", { name: verifierName })
+            : undefined
+        }
+      >
+        <CheckCircle2 className="w-3.5 h-3.5 shrink-0" aria-hidden />
+        {t("editor.companyDetail.verified")}
+      </span>
+    );
+  }
+
+  return (
+    <span className="inline-flex items-center gap-1 text-xs font-medium text-orange-03">
+      <HelpCircle className="w-3.5 h-3.5 shrink-0" aria-hidden />
+      {t("editor.companyDetail.unverified")}
+    </span>
+  );
+}

--- a/src/tabs/editor/components/single-company/CompanyIdentifiersList.tsx
+++ b/src/tabs/editor/components/single-company/CompanyIdentifiersList.tsx
@@ -1,0 +1,44 @@
+import { useI18n } from "@/contexts/I18nContext";
+import type { GarboCompanyIdentifier } from "../../lib/types";
+import { CompanyIdentifierVerificationBadge } from "./CompanyIdentifierVerificationBadge";
+
+const IDENTIFIER_TYPE_KEYS = {
+  WIKIDATA: "wikidata",
+  LEI: "lei",
+  ORG_NUMBER: "orgNumber",
+  ISIN: "isin",
+} as const satisfies Record<GarboCompanyIdentifier["type"], string>;
+
+export function CompanyIdentifiersList({
+  identifiers,
+}: {
+  identifiers: GarboCompanyIdentifier[];
+}) {
+  const { t } = useI18n();
+
+  if (identifiers.length === 0) return null;
+
+  return (
+    <ul className="space-y-2">
+      {identifiers.map((identifier) => {
+        const typeKey = IDENTIFIER_TYPE_KEYS[identifier.type];
+        return (
+          <li
+            key={identifier.id}
+            className="flex flex-wrap items-center justify-between gap-2 rounded-md bg-gray-05/80 px-3 py-2"
+          >
+            <div className="min-w-0">
+              <div className="text-xs font-semibold uppercase tracking-wide text-gray-02">
+                {t(`editor.companyDetail.identifierType.${typeKey}`)}
+              </div>
+              <code className="text-sm font-mono text-gray-01 break-all">
+                {identifier.value}
+              </code>
+            </div>
+            <CompanyIdentifierVerificationBadge identifier={identifier} />
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/src/tabs/editor/lib/companies-api.ts
+++ b/src/tabs/editor/lib/companies-api.ts
@@ -8,7 +8,7 @@ import {
   type GarboRegistryReportSummary,
   type ReportingPeriodWritePayload,
 } from "./types";
-import { parseGarboCompanyDetail } from "./companies-schemas";
+import { parseGarboCompanyDetail, garboCompanyIdSchema } from "./companies-schemas";
 import { apiUrl } from "./api-utils";
 
 function normalizeReportingPeriodUrls(
@@ -167,7 +167,7 @@ async function fetchPipelineCompanyByRef(
 }
 
 /**
- * Pipeline GET /:ref only accepts Wikidata IDs; other refs resolve via list lookup.
+ * Pipeline GET /:ref accepts Wikidata IDs and internal company UUIDs (Phase 3+).
  */
 export async function getCompany(
   identifier: string,
@@ -178,6 +178,19 @@ export async function getCompany(
     return fetchPipelineCompanyByRef(ref, signal);
   }
 
+  if (garboCompanyIdSchema.safeParse(ref).success) {
+    try {
+      return await fetchPipelineCompanyByRef(ref, signal);
+    } catch (error) {
+      if (
+        !(error instanceof Error) ||
+        !error.message.includes("not found")
+      ) {
+        throw error;
+      }
+    }
+  }
+
   const companies = await listCompanies(signal);
   const match = companies.find((company) =>
     companyMatchesEditorRef(company, ref),
@@ -186,11 +199,11 @@ export async function getCompany(
     throw new Error("Company not found.");
   }
 
-  if (match.wikidataId) {
-    return fetchPipelineCompanyByRef(match.wikidataId, signal);
+  try {
+    return await fetchPipelineCompanyByRef(match.id, signal);
+  } catch {
+    return match as GarboCompanyDetail;
   }
-
-  return match as GarboCompanyDetail;
 }
 
 export async function createCompany(body: {
@@ -302,9 +315,9 @@ export async function updateReportingPeriods(
   }
 }
 
-export async function deleteCompany(wikidataId: string): Promise<void> {
+export async function deleteCompany(companyId: string): Promise<void> {
   const res = await garboAuthFetch(
-    apiUrl(companiesPath(encodeURIComponent(wikidataId))),
+    apiUrl(companiesPath(encodeURIComponent(companyId))),
     {
       method: "DELETE",
       headers: { Accept: "application/json" },

--- a/src/tabs/editor/lib/companies-api.ts
+++ b/src/tabs/editor/lib/companies-api.ts
@@ -8,7 +8,10 @@ import {
   type GarboRegistryReportSummary,
   type ReportingPeriodWritePayload,
 } from "./types";
-import { parseGarboCompanyDetail, garboCompanyIdSchema } from "./companies-schemas";
+import {
+  parseGarboCompanyDetail,
+  garboCompanyIdSchema,
+} from "./companies-schemas";
 import { apiUrl } from "./api-utils";
 
 function normalizeReportingPeriodUrls(

--- a/src/tabs/editor/lib/companies-api.ts
+++ b/src/tabs/editor/lib/companies-api.ts
@@ -140,10 +140,10 @@ function companyMatchesEditorRef(
   return idPrefix.toLowerCase() === ref.toLowerCase();
 }
 
-async function fetchPipelineCompanyByRef(
+async function fetchPipelineCompanyByRefIfExists(
   pipelineRef: string,
   signal?: AbortSignal,
-): Promise<GarboCompanyDetail> {
+): Promise<GarboCompanyDetail | null> {
   const res = await garboAuthFetch(
     apiUrl(pipelineCompaniesPath(encodeURIComponent(pipelineRef))),
     {
@@ -156,7 +156,7 @@ async function fetchPipelineCompanyByRef(
     throw new Error("Please log in to view company.");
   }
   if (res.status === 404) {
-    throw new Error("Company not found.");
+    return null;
   }
   if (!res.ok) {
     const text = await res.text();
@@ -164,6 +164,17 @@ async function fetchPipelineCompanyByRef(
   }
   const data = parseGarboCompanyDetail(await res.json());
   return normalizeCompany(data as GarboCompanyDetail);
+}
+
+async function fetchPipelineCompanyByRef(
+  pipelineRef: string,
+  signal?: AbortSignal,
+): Promise<GarboCompanyDetail> {
+  const company = await fetchPipelineCompanyByRefIfExists(pipelineRef, signal);
+  if (!company) {
+    throw new Error("Company not found.");
+  }
+  return company;
 }
 
 /**
@@ -179,16 +190,8 @@ export async function getCompany(
   }
 
   if (garboCompanyIdSchema.safeParse(ref).success) {
-    try {
-      return await fetchPipelineCompanyByRef(ref, signal);
-    } catch (error) {
-      if (
-        !(error instanceof Error) ||
-        !error.message.includes("not found")
-      ) {
-        throw error;
-      }
-    }
+    const byId = await fetchPipelineCompanyByRefIfExists(ref, signal);
+    if (byId) return byId;
   }
 
   const companies = await listCompanies(signal);
@@ -199,11 +202,8 @@ export async function getCompany(
     throw new Error("Company not found.");
   }
 
-  try {
-    return await fetchPipelineCompanyByRef(match.id, signal);
-  } catch {
-    return match as GarboCompanyDetail;
-  }
+  const byMatchId = await fetchPipelineCompanyByRefIfExists(match.id, signal);
+  return byMatchId ?? (match as GarboCompanyDetail);
 }
 
 export async function createCompany(body: {

--- a/src/tabs/editor/lib/companies-schemas.test.ts
+++ b/src/tabs/editor/lib/companies-schemas.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { parseGarboCompanyDetail } from "./companies-schemas";
+
+describe("parseGarboCompanyDetail", () => {
+  it("parses company with null wikidataId and identifiers", () => {
+    const parsed = parseGarboCompanyDetail({
+      id: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+      name: "Example AB",
+      wikidataId: null,
+      identifiers: [
+        {
+          id: "id1",
+          type: "WIKIDATA",
+          value: "Q12345",
+          metadata: { verifiedBy: null },
+        },
+        {
+          id: "id2",
+          type: "LEI",
+          value: "5493001KJTIIGC8Y1R12",
+          metadata: {
+            verifiedBy: { name: "Reviewer" },
+          },
+        },
+      ],
+    });
+
+    expect(parsed.wikidataId).toBeNull();
+    expect(parsed.identifiers).toHaveLength(2);
+    expect(parsed.identifiers?.[1].metadata?.verifiedBy?.name).toBe("Reviewer");
+  });
+
+  it("parses company with wikidataId and no identifiers", () => {
+    const parsed = parseGarboCompanyDetail({
+      id: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+      name: "Example AB",
+      wikidataId: "Q999",
+    });
+
+    expect(parsed.wikidataId).toBe("Q999");
+    expect(parsed.identifiers).toBeUndefined();
+  });
+});

--- a/src/tabs/editor/lib/companies-schemas.test.ts
+++ b/src/tabs/editor/lib/companies-schemas.test.ts
@@ -40,4 +40,14 @@ describe("parseGarboCompanyDetail", () => {
     expect(parsed.wikidataId).toBe("Q999");
     expect(parsed.identifiers).toBeUndefined();
   });
+
+  it("parses company with empty wikidataId as null", () => {
+    const parsed = parseGarboCompanyDetail({
+      id: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+      name: "Example AB",
+      wikidataId: "",
+    });
+
+    expect(parsed.wikidataId).toBeNull();
+  });
 });

--- a/src/tabs/editor/lib/companies-schemas.ts
+++ b/src/tabs/editor/lib/companies-schemas.ts
@@ -6,11 +6,11 @@ export const garboCompanyIdSchema = z.string().uuid();
 
 const garboMinimalMetadataSchema = z
   .object({
-    user: z.object({ name: z.string().nullable().optional() }).nullable().optional(),
-    verifiedBy: z
-      .object({ name: z.string() })
+    user: z
+      .object({ name: z.string().nullable().optional() })
       .nullable()
       .optional(),
+    verifiedBy: z.object({ name: z.string() }).nullable().optional(),
     source: z.string().nullable().optional(),
     comment: z.string().nullable().optional(),
   })

--- a/src/tabs/editor/lib/companies-schemas.ts
+++ b/src/tabs/editor/lib/companies-schemas.ts
@@ -27,7 +27,10 @@ export const garboCompanyIdentifierSchema = z.object({
 export const garboCompanyListItemSchema = z
   .object({
     id: garboCompanyIdSchema,
-    wikidataId: z.string().regex(WIKIDATA_ID_REGEX).nullable().optional(),
+    wikidataId: z
+      .union([z.string().regex(WIKIDATA_ID_REGEX), z.literal(""), z.null()])
+      .optional()
+      .transform((value) => (value === "" ? null : value)),
     name: z.string(),
     tags: z.array(z.string()).optional(),
     baseYear: z.unknown().optional(),

--- a/src/tabs/editor/lib/companies-schemas.ts
+++ b/src/tabs/editor/lib/companies-schemas.ts
@@ -1,8 +1,27 @@
 import { z } from "zod";
 import { WIKIDATA_ID_REGEX } from "./types";
 
-/** Garbo internal `Company.id` (CUID). Distinct from `wikidataId`. */
+/** Garbo internal `Company.id` (UUID). Distinct from `wikidataId`. */
 export const garboCompanyIdSchema = z.string().uuid();
+
+const garboMinimalMetadataSchema = z
+  .object({
+    user: z.object({ name: z.string().nullable().optional() }).nullable().optional(),
+    verifiedBy: z
+      .object({ name: z.string() })
+      .nullable()
+      .optional(),
+    source: z.string().nullable().optional(),
+    comment: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+export const garboCompanyIdentifierSchema = z.object({
+  id: z.string(),
+  type: z.enum(["WIKIDATA", "LEI", "ORG_NUMBER", "ISIN"]),
+  value: z.string(),
+  metadata: garboMinimalMetadataSchema.nullable().optional(),
+});
 
 /** Minimal company shape from GET /api/companies (list). */
 export const garboCompanyListItemSchema = z
@@ -16,10 +35,11 @@ export const garboCompanyListItemSchema = z
     reportingPeriods: z.array(z.unknown()).optional(),
     hasUnverifiedEmissions: z.boolean().optional(),
     hasUnverifiedData: z.boolean().optional(),
+    identifiers: z.array(garboCompanyIdentifierSchema).optional(),
   })
   .passthrough();
 
-/** Company detail from GET /api/pipeline/companies/:wikidataId. */
+/** Company detail from GET /api/pipeline/companies/:ref. */
 export const garboCompanyDetailSchema = garboCompanyListItemSchema
   .extend({
     url: z.string().nullable().optional(),

--- a/src/tabs/editor/lib/company-identifiers.ts
+++ b/src/tabs/editor/lib/company-identifiers.ts
@@ -1,0 +1,34 @@
+import type { GarboCompanyDetail, GarboCompanyIdentifier } from "./types";
+
+export function isIdentifierVerified(
+  identifier: GarboCompanyIdentifier | undefined,
+): boolean {
+  return Boolean(identifier?.metadata?.verifiedBy);
+}
+
+export function identifierByType(
+  company: GarboCompanyDetail,
+  type: GarboCompanyIdentifier["type"],
+): GarboCompanyIdentifier | undefined {
+  return company.identifiers?.find((row) => row.type === type);
+}
+
+export function wikidataFromIdentifiers(
+  company: GarboCompanyDetail,
+): string | null {
+  const row = identifierByType(company, "WIKIDATA");
+  return row?.value?.trim() || company.wikidataId?.trim() || null;
+}
+
+export function leiFromIdentifiers(company: GarboCompanyDetail): string | null {
+  const row = identifierByType(company, "LEI");
+  return row?.value?.trim() || company.lei?.trim() || null;
+}
+
+/** Prefer internal id for editor URLs; fall back to wikidata when present. */
+export function editorCompanyRef(company: {
+  id: string;
+  wikidataId?: string | null;
+}): string {
+  return company.id?.trim() || company.wikidataId?.trim() || "";
+}

--- a/src/tabs/editor/lib/company-identifiers.ts
+++ b/src/tabs/editor/lib/company-identifiers.ts
@@ -24,11 +24,3 @@ export function leiFromIdentifiers(company: GarboCompanyDetail): string | null {
   const row = identifierByType(company, "LEI");
   return row?.value?.trim() || company.lei?.trim() || null;
 }
-
-/** Prefer internal id for editor URLs; fall back to wikidata when present. */
-export function editorCompanyRef(company: {
-  id: string;
-  wikidataId?: string | null;
-}): string {
-  return company.id?.trim() || company.wikidataId?.trim() || "";
-}

--- a/src/tabs/editor/lib/types.ts
+++ b/src/tabs/editor/lib/types.ts
@@ -40,6 +40,7 @@ export interface GarboCompanyListItem {
   reportingPeriods?: GarboReportingPeriodSummary[];
   hasUnverifiedEmissions?: boolean;
   hasUnverifiedData?: boolean;
+  identifiers?: GarboCompanyIdentifier[];
 }
 
 export interface GarboRegistryReportSummary {
@@ -98,6 +99,21 @@ export type ReportingPeriodWritePayload = {
 export interface GarboMinimalMetadata {
   user?: { name?: string | null } | null;
   verifiedBy?: { name: string } | null;
+  source?: string | null;
+  comment?: string | null;
+}
+
+export type GarboCompanyIdentifierType =
+  | "WIKIDATA"
+  | "LEI"
+  | "ORG_NUMBER"
+  | "ISIN";
+
+export interface GarboCompanyIdentifier {
+  id: string;
+  type: GarboCompanyIdentifierType;
+  value: string;
+  metadata?: GarboMinimalMetadata | null;
 }
 
 export interface GarboFieldMetadata extends GarboMinimalMetadata {
@@ -161,6 +177,7 @@ export interface GarboCompanyDetail extends GarboCompanyListItem {
   logoUrl?: string | null;
   lei?: string | null;
   internalComment?: string | null;
+  identifiers?: GarboCompanyIdentifier[];
   descriptions?: Array<{ id?: string; language: string; text: string }>;
   industry?: { subIndustryCode?: string } | null;
   baseYear?: number | null;

--- a/src/tabs/jobbstatus/components/JobbstatusArchiveRunCard.tsx
+++ b/src/tabs/jobbstatus/components/JobbstatusArchiveRunCard.tsx
@@ -25,6 +25,8 @@ import {
 import type { ArchiveRunJobRow, ArchiveRunSummary } from "../lib/archive-types";
 import { formatArchiveWhen } from "../lib/format-archive-datetime";
 import { ArchiveQueueStepPill } from "./ArchiveQueueStepPill";
+import { Link } from "react-router-dom";
+import { editorCompanyPath } from "@/tabs/editor/lib/editor-routes";
 
 export type {
   ArchiveRunJobRow,
@@ -196,6 +198,16 @@ export function JobbstatusArchiveRunCard({
                   <span className="font-mono text-gray-01">
                     {run.wikidataId}
                   </span>
+                </span>
+              ) : run.companyId ? (
+                <span className="shrink-0">
+                  {t("jobstatus.archiveCompanyId")}:{" "}
+                  <Link
+                    to={editorCompanyPath(run.companyId)}
+                    className="font-mono text-blue-03 hover:text-blue-04"
+                  >
+                    {run.companyId}
+                  </Link>
                 </span>
               ) : null}
               {run.batch?.batchName ? (

--- a/src/tabs/jobbstatus/components/JobbstatusArchiveRunCard.tsx
+++ b/src/tabs/jobbstatus/components/JobbstatusArchiveRunCard.tsx
@@ -5,6 +5,7 @@
  */
 
 import { useMemo, useState, type ReactElement } from "react";
+import { Link } from "react-router-dom";
 import { ChevronDown, FileText } from "lucide-react";
 import { Button } from "@/ui/button";
 import { useI18n } from "@/contexts/I18nContext";
@@ -25,7 +26,6 @@ import {
 import type { ArchiveRunJobRow, ArchiveRunSummary } from "../lib/archive-types";
 import { formatArchiveWhen } from "../lib/format-archive-datetime";
 import { ArchiveQueueStepPill } from "./ArchiveQueueStepPill";
-import { Link } from "react-router-dom";
 import { editorCompanyPath } from "@/tabs/editor/lib/editor-routes";
 
 export type {

--- a/src/tabs/jobbstatus/components/WikidataApprovalDisplay.tsx
+++ b/src/tabs/jobbstatus/components/WikidataApprovalDisplay.tsx
@@ -4,25 +4,7 @@ import { Callout } from "@/ui/callout";
 import { useI18n } from "@/contexts/I18nContext";
 import { Check, ExternalLink, AlertCircle, RotateCcw, ShieldAlert } from "lucide-react";
 import { cn } from "@/lib/utils";
-
-interface WikidataData {
-  node: string;
-  url: string;
-  label: string;
-  description?: string;
-}
-
-interface WikidataApprovalData {
-  status: "approved" | "pending_approval" | "approved_unverified";
-  wikidata: WikidataData;
-  message?: string;
-  metadata?: {
-    source?: string;
-    comment?: string;
-  };
-  autoApproved?: boolean;
-  verifiedByUserId?: string;
-}
+import type { WikidataApprovalData } from "../lib/job-specific-data-parsing";
 
 interface WikidataApprovalDisplayProps {
   data: WikidataApprovalData;
@@ -106,15 +88,11 @@ export function WikidataApprovalDisplay({
       </div>
 
       {/* Message */}
-      {data.message && (
-        <Callout
-          variant={
-            isApproved ? "success" : isApprovedUnverified ? "warning" : "warning"
-          }
-        >
+      {data.message ? (
+        <Callout variant={isApproved ? "success" : "warning"}>
           {data.message}
         </Callout>
-      )}
+      ) : null}
 
       {/* Wikidata Information */}
       <div className="bg-gray-03/20 rounded-lg p-4 space-y-3">

--- a/src/tabs/jobbstatus/components/WikidataApprovalDisplay.tsx
+++ b/src/tabs/jobbstatus/components/WikidataApprovalDisplay.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Button } from "@/ui/button";
 import { Callout } from "@/ui/callout";
 import { useI18n } from "@/contexts/I18nContext";
-import { Check, ExternalLink, AlertCircle, RotateCcw } from "lucide-react";
+import { Check, ExternalLink, AlertCircle, RotateCcw, ShieldAlert } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 interface WikidataData {
@@ -13,13 +13,15 @@ interface WikidataData {
 }
 
 interface WikidataApprovalData {
-  status: "approved" | "pending_approval";
+  status: "approved" | "pending_approval" | "approved_unverified";
   wikidata: WikidataData;
   message?: string;
   metadata?: {
     source?: string;
     comment?: string;
   };
+  autoApproved?: boolean;
+  verifiedByUserId?: string;
 }
 
 interface WikidataApprovalDisplayProps {
@@ -38,6 +40,7 @@ export function WikidataApprovalDisplay({
   const [overrideError, setOverrideError] = useState("");
 
   const isApproved = data.status === "approved";
+  const isApprovedUnverified = data.status === "approved_unverified";
   const isPending = data.status === "pending_approval";
 
   const handleOverrideChange = (value: string) => {
@@ -85,6 +88,13 @@ export function WikidataApprovalDisplay({
               {t("wikidata.approved")}
             </span>
           </div>
+        ) : isApprovedUnverified ? (
+          <div className="flex items-center space-x-2 px-3 py-1.5 rounded-full bg-green-02/20 border border-green-02">
+            <ShieldAlert className="w-4 h-4 text-green-02" />
+            <span className="text-sm font-medium text-green-02">
+              {t("wikidata.autoApprovedUnverified")}
+            </span>
+          </div>
         ) : (
           <div className="flex items-center space-x-2 px-3 py-1.5 rounded-full bg-orange-03/20 border border-orange-03">
             <AlertCircle className="w-4 h-4 text-orange-03" />
@@ -97,7 +107,11 @@ export function WikidataApprovalDisplay({
 
       {/* Message */}
       {data.message && (
-        <Callout variant={isApproved ? "success" : "warning"}>
+        <Callout
+          variant={
+            isApproved ? "success" : isApprovedUnverified ? "warning" : "warning"
+          }
+        >
           {data.message}
         </Callout>
       )}

--- a/src/tabs/jobbstatus/components/WikidataApprovalDisplay.tsx
+++ b/src/tabs/jobbstatus/components/WikidataApprovalDisplay.tsx
@@ -2,7 +2,13 @@ import { useState } from "react";
 import { Button } from "@/ui/button";
 import { Callout } from "@/ui/callout";
 import { useI18n } from "@/contexts/I18nContext";
-import { Check, ExternalLink, AlertCircle, RotateCcw, ShieldAlert } from "lucide-react";
+import {
+  Check,
+  ExternalLink,
+  AlertCircle,
+  RotateCcw,
+  ShieldAlert,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { WikidataApprovalData } from "../lib/job-specific-data-parsing";
 

--- a/src/tabs/jobbstatus/components/job-details/JobStatusSection.tsx
+++ b/src/tabs/jobbstatus/components/job-details/JobStatusSection.tsx
@@ -23,6 +23,7 @@ function getStatusLabelKey(status: string, isActive?: boolean): string {
     failed: "status.failed",
     processing: "status.processing",
     needs_approval: "status.needs_approval",
+    wikidata_unverified: "status.wikidata_unverified",
     waiting: "status.waiting",
   };
   return keyMap[status] ?? "status.waiting";

--- a/src/tabs/jobbstatus/hooks/useJobRerunActions.ts
+++ b/src/tabs/jobbstatus/hooks/useJobRerunActions.ts
@@ -9,6 +9,7 @@ import { authenticatedFetch } from "@/lib/api-helpers";
 import { getPipelineUrl } from "@/config/api-env";
 import { buildRerunRequestData } from "@/lib/job-rerun-utils";
 import { useI18n } from "@/contexts/I18nContext";
+import { useAuth } from "@/hooks/useAuth";
 import type { DetailedJobResponse, QueueJob } from "@/lib/types";
 
 interface UseJobRerunActionsArgs {
@@ -25,6 +26,7 @@ export function useJobRerunActions({
   setDetailed,
 }: UseJobRerunActionsArgs) {
   const { t } = useI18n();
+  const { user } = useAuth();
   const refreshJobData = useCallback(async () => {
     if (!job?.queueId || !job?.id) return;
     try {
@@ -55,7 +57,14 @@ export function useJobRerunActions({
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ data: { approval: { approved: true } } }),
+          body: JSON.stringify({
+            data: {
+              approval: {
+                approved: true,
+                ...(user?.id && { verifiedByUserId: user.id }),
+              },
+            },
+          }),
         },
       );
       if (!response.ok) {
@@ -77,7 +86,7 @@ export function useJobRerunActions({
         }),
       );
     }
-  }, [effectiveJob?.queueId, effectiveJob?.id, refreshJobData, t]);
+  }, [effectiveJob?.queueId, effectiveJob?.id, refreshJobData, t, user?.id]);
 
   const handleWikidataOverride = useCallback(
     async (overrideWikidataId: string) => {

--- a/src/tabs/jobbstatus/lib/archive-types.ts
+++ b/src/tabs/jobbstatus/lib/archive-types.ts
@@ -15,6 +15,7 @@ export type ArchiveRunSummary = {
   pdfUrl: string;
   companyName: string | null;
   wikidataId: string | null;
+  companyId?: string | null;
   companyReportId?: string | null;
   batch?: { id: string; batchName: string } | null;
   status: string;

--- a/src/tabs/jobbstatus/lib/calculation-utils.ts
+++ b/src/tabs/jobbstatus/lib/calculation-utils.ts
@@ -91,6 +91,7 @@ export function calculateOverallStatistics(
 
         switch (status) {
           case "completed":
+          case "wikidata_unverified":
             completedFields++;
             break;
           case "processing":
@@ -173,6 +174,7 @@ export function calculateSwimlaneOverallStats(
       if (agg.attempts.length === 0) return;
       switch (agg.status) {
         case "completed":
+        case "wikidata_unverified":
           completedFields++;
           break;
         case "processing":

--- a/src/tabs/jobbstatus/lib/job-specific-data-parsing.ts
+++ b/src/tabs/jobbstatus/lib/job-specific-data-parsing.ts
@@ -93,7 +93,9 @@ export interface WikidataApprovalData {
   verifiedByUserId?: string;
 }
 
-function approvalSummary(approval: Record<string, unknown>): string | undefined {
+function approvalSummary(
+  approval: Record<string, unknown>,
+): string | undefined {
   return typeof approval.summary === "string" && approval.summary.trim()
     ? approval.summary
     : undefined;
@@ -113,7 +115,8 @@ function wikidataApprovalFromApprovalObject(
     typeof approval.verifiedByUserId === "string"
       ? approval.verifiedByUserId
       : undefined;
-  const metadata = (approval.metadata as WikidataApprovalData["metadata"]) || {};
+  const metadata =
+    (approval.metadata as WikidataApprovalData["metadata"]) || {};
 
   if (approval.approved === false) {
     return {
@@ -149,7 +152,11 @@ export function getWikidataApprovalData(
   const jobData = effectiveJob?.data || job?.data;
   const approval = jobData?.approval;
 
-  if (approval && typeof approval === "object" && approval.type === "wikidata") {
+  if (
+    approval &&
+    typeof approval === "object" &&
+    approval.type === "wikidata"
+  ) {
     return wikidataApprovalFromApprovalObject(
       approval as Record<string, unknown>,
       jobData as Record<string, unknown> | undefined,

--- a/src/tabs/jobbstatus/lib/job-specific-data-parsing.ts
+++ b/src/tabs/jobbstatus/lib/job-specific-data-parsing.ts
@@ -74,60 +74,78 @@ export function getScope3Data(processedData: any, returnValueData: any): any {
   return null;
 }
 
+function wikidataApprovalFromApprovalObject(
+  approval: Record<string, unknown>,
+  jobData?: Record<string, unknown>,
+): {
+  status: "approved" | "pending_approval" | "approved_unverified";
+  wikidata: {
+    node: string;
+    url: string;
+    label: string;
+    description?: string;
+  };
+  message?: string;
+  metadata?: Record<string, unknown>;
+  autoApproved?: boolean;
+  verifiedByUserId?: string;
+} | null {
+  const wikidata = (approval.data as any)?.newValue?.wikidata;
+  if (!wikidata || typeof wikidata !== "object" || !wikidata.node) {
+    return null;
+  }
+
+  const autoApproved = Boolean(jobData?.autoApprove);
+  const verifiedByUserId =
+    typeof approval.verifiedByUserId === "string"
+      ? approval.verifiedByUserId
+      : undefined;
+
+  if (approval.approved === false) {
+    return {
+      status: "pending_approval",
+      wikidata,
+      message:
+        (typeof approval.summary === "string" && approval.summary) ||
+        "Waiting for approval",
+      metadata: (approval.metadata as Record<string, unknown>) || {},
+      autoApproved,
+      verifiedByUserId,
+    };
+  }
+
+  if (approval.approved === true) {
+    const status =
+      autoApproved && !verifiedByUserId ? "approved_unverified" : "approved";
+    return {
+      status,
+      wikidata,
+      message:
+        (typeof approval.summary === "string" && approval.summary) ||
+        (status === "approved_unverified"
+          ? "Auto-approved (identifier unverified)"
+          : "Approved"),
+      metadata: (approval.metadata as Record<string, unknown>) || {},
+      autoApproved,
+      verifiedByUserId,
+    };
+  }
+
+  return null;
+}
+
 export function getWikidataApprovalData(
   job?: QueueJob,
   effectiveJob?: any,
-): any {
+): ReturnType<typeof wikidataApprovalFromApprovalObject> {
   const jobData = effectiveJob?.data || job?.data;
   const approval = jobData?.approval;
 
-  if (approval && typeof approval === "object") {
-    if (
-      approval.type === "wikidata" &&
-      approval.approved === false &&
-      approval.data?.newValue?.wikidata &&
-      typeof approval.data.newValue.wikidata === "object" &&
-      approval.data.newValue.wikidata.node
-    ) {
-      return {
-        status: "pending_approval",
-        wikidata: approval.data.newValue.wikidata,
-        message: approval.summary || "Waiting for approval",
-        metadata: approval.metadata || {},
-      };
-    }
-    if (
-      approval.type === "wikidata" &&
-      approval.approved === true &&
-      approval.data?.newValue?.wikidata &&
-      typeof approval.data.newValue.wikidata === "object" &&
-      approval.data.newValue.wikidata.node
-    ) {
-      return {
-        status: "approved",
-        wikidata: approval.data.newValue.wikidata,
-        message: approval.summary || "Approved",
-        metadata: approval.metadata || {},
-      };
-    }
-  }
-
-  if (job?.queueId === "guessWikidata") {
-    return {
-      status: "pending_approval",
-      wikidata: {
-        node: "Q123456",
-        url: "https://wikidata.org/wiki/Q123456",
-        label: "Example Company AB",
-        description: "Swedish company",
-      },
-      message:
-        "Wikidata selection for Example Company AB - waiting for approval",
-      metadata: {
-        source: "wikidata-search",
-        comment: "Wikidata found via search and LLM selection",
-      },
-    };
+  if (approval && typeof approval === "object" && approval.type === "wikidata") {
+    return wikidataApprovalFromApprovalObject(
+      approval as Record<string, unknown>,
+      jobData as Record<string, unknown> | undefined,
+    );
   }
 
   return null;

--- a/src/tabs/jobbstatus/lib/job-specific-data-parsing.ts
+++ b/src/tabs/jobbstatus/lib/job-specific-data-parsing.ts
@@ -74,22 +74,35 @@ export function getScope3Data(processedData: any, returnValueData: any): any {
   return null;
 }
 
+export interface WikidataApprovalWikidata {
+  node: string;
+  url: string;
+  label: string;
+  description?: string;
+}
+
+export interface WikidataApprovalData {
+  status: "approved" | "pending_approval" | "approved_unverified";
+  wikidata: WikidataApprovalWikidata;
+  message?: string;
+  metadata?: {
+    source?: string;
+    comment?: string;
+  };
+  autoApproved?: boolean;
+  verifiedByUserId?: string;
+}
+
+function approvalSummary(approval: Record<string, unknown>): string | undefined {
+  return typeof approval.summary === "string" && approval.summary.trim()
+    ? approval.summary
+    : undefined;
+}
+
 function wikidataApprovalFromApprovalObject(
   approval: Record<string, unknown>,
   jobData?: Record<string, unknown>,
-): {
-  status: "approved" | "pending_approval" | "approved_unverified";
-  wikidata: {
-    node: string;
-    url: string;
-    label: string;
-    description?: string;
-  };
-  message?: string;
-  metadata?: Record<string, unknown>;
-  autoApproved?: boolean;
-  verifiedByUserId?: string;
-} | null {
+): WikidataApprovalData | null {
   const wikidata = (approval.data as any)?.newValue?.wikidata;
   if (!wikidata || typeof wikidata !== "object" || !wikidata.node) {
     return null;
@@ -100,15 +113,14 @@ function wikidataApprovalFromApprovalObject(
     typeof approval.verifiedByUserId === "string"
       ? approval.verifiedByUserId
       : undefined;
+  const metadata = (approval.metadata as WikidataApprovalData["metadata"]) || {};
 
   if (approval.approved === false) {
     return {
       status: "pending_approval",
       wikidata,
-      message:
-        (typeof approval.summary === "string" && approval.summary) ||
-        "Waiting for approval",
-      metadata: (approval.metadata as Record<string, unknown>) || {},
+      message: approvalSummary(approval),
+      metadata,
       autoApproved,
       verifiedByUserId,
     };
@@ -120,12 +132,8 @@ function wikidataApprovalFromApprovalObject(
     return {
       status,
       wikidata,
-      message:
-        (typeof approval.summary === "string" && approval.summary) ||
-        (status === "approved_unverified"
-          ? "Auto-approved (identifier unverified)"
-          : "Approved"),
-      metadata: (approval.metadata as Record<string, unknown>) || {},
+      message: approvalSummary(approval),
+      metadata,
       autoApproved,
       verifiedByUserId,
     };
@@ -137,7 +145,7 @@ function wikidataApprovalFromApprovalObject(
 export function getWikidataApprovalData(
   job?: QueueJob,
   effectiveJob?: any,
-): ReturnType<typeof wikidataApprovalFromApprovalObject> {
+): WikidataApprovalData | null {
   const jobData = effectiveJob?.data || job?.data;
   const approval = jobData?.approval;
 


### PR DESCRIPTION
### ✨ What’s Changed?

Validate Phase 4 companion to garbo’s company identifier / `companyId` work ([garbo Phase 3](https://github.com/Klimatbyran/garbo/pull/1339)). Staff UI now understands `identifiers[]`, nullable `wikidataId`, internal company UUIDs, and the distinction between **pipeline blocked** (pending Wikidata approval) vs **Wikidata auto-approved but unverified** (pipeline continues).

**Editor (4.1 / 4.2)**
- Parse and display `identifiers[]` on company detail with verified / unverified badges
- Sync editable Wikidata / LEI fields from identifiers when present
- `getCompany` fetches pipeline detail by internal UUID (not only Q-id); falls back to list match pre-deploy
- `deleteCompany` uses internal `company.id` instead of requiring `wikidataId`

**Job status / approvals (4.3)**
- Wikidata approve rerun sends `verifiedByUserId` from the logged-in Validate user
- `WikidataApprovalDisplay` shows human-approved vs **auto-approved (unverified)**
- Removed placeholder guessWikidata mock data from job parsing

**Swimlane (4.4)**
- New status `wikidata_unverified` for completed `guessWikidata` jobs with `autoApprove` and no human verifier
- Distinct styling from orange `needs_approval` (pipeline blocked)
- Step-level aggregation treats unverified Wikidata as progress, not a blocker

**Overview / archive (4.5)**
- Archive run cards show `companyId` with editor link when `wikidataId` is null
- Overview / editor navigation already use internal id where available

### 🔎 Context

- **Validate issue:** [#235](https://github.com/Klimatbyran/validate-frontend/issues/235)
- **Plan:** garbo `doc/COMPANY_IDENTIFIERS_PLAN.md` — Phase 4
- **Depends on garbo:** Phase 2 (PK flip, [#1332](https://github.com/Klimatbyran/garbo/pull/1332)) and Phase 3 (non-blocking Wikidata + `companyId`, [#1339](https://github.com/Klimatbyran/garbo/pull/1339)) merged and deployed before end-to-end testing
- **Deploy order:** garbo Phase 2 → garbo Phase 3 → validate Phase 4 (this PR)

### ✅ Validation / Test Plan (if applicable)

- [x] `npm test` — 46 tests pass (includes new `workflow-utils` and `companies-schemas` tests, updated `CompanyDetailTab` test)
- [x] `tsc --noEmit` — clean
- [ ] Manual verification against stage **after garbo Phase 2 + 3 deploy:**
  - [ ] Company detail shows identifier list + verification badges from live API
  - [ ] Company without Wikidata loads via internal UUID in editor URL
  - [ ] Wikidata approve in job details sets verifier metadata end-to-end
  - [ ] Swimlane: pending approval = orange; auto-approved unverified = distinct badge; manually approved = green
  - [ ] Archive run without Wikidata shows company id link to editor

### 📸 Screenshots / Screen recordings (if applicable)

N/A — blocked on garbo deploy for meaningful before/after screenshots.

### 💥 Impact (check all that apply)

- [ ] **Docs updated** (README/docs)
- [ ] **Routes/query params updated** (deep-links / URL state)
- [ ] **Breaking change**
- [ ] **Backfill/migration needed**
- [x] **Data/validation behavior changed** (rules, units, rounding, derived calcs, defaults)
- [ ] **Visual or setup change only** (styling, ui, gh templates, etc)

### 📋 Checklist

- [x] PR title starts with an issue reference (e.g. `[#123] ...`) or uses a prefix like `[fix]` / `[feat]` / `[chore]`
- [x] Labels set (and milestone if relevant)
- [ ] I’ve verified the change locally (repro steps included above when non-trivial)
- [x] Any new env vars/config are documented (and safe defaults exist)
- [x] Follow-ups created as issues (or N/A)

### 🛠 Related Issue

Closes #235