### PR TITLE
[Prod] Patch Version Bump v1.13.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "garbo-validation-tool",
-  "version": "1.13.2-rc.4",
+  "version": "1.13.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "garbo-validation-tool",
-      "version": "1.13.2-rc.4",
+      "version": "1.13.2",
       "dependencies": {
         "@mendable/firecrawl-js": "^4.12.1",
         "@radix-ui/react-dialog": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "garbo-validation-tool",
   "private": true,
-  "version": "1.13.2-rc.4",
+  "version": "1.13.2",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Coverage tab **Edit match** dialog with Garbo company search ([#248](https://github.com/Klimatbyran/validate-frontend/pull/248))
- Fix company search `z is not defined` error ([#249](https://github.com/Klimatbyran/validate-frontend/pull/249))
- Toast feedback on save/clear match ([#250](https://github.com/Klimatbyran/validate-frontend/pull/250))
- **Mark as missing** for ambiguous entries ([#251](https://github.com/Klimatbyran/validate-frontend/pull/251))
- Paired with [garbo v6.0.2](https://github.com/Klimatbyran/garbo/pull/1354) and [unearth-api v1.5.2](https://github.com/UnearthData/api/pull/47)

## Release type
- [ ] Major
- [ ] Minor
- [x] Patch

## Version / artifacts
- **Version being released**: v1.13.2
- **Rollback target version**: v1.13.1

## Deployment notes

**Paired release** — deploy after Garbo prod migrations and unearth-api v1.5.2.

**Order (prod):**
1. [Garbo v6.0.2](https://github.com/Klimatbyran/garbo/pull/1354) deploy
2. [unearth-api v1.5.2](https://github.com/UnearthData/api/pull/47) deploy
3. **validate** (this PR) deploy
4. Smoke test: Overview → Coverage → edit match, save, mark as missing, clear manual match

## Test plan
- [ ] App loads in prod
- [ ] Coverage subtab — edit match search works
- [ ] Save match / use suggested / mark as missing / clear manual match with toasts
- [ ] No console/network errors on coverage API calls

## Checklist
- [x] Version updated correctly
- [x] Changes QA'd in staging
- [x] Rollback target recorded
- [x] Title follows required format


Made with [Cursor](https://cursor.com)