### PR TITLE
Coverage tab: edit entry company match

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1155,8 +1155,21 @@
         "updated": "Updated",
         "listName": "List name",
         "status": "Status",
-        "dbMatch": "DB match"
+        "dbMatch": "DB match",
+        "actions": "Actions"
       },
+      "editMatch": "Edit match",
+      "editMatchTitle": "Edit company match",
+      "editMatchDescription": "Search Garbo companies and link this list entry to an existing company.",
+      "searchCompanyLabel": "Search companies",
+      "searchCompanyPlaceholder": "Type at least 2 characters…",
+      "searchMinLength": "Type at least 2 characters to search.",
+      "searchNoResults": "No companies found.",
+      "confirmMatch": "Save match",
+      "clearMatch": "Clear manual match",
+      "useSuggestedMatch": "Use suggested match",
+      "suggestedMatch": "suggested",
+      "manualBadge": "manual",
       "stats": {
         "total": "Total names",
         "matched": "Matched",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -1155,8 +1155,21 @@
         "updated": "Uppdaterad",
         "listName": "Listnamn",
         "status": "Status",
-        "dbMatch": "DB-match"
+        "dbMatch": "DB-match",
+        "actions": "Åtgärder"
       },
+      "editMatch": "Redigera match",
+      "editMatchTitle": "Redigera företagsmatch",
+      "editMatchDescription": "Sök Garbo-företag och koppla listraden till ett befintligt företag.",
+      "searchCompanyLabel": "Sök företag",
+      "searchCompanyPlaceholder": "Skriv minst 2 tecken…",
+      "searchMinLength": "Skriv minst 2 tecken för att söka.",
+      "searchNoResults": "Inga företag hittades.",
+      "confirmMatch": "Spara match",
+      "clearMatch": "Rensa manuell match",
+      "useSuggestedMatch": "Använd föreslagen match",
+      "suggestedMatch": "föreslagen",
+      "manualBadge": "manuell",
       "stats": {
         "total": "Totalt antal namn",
         "matched": "Matchade",

--- a/src/tabs/overview/components/CoverageEntryMatchDialog.tsx
+++ b/src/tabs/overview/components/CoverageEntryMatchDialog.tsx
@@ -53,9 +53,7 @@ export function CoverageEntryMatchDialog({
         .then((hits) => setResults(hits))
         .catch((err) => {
           setResults([]);
-          setSearchError(
-            err instanceof Error ? err.message : "Search failed",
-          );
+          setSearchError(err instanceof Error ? err.message : "Search failed");
         })
         .finally(() => setIsSearching(false));
     }, 300);
@@ -160,7 +158,9 @@ export function CoverageEntryMatchDialog({
                     <button
                       type="button"
                       className={`w-full px-3 py-2 text-left text-sm border-b border-gray-03/60 hover:bg-gray-04/40 ${
-                        isSelected ? "bg-blue-03/10 text-blue-03" : "text-gray-01"
+                        isSelected
+                          ? "bg-blue-03/10 text-blue-03"
+                          : "text-gray-01"
                       }`}
                       onClick={() => setSelectedId(hit.id)}
                     >

--- a/src/tabs/overview/components/CoverageEntryMatchDialog.tsx
+++ b/src/tabs/overview/components/CoverageEntryMatchDialog.tsx
@@ -1,0 +1,184 @@
+import { useEffect, useMemo, useState } from "react";
+import { useI18n } from "@/contexts/I18nContext";
+import { searchCoverageCompanies } from "@/tabs/overview/lib/coverage-api";
+import type {
+  CoverageCompanySearchHit,
+  CoverageEntry,
+} from "@/tabs/overview/lib/coverage-types";
+import { Button } from "@/ui/button";
+import { Modal } from "@/ui/modal";
+
+type CoverageEntryMatchDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  entry: CoverageEntry | null;
+  onConfirm: (companyId: string | null) => Promise<void>;
+  isSubmitting?: boolean;
+};
+
+export function CoverageEntryMatchDialog({
+  open,
+  onOpenChange,
+  entry,
+  onConfirm,
+  isSubmitting = false,
+}: CoverageEntryMatchDialogProps) {
+  const { t } = useI18n();
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<CoverageCompanySearchHit[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [searchError, setSearchError] = useState<string | null>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open || !entry) return;
+    setQuery(entry.matchedCompany?.name ?? entry.name);
+    setSelectedId(null);
+    setSearchError(null);
+  }, [open, entry]);
+
+  useEffect(() => {
+    if (!open) return;
+    const trimmed = query.trim();
+    if (trimmed.length < 2) {
+      setResults([]);
+      setSearchError(null);
+      return;
+    }
+
+    const handle = window.setTimeout(() => {
+      setIsSearching(true);
+      setSearchError(null);
+      void searchCoverageCompanies(trimmed)
+        .then((hits) => setResults(hits))
+        .catch((err) => {
+          setResults([]);
+          setSearchError(
+            err instanceof Error ? err.message : "Search failed",
+          );
+        })
+        .finally(() => setIsSearching(false));
+    }, 300);
+
+    return () => window.clearTimeout(handle);
+  }, [open, query]);
+
+  const selectedCompany = useMemo(
+    () => results.find((hit) => hit.id === selectedId) ?? null,
+    [results, selectedId],
+  );
+
+  if (!entry) return null;
+
+  const suggestedHit = entry.matchedCompany
+    ? results.find((hit) => hit.wikidataId === entry.matchedCompany?.wikidataId)
+    : null;
+
+  return (
+    <Modal
+      open={open}
+      onOpenChange={onOpenChange}
+      size="lg"
+      scrollable
+      title={t("overview.coverage.editMatchTitle")}
+      description={t("overview.coverage.editMatchDescription")}
+      footer={
+        <div className="flex flex-wrap justify-end gap-2">
+          {entry.matchMethod === "manual" ? (
+            <Button
+              variant="secondary"
+              disabled={isSubmitting}
+              onClick={() => void onConfirm(null)}
+            >
+              {t("overview.coverage.clearMatch")}
+            </Button>
+          ) : null}
+          {entry.status === "ambiguous" && suggestedHit ? (
+            <Button
+              variant="secondary"
+              disabled={isSubmitting}
+              onClick={() => void onConfirm(suggestedHit.id)}
+            >
+              {t("overview.coverage.useSuggestedMatch")}
+            </Button>
+          ) : null}
+          <Button variant="secondary" onClick={() => onOpenChange(false)}>
+            {t("common.cancel")}
+          </Button>
+          <Button
+            disabled={!selectedCompany || isSubmitting}
+            onClick={() =>
+              selectedCompany ? void onConfirm(selectedCompany.id) : undefined
+            }
+          >
+            {t("overview.coverage.confirmMatch")}
+          </Button>
+        </div>
+      }
+    >
+      <div className="space-y-4">
+        <div>
+          <p className="text-xs uppercase tracking-wide text-gray-02">
+            {t("overview.coverage.columns.listName")}
+          </p>
+          <p className="text-sm text-gray-01 font-medium">{entry.name}</p>
+        </div>
+
+        <label className="block space-y-1">
+          <span className="text-sm text-gray-02">
+            {t("overview.coverage.searchCompanyLabel")}
+          </span>
+          <input
+            className="w-full rounded-md border border-gray-03 bg-gray-05 px-3 py-2 text-sm"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder={t("overview.coverage.searchCompanyPlaceholder")}
+          />
+        </label>
+
+        <div className="rounded-md border border-gray-03 max-h-64 overflow-y-auto">
+          {isSearching ? (
+            <p className="px-3 py-4 text-sm text-gray-02">
+              {t("common.loading")}
+            </p>
+          ) : searchError ? (
+            <p className="px-3 py-4 text-sm text-orange-03">{searchError}</p>
+          ) : results.length === 0 ? (
+            <p className="px-3 py-4 text-sm text-gray-02">
+              {query.trim().length < 2
+                ? t("overview.coverage.searchMinLength")
+                : t("overview.coverage.searchNoResults")}
+            </p>
+          ) : (
+            <ul>
+              {results.map((hit) => {
+                const isSelected = selectedId === hit.id;
+                const isSuggested =
+                  hit.wikidataId === entry.matchedCompany?.wikidataId;
+                return (
+                  <li key={hit.id}>
+                    <button
+                      type="button"
+                      className={`w-full px-3 py-2 text-left text-sm border-b border-gray-03/60 hover:bg-gray-04/40 ${
+                        isSelected ? "bg-blue-03/10 text-blue-03" : "text-gray-01"
+                      }`}
+                      onClick={() => setSelectedId(hit.id)}
+                    >
+                      <span className="font-medium">{hit.name}</span>
+                      <span className="ml-2 text-xs text-gray-02">
+                        {hit.wikidataId}
+                        {isSuggested
+                          ? ` · ${t("overview.coverage.suggestedMatch")}`
+                          : ""}
+                      </span>
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/tabs/overview/components/CoverageView.tsx
+++ b/src/tabs/overview/components/CoverageView.tsx
@@ -12,6 +12,8 @@ import {
 import { CoverageListTable } from "./CoverageListTable";
 import { CoverageYearDetailView } from "./CoverageYearDetail";
 import { CoverageYearFormDialog } from "./CoverageYearFormDialog";
+import { CoverageEntryMatchDialog } from "./CoverageEntryMatchDialog";
+import type { CoverageEntry } from "@/tabs/overview/lib/coverage-types";
 
 type DialogState =
   | { kind: "closed" }
@@ -35,6 +37,8 @@ export function CoverageView() {
   });
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [matchEntry, setMatchEntry] = useState<CoverageEntry | null>(null);
+  const [isMatchSubmitting, setIsMatchSubmitting] = useState(false);
 
   const selectedList = useMemo(
     () => coverage.lists.find((list) => list.id === selectedListId) ?? null,
@@ -267,6 +271,7 @@ export function CoverageView() {
                         .join("\n"),
                     })
                   }
+                  onEditEntry={setMatchEntry}
                 />
               ) : null}
             </div>
@@ -337,6 +342,26 @@ export function CoverageView() {
         confirmVariant="danger"
         onConfirm={handleConfirmDelete}
         isLoading={isDeleting}
+      />
+
+      <CoverageEntryMatchDialog
+        open={matchEntry !== null}
+        onOpenChange={(open) => {
+          if (!open) setMatchEntry(null);
+        }}
+        entry={matchEntry}
+        isSubmitting={isMatchSubmitting}
+        onConfirm={async (matchedCompanyId) => {
+          if (!matchEntry) return;
+          setIsMatchSubmitting(true);
+          try {
+            await yearDetail.setEntryMatch(matchEntry.id, matchedCompanyId);
+            await coverage.refresh();
+            setMatchEntry(null);
+          } finally {
+            setIsMatchSubmitting(false);
+          }
+        }}
       />
     </div>
   );

--- a/src/tabs/overview/components/CoverageYearDetail.tsx
+++ b/src/tabs/overview/components/CoverageYearDetail.tsx
@@ -213,7 +213,11 @@ function CoverageEntryRow({
         )}
       </td>
       <td className="px-4 py-2">
-        <Button variant="secondary" size="sm" onClick={() => onEditEntry(entry)}>
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={() => onEditEntry(entry)}
+        >
           {t("overview.coverage.editMatch")}
         </Button>
       </td>

--- a/src/tabs/overview/components/CoverageYearDetail.tsx
+++ b/src/tabs/overview/components/CoverageYearDetail.tsx
@@ -13,11 +13,13 @@ import type {
 type CoverageYearDetailProps = {
   detail: CoverageYearDetail;
   onEdit: () => void;
+  onEditEntry: (entry: CoverageEntry) => void;
 };
 
 export function CoverageYearDetailView({
   detail,
   onEdit,
+  onEditEntry,
 }: CoverageYearDetailProps) {
   const { t } = useI18n();
   const [filter, setFilter] = useState<CoverageEntryFilter>("all");
@@ -120,15 +122,22 @@ export function CoverageYearDetailView({
               <th className="px-4 py-2 font-medium">
                 {t("overview.coverage.columns.dbMatch")}
               </th>
+              <th className="px-4 py-2 font-medium w-28">
+                {t("overview.coverage.columns.actions")}
+              </th>
             </tr>
           </thead>
           <tbody>
             {filteredEntries.map((entry) => (
-              <CoverageEntryRow key={entry.id} entry={entry} />
+              <CoverageEntryRow
+                key={entry.id}
+                entry={entry}
+                onEditEntry={onEditEntry}
+              />
             ))}
             {filteredEntries.length === 0 ? (
               <tr>
-                <td colSpan={3} className="px-4 py-8 text-center text-gray-02">
+                <td colSpan={4} className="px-4 py-8 text-center text-gray-02">
                   {t("overview.coverage.noEntries")}
                 </td>
               </tr>
@@ -157,7 +166,13 @@ function CoverageStatCard({
   );
 }
 
-function CoverageEntryRow({ entry }: { entry: CoverageEntry }) {
+function CoverageEntryRow({
+  entry,
+  onEditEntry,
+}: {
+  entry: CoverageEntry;
+  onEditEntry: (entry: CoverageEntry) => void;
+}) {
   const { t } = useI18n();
 
   const statusLabel =
@@ -177,7 +192,14 @@ function CoverageEntryRow({ entry }: { entry: CoverageEntry }) {
   return (
     <tr className="border-t border-gray-03/60">
       <td className="px-4 py-2 text-gray-01">{entry.name}</td>
-      <td className={`px-4 py-2 font-medium ${statusClass}`}>{statusLabel}</td>
+      <td className={`px-4 py-2 font-medium ${statusClass}`}>
+        <span>{statusLabel}</span>
+        {entry.matchMethod === "manual" ? (
+          <span className="ml-2 text-[10px] uppercase tracking-wide text-blue-03">
+            {t("overview.coverage.manualBadge")}
+          </span>
+        ) : null}
+      </td>
       <td className="px-4 py-2 text-gray-02">
         {entry.matchedCompany ? (
           <Link
@@ -189,6 +211,11 @@ function CoverageEntryRow({ entry }: { entry: CoverageEntry }) {
         ) : (
           "—"
         )}
+      </td>
+      <td className="px-4 py-2">
+        <Button variant="secondary" size="sm" onClick={() => onEditEntry(entry)}>
+          {t("overview.coverage.editMatch")}
+        </Button>
       </td>
     </tr>
   );

--- a/src/tabs/overview/hooks/useCoverageLists.ts
+++ b/src/tabs/overview/hooks/useCoverageLists.ts
@@ -8,6 +8,7 @@ import {
   fetchCoverageYearDetail,
   renameCoverageList,
   replaceCoverageYearNames,
+  setCoverageEntryMatch,
 } from "../lib/coverage-api";
 import type {
   CoverageListSummary,
@@ -113,5 +114,21 @@ export function useCoverageYearDetail(
     void loadDetail();
   }, [loadDetail]);
 
-  return { detail, isLoading, error, refresh: loadDetail };
+  return {
+    detail,
+    isLoading,
+    error,
+    refresh: loadDetail,
+    setEntryMatch: async (entryId: string, matchedCompanyId: string | null) => {
+      if (!listId || year === null) return null;
+      const updated = await setCoverageEntryMatch(
+        listId,
+        year,
+        entryId,
+        matchedCompanyId,
+      );
+      setDetail(updated);
+      return updated;
+    },
+  };
 }

--- a/src/tabs/overview/lib/coverage-api.ts
+++ b/src/tabs/overview/lib/coverage-api.ts
@@ -4,8 +4,10 @@ import {
   coverageListCollectionSchema,
   coverageListSummarySchema,
   coverageYearDetailSchema,
+  coverageCompanySearchHitSchema,
   type CoverageListSummary,
   type CoverageYearDetail,
+  type CoverageCompanySearchHit,
 } from "./coverage-types";
 
 function coverageUrl(path: string): string {
@@ -150,6 +152,33 @@ export async function deleteCoverageListYear(
       `Delete coverage year failed (${response.status})${body ? `: ${body.slice(0, 200)}` : ""}`,
     );
   }
+}
+
+export async function searchCoverageCompanies(
+  query: string,
+): Promise<CoverageCompanySearchHit[]> {
+  const url = `${coverageUrl("companies/search")}?q=${encodeURIComponent(query)}`;
+  const response = await garboAuthFetch(url, { cache: "no-store" });
+  return parseJson(response, url, (data) =>
+    z.array(coverageCompanySearchHitSchema).parse(data),
+  );
+}
+
+export async function setCoverageEntryMatch(
+  listId: string,
+  year: number,
+  entryId: string,
+  matchedCompanyId: string | null,
+): Promise<CoverageYearDetail> {
+  const url = coverageUrl(`${listId}/years/${year}/entries/${entryId}`);
+  const response = await garboAuthFetch(url, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ matchedCompanyId }),
+  });
+  return parseJson(response, url, (data) =>
+    coverageYearDetailSchema.parse(data),
+  );
 }
 
 export function namesFromTextarea(text: string): string[] {

--- a/src/tabs/overview/lib/coverage-types.ts
+++ b/src/tabs/overview/lib/coverage-types.ts
@@ -26,11 +26,20 @@ export const coverageEntryStatusSchema = z.enum([
   "ambiguous",
 ]);
 
+export const coverageMatchMethodSchema = z.enum(["auto", "manual"]);
+
 export const coverageEntrySchema = z.object({
   id: z.string(),
   name: z.string(),
   status: coverageEntryStatusSchema,
+  matchMethod: coverageMatchMethodSchema.optional(),
   matchedCompany: coverageMatchedCompanySchema.optional(),
+});
+
+export const coverageCompanySearchHitSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  wikidataId: z.string(),
 });
 
 export const coverageYearDetailSchema = coverageYearSummarySchema.extend({
@@ -51,5 +60,8 @@ export type CoverageListSummary = z.infer<typeof coverageListSummarySchema>;
 export type CoverageEntryStatus = z.infer<typeof coverageEntryStatusSchema>;
 export type CoverageEntry = z.infer<typeof coverageEntrySchema>;
 export type CoverageYearDetail = z.infer<typeof coverageYearDetailSchema>;
+export type CoverageCompanySearchHit = z.infer<
+  typeof coverageCompanySearchHitSchema
+>;
 
 export type CoverageEntryFilter = "all" | CoverageEntryStatus;


### PR DESCRIPTION
## Summary
- Adds per-row "Edit match" action on Coverage year detail
- Search dialog queries Garbo companies via new API endpoint
- Staff can confirm a match, use suggested match for ambiguous rows, or clear manual overrides
- Shows manual badge when `matchMethod` is `manual`

## Depends on
- https://github.com/Klimatbyran/garbo/pull/1352 (`matched_company_id` column)
- https://github.com/UnearthData/api/pull/44 (search + PATCH endpoints)

## Test plan
- [x] `npm run build`
- [ ] Open Coverage tab → year detail → Edit match on missing/ambiguous row
- [ ] Search company, save match, verify status and link update
- [ ] Clear manual match and confirm auto-matching resumes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Staff can persist company links for index coverage entries via authenticated PATCH; wrong matches affect coverage metrics but scope is limited to the Coverage tab and existing auth.
> 
> **Overview**
> Adds **staff workflows to fix Coverage list entries** that are missing or ambiguous by linking them to Garbo companies from the year-detail table.
> 
> Each row gets an **Edit match** action that opens a modal with debounced company search (min 2 characters), result selection, **Save match**, optional **Use suggested match** for ambiguous rows, and **Clear manual match** when `matchMethod` is manual. Manual overrides show a **manual** badge on the status column.
> 
> The client wires **company search** and **PATCH entry match** (`matchedCompanyId`, including `null` to clear) through `coverage-api` and `useCoverageYearDetail.setEntryMatch`, with updated Zod types for `matchMethod` and search hits. **EN/SV** strings cover the new UI.
> 
> Depends on backend coverage search + PATCH endpoints and Garbo `matched_company_id` support (see linked PRs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f52e279e9640bc470ae80fc7f626633829c3d6f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->