### PR TITLE
[Prod] Patch Version Bump v1.13.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "garbo-validation-tool",
-  "version": "1.13.1-rc.2",
+  "version": "1.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "garbo-validation-tool",
-      "version": "1.13.1-rc.2",
+      "version": "1.13.1",
       "dependencies": {
         "@mendable/firecrawl-js": "^4.12.1",
         "@radix-ui/react-dialog": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "garbo-validation-tool",
   "private": true,
-  "version": "1.13.1-rc.2",
+  "version": "1.13.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Overview **Coverage** subtab for index constituent list tracking ([#234](https://github.com/Klimatbyran/validate-frontend/pull/234))
- Create/edit coverage lists and year editions; view matched, missing, and ambiguous rows with DB links
- Paired with [garbo v6.0.1](https://github.com/Klimatbyran/garbo/pull/1350) (DB migration) and [unearth-api v1.5.1](https://github.com/UnearthData/api/pull/43)

## Release type
- [ ] Major
- [ ] Minor
- [x] Patch

## Version / artifacts
- **Version being released**: v1.13.1
- **Rollback target version**: v1.13.0

## Deployment notes

**Paired release** — deploy after Garbo prod migration and unearth-api v1.5.1.

**Order (prod):**
1. [Garbo v6.0.1](https://github.com/Klimatbyran/garbo/pull/1350) deploy (coverage_lists migration)
2. [unearth-api v1.5.1](https://github.com/UnearthData/api/pull/43) deploy
3. **validate** (this PR) deploy
4. Smoke test: Overview → Coverage → create list, add year, paste names; filter by matched/missing/ambiguous

## Test plan
- [ ] App loads in prod
- [ ] Coverage subtab visible under Overview
- [ ] Create list + year edition with pasted company names
- [ ] Matched rows link to editor; ambiguous rows show suggested match
- [ ] No console/network errors on coverage API calls

## Checklist
- [x] Version updated correctly
- [ ] Changes QA'd in staging
- [x] Rollback target recorded
- [x] Title follows required format