### PR TITLE
Fix coverage company search in edit match dialog

### DIFF
--- a/src/tabs/overview/components/CoverageEntryMatchDialog.tsx
+++ b/src/tabs/overview/components/CoverageEntryMatchDialog.tsx
@@ -50,7 +50,14 @@ export function CoverageEntryMatchDialog({
       setIsSearching(true);
       setSearchError(null);
       void searchCoverageCompanies(trimmed)
-        .then((hits) => setResults(hits))
+        .then((hits) => {
+          setResults(hits);
+          if (!entry?.matchedCompany) return;
+          const suggested = hits.find(
+            (hit) => hit.wikidataId === entry.matchedCompany?.wikidataId,
+          );
+          if (suggested) setSelectedId(suggested.id);
+        })
         .catch((err) => {
           setResults([]);
           setSearchError(err instanceof Error ? err.message : "Search failed");
@@ -59,7 +66,7 @@ export function CoverageEntryMatchDialog({
     }, 300);
 
     return () => window.clearTimeout(handle);
-  }, [open, query]);
+  }, [open, query, entry]);
 
   const selectedCompany = useMemo(
     () => results.find((hit) => hit.id === selectedId) ?? null,

--- a/src/tabs/overview/lib/coverage-api.ts
+++ b/src/tabs/overview/lib/coverage-api.ts
@@ -4,7 +4,7 @@ import {
   coverageListCollectionSchema,
   coverageListSummarySchema,
   coverageYearDetailSchema,
-  coverageCompanySearchHitSchema,
+  coverageCompanySearchResponseSchema,
   type CoverageListSummary,
   type CoverageYearDetail,
   type CoverageCompanySearchHit,
@@ -160,7 +160,7 @@ export async function searchCoverageCompanies(
   const url = `${coverageUrl("companies/search")}?q=${encodeURIComponent(query)}`;
   const response = await garboAuthFetch(url, { cache: "no-store" });
   return parseJson(response, url, (data) =>
-    z.array(coverageCompanySearchHitSchema).parse(data),
+    coverageCompanySearchResponseSchema.parse(data),
   );
 }
 

--- a/src/tabs/overview/lib/coverage-types.ts
+++ b/src/tabs/overview/lib/coverage-types.ts
@@ -42,6 +42,10 @@ export const coverageCompanySearchHitSchema = z.object({
   wikidataId: z.string(),
 });
 
+export const coverageCompanySearchResponseSchema = z.array(
+  coverageCompanySearchHitSchema,
+);
+
 export const coverageYearDetailSchema = coverageYearSummarySchema.extend({
   listId: z.string(),
   listName: z.string(),


### PR DESCRIPTION
## Summary
- Fixes `z is not defined` when searching companies in the Coverage edit-match dialog
- Adds `coverageCompanySearchResponseSchema` and uses it in `searchCoverageCompanies()`
- Pre-selects the suggested DB match for ambiguous entries once search results load

## Test plan
- [x] `npm run build`
- [ ] Open ambiguous entry (e.g. Better Collective) → Edit match → search returns results instead of error
- [ ] Suggested match is pre-selected; **Save match** and **Use suggested match** work


Made with [Cursor](https://cursor.com)