### PR TITLE
Add toast feedback for coverage match save

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1170,6 +1170,9 @@
       "useSuggestedMatch": "Use suggested match",
       "suggestedMatch": "suggested",
       "manualBadge": "manual",
+      "saveMatchSuccess": "Saved match for {{name}} → {{company}}",
+      "clearMatchSuccess": "Cleared manual match for {{name}}",
+      "saveMatchError": "Could not save match for {{name}}: {{message}}",
       "stats": {
         "total": "Total names",
         "matched": "Matched",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -1170,6 +1170,9 @@
       "useSuggestedMatch": "Använd föreslagen match",
       "suggestedMatch": "föreslagen",
       "manualBadge": "manuell",
+      "saveMatchSuccess": "Sparade match för {{name}} → {{company}}",
+      "clearMatchSuccess": "Rensade manuell match för {{name}}",
+      "saveMatchError": "Kunde inte spara match för {{name}}: {{message}}",
       "stats": {
         "total": "Totalt antal namn",
         "matched": "Matchade",

--- a/src/tabs/overview/components/CoverageEntryMatchDialog.tsx
+++ b/src/tabs/overview/components/CoverageEntryMatchDialog.tsx
@@ -12,7 +12,10 @@ type CoverageEntryMatchDialogProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   entry: CoverageEntry | null;
-  onConfirm: (companyId: string | null) => Promise<void>;
+  onConfirm: (
+    companyId: string | null,
+    companyName?: string | null,
+  ) => Promise<void>;
   isSubmitting?: boolean;
 };
 
@@ -102,7 +105,7 @@ export function CoverageEntryMatchDialog({
             <Button
               variant="secondary"
               disabled={isSubmitting}
-              onClick={() => void onConfirm(suggestedHit.id)}
+              onClick={() => void onConfirm(suggestedHit.id, suggestedHit.name)}
             >
               {t("overview.coverage.useSuggestedMatch")}
             </Button>
@@ -113,7 +116,9 @@ export function CoverageEntryMatchDialog({
           <Button
             disabled={!selectedCompany || isSubmitting}
             onClick={() =>
-              selectedCompany ? void onConfirm(selectedCompany.id) : undefined
+              selectedCompany
+                ? void onConfirm(selectedCompany.id, selectedCompany.name)
+                : undefined
             }
           >
             {t("overview.coverage.confirmMatch")}

--- a/src/tabs/overview/components/CoverageView.tsx
+++ b/src/tabs/overview/components/CoverageView.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
 import { Loader2, RefreshCw } from "lucide-react";
+import { toast } from "sonner";
 import { useI18n } from "@/contexts/I18nContext";
 import { Button } from "@/ui/button";
 import { Callout } from "@/ui/callout";
@@ -351,13 +352,34 @@ export function CoverageView() {
         }}
         entry={matchEntry}
         isSubmitting={isMatchSubmitting}
-        onConfirm={async (matchedCompanyId) => {
+        onConfirm={async (matchedCompanyId, companyName) => {
           if (!matchEntry) return;
           setIsMatchSubmitting(true);
           try {
             await yearDetail.setEntryMatch(matchEntry.id, matchedCompanyId);
             await coverage.refresh();
             setMatchEntry(null);
+            if (matchedCompanyId === null) {
+              toast.success(
+                t("overview.coverage.clearMatchSuccess", {
+                  name: matchEntry.name,
+                }),
+              );
+            } else {
+              toast.success(
+                t("overview.coverage.saveMatchSuccess", {
+                  name: matchEntry.name,
+                  company: companyName ?? "",
+                }),
+              );
+            }
+          } catch (err) {
+            toast.error(
+              t("overview.coverage.saveMatchError", {
+                name: matchEntry.name,
+                message: err instanceof Error ? err.message : "Unknown error",
+              }),
+            );
           } finally {
             setIsMatchSubmitting(false);
           }


### PR DESCRIPTION
## Summary
- Shows a success toast when saving or clearing a manual coverage match
- Shows an error toast if the save request fails
- Includes list entry name and matched company name in the success message

## Test plan
- [x] `npm run build`
- [ ] Save match on ambiguous entry → green success toast
- [ ] Use suggested match → green success toast with company name
- [ ] Clear manual match → green success toast
- [ ] Simulate API failure → red error toast, dialog stays open


Made with [Cursor](https://cursor.com)