### PR TITLE
Mark ambiguous coverage entries as missing

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1167,11 +1167,13 @@
       "searchNoResults": "No companies found.",
       "confirmMatch": "Save match",
       "clearMatch": "Clear manual match",
+      "markAsMissing": "Mark as missing",
       "useSuggestedMatch": "Use suggested match",
       "suggestedMatch": "suggested",
       "manualBadge": "manual",
       "saveMatchSuccess": "Saved match for {{name}} → {{company}}",
       "clearMatchSuccess": "Cleared manual match for {{name}}",
+      "markAsMissingSuccess": "Marked {{name}} as missing in Garbo",
       "saveMatchError": "Could not save match for {{name}}: {{message}}",
       "stats": {
         "total": "Total names",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -1167,11 +1167,13 @@
       "searchNoResults": "Inga företag hittades.",
       "confirmMatch": "Spara match",
       "clearMatch": "Rensa manuell match",
+      "markAsMissing": "Markera som saknas",
       "useSuggestedMatch": "Använd föreslagen match",
       "suggestedMatch": "föreslagen",
       "manualBadge": "manuell",
       "saveMatchSuccess": "Sparade match för {{name}} → {{company}}",
       "clearMatchSuccess": "Rensade manuell match för {{name}}",
+      "markAsMissingSuccess": "Markerade {{name}} som saknas i Garbo",
       "saveMatchError": "Kunde inte spara match för {{name}}: {{message}}",
       "stats": {
         "total": "Totalt antal namn",

--- a/src/tabs/overview/components/CoverageEntryMatchDialog.tsx
+++ b/src/tabs/overview/components/CoverageEntryMatchDialog.tsx
@@ -4,6 +4,7 @@ import { searchCoverageCompanies } from "@/tabs/overview/lib/coverage-api";
 import type {
   CoverageCompanySearchHit,
   CoverageEntry,
+  CoverageMatchSaveAction,
 } from "@/tabs/overview/lib/coverage-types";
 import { Button } from "@/ui/button";
 import { Modal } from "@/ui/modal";
@@ -12,10 +13,7 @@ type CoverageEntryMatchDialogProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   entry: CoverageEntry | null;
-  onConfirm: (
-    companyId: string | null,
-    companyName?: string | null,
-  ) => Promise<void>;
+  onAction: (action: CoverageMatchSaveAction) => Promise<void>;
   isSubmitting?: boolean;
 };
 
@@ -23,7 +21,7 @@ export function CoverageEntryMatchDialog({
   open,
   onOpenChange,
   entry,
-  onConfirm,
+  onAction,
   isSubmitting = false,
 }: CoverageEntryMatchDialogProps) {
   const { t } = useI18n();
@@ -96,16 +94,30 @@ export function CoverageEntryMatchDialog({
             <Button
               variant="secondary"
               disabled={isSubmitting}
-              onClick={() => void onConfirm(null)}
+              onClick={() => void onAction({ type: "clear" })}
             >
               {t("overview.coverage.clearMatch")}
+            </Button>
+          ) : entry.status === "ambiguous" ? (
+            <Button
+              variant="secondary"
+              disabled={isSubmitting}
+              onClick={() => void onAction({ type: "markMissing" })}
+            >
+              {t("overview.coverage.markAsMissing")}
             </Button>
           ) : null}
           {entry.status === "ambiguous" && suggestedHit ? (
             <Button
               variant="secondary"
               disabled={isSubmitting}
-              onClick={() => void onConfirm(suggestedHit.id, suggestedHit.name)}
+              onClick={() =>
+                void onAction({
+                  type: "match",
+                  companyId: suggestedHit.id,
+                  companyName: suggestedHit.name,
+                })
+              }
             >
               {t("overview.coverage.useSuggestedMatch")}
             </Button>
@@ -117,7 +129,11 @@ export function CoverageEntryMatchDialog({
             disabled={!selectedCompany || isSubmitting}
             onClick={() =>
               selectedCompany
-                ? void onConfirm(selectedCompany.id, selectedCompany.name)
+                ? void onAction({
+                    type: "match",
+                    companyId: selectedCompany.id,
+                    companyName: selectedCompany.name,
+                  })
                 : undefined
             }
           >

--- a/src/tabs/overview/components/CoverageView.tsx
+++ b/src/tabs/overview/components/CoverageView.tsx
@@ -14,7 +14,10 @@ import { CoverageListTable } from "./CoverageListTable";
 import { CoverageYearDetailView } from "./CoverageYearDetail";
 import { CoverageYearFormDialog } from "./CoverageYearFormDialog";
 import { CoverageEntryMatchDialog } from "./CoverageEntryMatchDialog";
-import type { CoverageEntry } from "@/tabs/overview/lib/coverage-types";
+import type {
+  CoverageEntry,
+  CoverageMatchSaveAction,
+} from "@/tabs/overview/lib/coverage-types";
 
 type DialogState =
   | { kind: "closed" }
@@ -352,16 +355,22 @@ export function CoverageView() {
         }}
         entry={matchEntry}
         isSubmitting={isMatchSubmitting}
-        onConfirm={async (matchedCompanyId, companyName) => {
+        onAction={async (action: CoverageMatchSaveAction) => {
           if (!matchEntry) return;
           setIsMatchSubmitting(true);
           try {
-            await yearDetail.setEntryMatch(matchEntry.id, matchedCompanyId);
+            await yearDetail.setEntryMatch(matchEntry.id, action);
             await coverage.refresh();
             setMatchEntry(null);
-            if (matchedCompanyId === null) {
+            if (action.type === "clear") {
               toast.success(
                 t("overview.coverage.clearMatchSuccess", {
+                  name: matchEntry.name,
+                }),
+              );
+            } else if (action.type === "markMissing") {
+              toast.success(
+                t("overview.coverage.markAsMissingSuccess", {
                   name: matchEntry.name,
                 }),
               );
@@ -369,7 +378,7 @@ export function CoverageView() {
               toast.success(
                 t("overview.coverage.saveMatchSuccess", {
                   name: matchEntry.name,
-                  company: companyName ?? "",
+                  company: action.companyName,
                 }),
               );
             }

--- a/src/tabs/overview/hooks/useCoverageLists.ts
+++ b/src/tabs/overview/hooks/useCoverageLists.ts
@@ -13,6 +13,7 @@ import {
 import type {
   CoverageListSummary,
   CoverageYearDetail,
+  CoverageMatchSaveAction,
 } from "../lib/coverage-types";
 
 export function useCoverageLists() {
@@ -119,13 +120,28 @@ export function useCoverageYearDetail(
     isLoading,
     error,
     refresh: loadDetail,
-    setEntryMatch: async (entryId: string, matchedCompanyId: string | null) => {
+    setEntryMatch: async (entryId: string, action: CoverageMatchSaveAction) => {
       if (!listId || year === null) return null;
+      const payload =
+        action.type === "match"
+          ? {
+              matchedCompanyId: action.companyId,
+              matchConfirmedMissing: false,
+            }
+          : action.type === "markMissing"
+            ? {
+                matchedCompanyId: null,
+                matchConfirmedMissing: true,
+              }
+            : {
+                matchedCompanyId: null,
+                matchConfirmedMissing: false,
+              };
       const updated = await setCoverageEntryMatch(
         listId,
         year,
         entryId,
-        matchedCompanyId,
+        payload,
       );
       setDetail(updated);
       return updated;

--- a/src/tabs/overview/lib/coverage-api.ts
+++ b/src/tabs/overview/lib/coverage-api.ts
@@ -168,13 +168,16 @@ export async function setCoverageEntryMatch(
   listId: string,
   year: number,
   entryId: string,
-  matchedCompanyId: string | null,
+  input: {
+    matchedCompanyId: string | null;
+    matchConfirmedMissing?: boolean;
+  },
 ): Promise<CoverageYearDetail> {
   const url = coverageUrl(`${listId}/years/${year}/entries/${entryId}`);
   const response = await garboAuthFetch(url, {
     method: "PATCH",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ matchedCompanyId }),
+    body: JSON.stringify(input),
   });
   return parseJson(response, url, (data) =>
     coverageYearDetailSchema.parse(data),

--- a/src/tabs/overview/lib/coverage-types.ts
+++ b/src/tabs/overview/lib/coverage-types.ts
@@ -68,4 +68,7 @@ export type CoverageCompanySearchHit = z.infer<
   typeof coverageCompanySearchHitSchema
 >;
 
-export type CoverageEntryFilter = "all" | CoverageEntryStatus;
+export type CoverageMatchSaveAction =
+  | { type: "match"; companyId: string; companyName: string }
+  | { type: "clear" }
+  | { type: "markMissing" };


### PR DESCRIPTION
## Summary
- Adds **Mark as missing** button for ambiguous entries in the edit-match dialog
- Dismisses wrong auto-match suggestions and persists confirmed missing status
- Success toast: "Marked {{name}} as missing in Garbo"
- **Clear manual match** still reverts manual overrides (including confirmed missing) back to auto-matching

## Depends on
- https://github.com/Klimatbyran/garbo/pull/1353
- https://github.com/UnearthData/api/pull/46

## Test plan
- [x] `npm run build`
- [ ] Ambiguous entry → Edit match → Mark as missing → status becomes Missing with manual badge
- [ ] Confirmed missing entry → Clear manual match → auto-match resumes
- [ ] Save match / suggested match still work as before