### PR TITLE
[Prod] Minor Version Bump v1.13.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "garbo-validation-tool",
-  "version": "1.12.1-rc.2",
+  "version": "1.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "garbo-validation-tool",
-      "version": "1.12.1-rc.2",
+      "version": "1.13.0",
       "dependencies": {
         "@mendable/firecrawl-js": "^4.12.1",
         "@radix-ui/react-dialog": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "garbo-validation-tool",
   "private": true,
-  "version": "1.12.1-rc.2",
+  "version": "1.13.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
# 🚀 Production Release PR (Validate)

> **Title format:** `[Prod] Major/Minor/Patch Version Bump vX.X.X`

## 📦 Release type

_Select one._

- [ ] Major
- [x] Minor
- [ ] Patch

## 🔁 Environment promotion

This release promotes changes **to production**.

## 🧾 Version / artifacts

- **Version being released**: v1.13.0
- **Rollback target version** (if needed): v1.12.0

## 📋 What's being released

_High-level bullets (avoid listing every file)._

### Company identifiers — Phase 4

- **Identifiers & internal company ID support** ([#236](https://github.com/Klimatbyran/validate-frontend/pull/236)): Validate companion to [garbo Phase 3](https://github.com/Klimatbyran/garbo/pull/1339) and [unearth-api #39](https://github.com/UnearthData/api/pull/39). Staff UI understands `identifiers[]`, nullable `wikidataId`, and internal company UUIDs.
  - Editor: parse/display `identifiers[]` with verified/unverified badges; sync editable Wikidata/LEI from identifiers; fetch company detail by internal UUID; `deleteCompany` uses `company.id`
  - Job status: Wikidata approve sends `verifiedByUserId`; `WikidataApprovalDisplay` distinguishes human-approved vs auto-approved (unverified); new `wikidata_unverified` swimlane status
  - Archive/overview: run cards link to editor via `companyId` when `wikidataId` is null
- **Job status fixes** for wikidataId/companyId pipeline changes (job parsing, approval display, company detail tab cleanup).

### Overview tab

- **Registry reports & prod-to-stage UI** ([#237](https://github.com/Klimatbyran/validate-frontend/pull/237)): default to all years; show registry report URL/ID columns; tighten `viewMode` handling; update prod-to-stage copy and diagnostics for corrected inclusion logic (paired with [unearth-api #21](https://github.com/UnearthData/api/pull/21)).

## 🗂 Deployment notes

**Paired release** — deploy in the same window as [garbo #1348](https://github.com/Klimatbyran/garbo/pull/1348) (v6.0.0) and [unearth-api #40](https://github.com/UnearthData/api/pull/40) (v1.5.0).

**Order (prod):**

1. Garbo Phase 2 + Phase 3 deploy (migrations + PK flip validation)
2. unearth-api v1.5.0 deploy
3. **validate** (this PR) deploy
4. Smoke test: editor open by UUID, identifier badges, Wikidata approve attribution, overview gap view, job status swimlanes

**Depends on:** garbo Phase 2 ([#1332](https://github.com/Klimatbyran/garbo/pull/1332)) and Phase 3 ([#1339](https://github.com/Klimatbyran/garbo/pull/1339)) live in prod before end-to-end Phase 4 testing.

## ✅ Validation / smoke check (production)

_Check anything you actually verified._

- [ ] App loads
- [ ] Key flows still work (open company, navigate tabs, save where applicable)
- [ ] No obvious console/network errors
- [ ] Company without Wikidata loads via internal UUID in editor URL
- [ ] Identifier list + verification badges from live API
- [ ] Wikidata approve sets verifier metadata end-to-end
- [ ] Swimlane: pending approval vs auto-approved unverified vs manually approved
- [ ] Overview gap view loads with registry URL columns and prod-to-stage rows

## ✅ Checklist

- [x] Version updated correctly (and changelog/release notes if you use them)
- [ ] Changes QA'd in staging (after garbo + unearth-api deploy)
- [x] Rollback target recorded above
- [ ] Title follows: `[Prod] Minor Version Bump v1.13.0`

---

_Use this template for versioned production releases. For other PR types, use a different template._
