### PR TITLE
Show registry report pills in Coverage year detail

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1169,7 +1169,17 @@
         "all": "All",
         "matched": "Matched",
         "missing": "Missing",
-        "ambiguous": "Ambiguous"
+        "ambiguous": "Ambiguous",
+        "hasReports": "Has reports",
+        "noReports": "No reports",
+        "prodReady": "Prod ready",
+        "reportNotProdReady": "Reports not prod-ready"
+      },
+      "reports": {
+        "none": "No reports",
+        "viewInRegistry": "View in Registry Reports",
+        "pillProdReady": "Run completed, data in prod",
+        "pillNotProdReady": "Report in registry, not prod-ready"
       },
       "columns": {
         "list": "List",
@@ -1179,6 +1189,7 @@
         "listName": "List name",
         "status": "Status",
         "dbMatch": "DB match",
+        "reports": "Reports",
         "actions": "Actions"
       },
       "editMatch": "Edit match",
@@ -1203,7 +1214,10 @@
         "matched": "Matched",
         "missing": "Missing",
         "ambiguous": "Ambiguous",
-        "coverage": "Coverage"
+        "coverage": "Coverage",
+        "hasReports": "Has reports",
+        "prodReady": "Prod ready",
+        "noReports": "No reports"
       }
     },
     "fetchError": "Could not load overview data.",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -1169,7 +1169,17 @@
         "all": "Alla",
         "matched": "Matchade",
         "missing": "Saknas",
-        "ambiguous": "Tvetydiga"
+        "ambiguous": "Tvetydiga",
+        "hasReports": "Har rapporter",
+        "noReports": "Inga rapporter",
+        "prodReady": "Prod-klar",
+        "reportNotProdReady": "Rapporter ej prod-klara"
+      },
+      "reports": {
+        "none": "Inga rapporter",
+        "viewInRegistry": "Visa i registerrapporter",
+        "pillProdReady": "Körning klar, data i prod",
+        "pillNotProdReady": "Rapport i register, ej prod-klar"
       },
       "columns": {
         "list": "Lista",
@@ -1179,6 +1189,7 @@
         "listName": "Listnamn",
         "status": "Status",
         "dbMatch": "DB-match",
+        "reports": "Rapporter",
         "actions": "Åtgärder"
       },
       "editMatch": "Redigera match",
@@ -1203,7 +1214,10 @@
         "matched": "Matchade",
         "missing": "Saknas",
         "ambiguous": "Tvetydiga",
-        "coverage": "Täckning"
+        "coverage": "Täckning",
+        "hasReports": "Har rapporter",
+        "prodReady": "Prod-klar",
+        "noReports": "Inga rapporter"
       }
     },
     "fetchError": "Kunde inte ladda översiktsdata.",

--- a/src/tabs/overview/OverviewTab.tsx
+++ b/src/tabs/overview/OverviewTab.tsx
@@ -336,7 +336,11 @@ export function OverviewTab() {
             <LoadingSpinner />
           </div>
         ) : data.error && !isCoverage ? null : isCoverage ? (
-          <CoverageView />
+          <CoverageView
+            onViewRegistryReports={(names) =>
+              data.openRegistryReportsWithSearch(names.join("\n"))
+            }
+          />
         ) : isProdToStage ? (
           <ProdToStageTable
             data={data}

--- a/src/tabs/overview/components/CoverageView.tsx
+++ b/src/tabs/overview/components/CoverageView.tsx
@@ -30,7 +30,11 @@ type DeleteConfirmState =
   | { kind: "year"; listId: string; listName: string; year: number }
   | { kind: "list"; listId: string; listName: string };
 
-export function CoverageView() {
+type CoverageViewProps = {
+  onViewRegistryReports?: (names: string[]) => void;
+};
+
+export function CoverageView({ onViewRegistryReports }: CoverageViewProps) {
   const { t } = useI18n();
   const coverage = useCoverageLists();
   const [selectedListId, setSelectedListId] = useState<string | null>(null);
@@ -265,6 +269,7 @@ export function CoverageView() {
               ) : yearDetail.detail ? (
                 <CoverageYearDetailView
                   detail={yearDetail.detail}
+                  onViewRegistryReports={onViewRegistryReports}
                   onEdit={() =>
                     setDialog({
                       kind: "editYear",

--- a/src/tabs/overview/components/CoverageYearDetail.tsx
+++ b/src/tabs/overview/components/CoverageYearDetail.tsx
@@ -4,6 +4,7 @@ import { useI18n } from "@/contexts/I18nContext";
 import { editorCompanyPath } from "@/tabs/editor/lib/editor-routes";
 import { Button } from "@/ui/button";
 import { ViewModePills } from "@/ui/view-mode-pills";
+import { ReportYearPill } from "./ReportYearPill";
 import type {
   CoverageEntry,
   CoverageEntryFilter,
@@ -14,12 +15,40 @@ type CoverageYearDetailProps = {
   detail: CoverageYearDetail;
   onEdit: () => void;
   onEditEntry: (entry: CoverageEntry) => void;
+  onViewRegistryReports?: (names: string[]) => void;
 };
+
+function entryMatchesFilter(
+  entry: CoverageEntry,
+  filter: CoverageEntryFilter,
+): boolean {
+  const reports = entry.registryReports ?? [];
+
+  switch (filter) {
+    case "all":
+      return true;
+    case "matched":
+    case "missing":
+    case "ambiguous":
+      return entry.status === filter;
+    case "hasReports":
+      return reports.length > 0;
+    case "noReports":
+      return reports.length === 0;
+    case "prodReady":
+      return reports.some((report) => report.prodReady);
+    case "reportNotProdReady":
+      return reports.length > 0 && !reports.some((report) => report.prodReady);
+    default:
+      return true;
+  }
+}
 
 export function CoverageYearDetailView({
   detail,
   onEdit,
   onEditEntry,
+  onViewRegistryReports,
 }: CoverageYearDetailProps) {
   const { t } = useI18n();
   const [filter, setFilter] = useState<CoverageEntryFilter>("all");
@@ -32,13 +61,17 @@ export function CoverageYearDetailView({
     const q = search.trim().toLocaleLowerCase("sv-SE");
 
     return detail.entries.filter((entry) => {
-      if (filter !== "all" && entry.status !== filter) return false;
+      if (!entryMatchesFilter(entry, filter)) return false;
       if (!q) return true;
 
       const haystack = [
         entry.name,
         entry.matchedCompany?.name ?? "",
         entry.matchedCompany?.wikidataId ?? "",
+        ...(entry.registryReports ?? []).map(
+          (report) =>
+            `${report.reportYear ?? ""} ${report.companyName ?? ""}`,
+        ),
       ]
         .join(" ")
         .toLocaleLowerCase("sv-SE");
@@ -52,6 +85,13 @@ export function CoverageYearDetailView({
     { value: "matched", label: t("overview.coverage.filters.matched") },
     { value: "missing", label: t("overview.coverage.filters.missing") },
     { value: "ambiguous", label: t("overview.coverage.filters.ambiguous") },
+    { value: "hasReports", label: t("overview.coverage.filters.hasReports") },
+    { value: "noReports", label: t("overview.coverage.filters.noReports") },
+    { value: "prodReady", label: t("overview.coverage.filters.prodReady") },
+    {
+      value: "reportNotProdReady",
+      label: t("overview.coverage.filters.reportNotProdReady"),
+    },
   ];
 
   return (
@@ -61,12 +101,25 @@ export function CoverageYearDetailView({
           <h3 className="text-lg font-semibold text-gray-01">
             {detail.listName} — {detail.year}
           </h3>
-          <Button variant="secondary" size="sm" onClick={onEdit}>
-            {t("overview.coverage.editYear")}
-          </Button>
+          <div className="flex flex-wrap gap-2">
+            {onViewRegistryReports ? (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() =>
+                  onViewRegistryReports(detail.entries.map((entry) => entry.name))
+                }
+              >
+                {t("overview.coverage.reports.viewInRegistry")}
+              </Button>
+            ) : null}
+            <Button variant="secondary" size="sm" onClick={onEdit}>
+              {t("overview.coverage.editYear")}
+            </Button>
+          </div>
         </div>
 
-        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-8 gap-3">
           <CoverageStatCard
             label={t("overview.coverage.stats.total")}
             value={detail.totalNames}
@@ -91,6 +144,21 @@ export function CoverageYearDetailView({
             label={t("overview.coverage.stats.coverage")}
             value={`${detail.coveragePercent}%`}
             className="border-blue-03/30 bg-blue-03/10 text-blue-03"
+          />
+          <CoverageStatCard
+            label={t("overview.coverage.stats.hasReports")}
+            value={detail.hasAnyReportCount}
+            className="border-gray-03/80 bg-gray-04/30 text-gray-01"
+          />
+          <CoverageStatCard
+            label={t("overview.coverage.stats.prodReady")}
+            value={detail.prodReadyCount}
+            className="border-green-03/30 bg-green-03/10 text-green-03"
+          />
+          <CoverageStatCard
+            label={t("overview.coverage.stats.noReports")}
+            value={detail.noReportCount}
+            className="border-orange-03/30 bg-orange-03/10 text-orange-03"
           />
         </div>
       </div>
@@ -122,6 +190,9 @@ export function CoverageYearDetailView({
               <th className="px-4 py-2 font-medium">
                 {t("overview.coverage.columns.dbMatch")}
               </th>
+              <th className="px-4 py-2 font-medium">
+                {t("overview.coverage.columns.reports")}
+              </th>
               <th className="px-4 py-2 font-medium w-28">
                 {t("overview.coverage.columns.actions")}
               </th>
@@ -137,7 +208,7 @@ export function CoverageYearDetailView({
             ))}
             {filteredEntries.length === 0 ? (
               <tr>
-                <td colSpan={4} className="px-4 py-8 text-center text-gray-02">
+                <td colSpan={5} className="px-4 py-8 text-center text-gray-02">
                   {t("overview.coverage.noEntries")}
                 </td>
               </tr>
@@ -189,6 +260,8 @@ function CoverageEntryRow({
         ? "text-orange-03"
         : "text-yellow-400";
 
+  const reports = entry.registryReports ?? [];
+
   return (
     <tr className="border-t border-gray-03/60">
       <td className="px-4 py-2 text-gray-01">{entry.name}</td>
@@ -210,6 +283,19 @@ function CoverageEntryRow({
           </Link>
         ) : (
           "—"
+        )}
+      </td>
+      <td className="px-4 py-2">
+        {reports.length > 0 ? (
+          <div className="flex flex-wrap gap-1.5">
+            {reports.map((report) => (
+              <ReportYearPill key={report.reportId} report={report} />
+            ))}
+          </div>
+        ) : (
+          <span className="text-gray-02">
+            {t("overview.coverage.reports.none")}
+          </span>
         )}
       </td>
       <td className="px-4 py-2">

--- a/src/tabs/overview/components/ReportYearPill.tsx
+++ b/src/tabs/overview/components/ReportYearPill.tsx
@@ -1,0 +1,31 @@
+import { useI18n } from "@/contexts/I18nContext";
+import type { RegistryReportPill } from "@/tabs/overview/lib/coverage-types";
+
+type ReportYearPillProps = {
+  report: RegistryReportPill;
+};
+
+export function ReportYearPill({ report }: ReportYearPillProps) {
+  const { t } = useI18n();
+  const href = report.sourceUrl?.trim() || report.url;
+  const label = report.reportYear ?? "?";
+  const className = report.prodReady
+    ? "border-green-03/40 bg-green-03/20 text-green-03 hover:bg-green-03/30"
+    : "border-orange-03/40 bg-orange-03/20 text-orange-03 hover:bg-orange-03/30";
+
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      title={
+        report.prodReady
+          ? t("overview.coverage.reports.pillProdReady")
+          : t("overview.coverage.reports.pillNotProdReady")
+      }
+      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium transition-colors ${className}`}
+    >
+      {label}
+    </a>
+  );
+}

--- a/src/tabs/overview/hooks/useCoverageLists.ts
+++ b/src/tabs/overview/hooks/useCoverageLists.ts
@@ -11,10 +11,50 @@ import {
   setCoverageEntryMatch,
 } from "../lib/coverage-api";
 import type {
+  CoverageEntry,
   CoverageListSummary,
   CoverageYearDetail,
   CoverageMatchSaveAction,
 } from "../lib/coverage-types";
+
+function entryMatchChanged(
+  previous: CoverageEntry,
+  updated: CoverageEntry,
+): boolean {
+  return (
+    previous.status !== updated.status ||
+    previous.matchMethod !== updated.matchMethod ||
+    previous.matchedCompany?.wikidataId !== updated.matchedCompany?.wikidataId
+  );
+}
+
+function mergeCoverageMatchUpdate(
+  previous: CoverageYearDetail | null,
+  updated: CoverageYearDetail,
+): CoverageYearDetail {
+  if (!previous) return updated;
+
+  const previousById = new Map(
+    previous.entries.map((entry) => [entry.id, entry] as const),
+  );
+
+  return {
+    ...updated,
+    hasAnyReportCount: previous.hasAnyReportCount,
+    prodReadyCount: previous.prodReadyCount,
+    noReportCount: previous.noReportCount,
+    entries: updated.entries.map((entry) => {
+      const prior = previousById.get(entry.id);
+      if (!prior || entryMatchChanged(prior, entry)) {
+        return entry;
+      }
+      return {
+        ...entry,
+        registryReports: prior.registryReports ?? [],
+      };
+    }),
+  };
+}
 
 export function useCoverageLists() {
   const [lists, setLists] = useState<CoverageListSummary[]>([]);
@@ -94,20 +134,26 @@ export function useCoverageYearDetail(
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const loadDetail = useCallback(async () => {
+  const loadDetail = useCallback(async (options?: { silent?: boolean }) => {
     if (!listId || year === null) {
       setDetail(null);
       return;
     }
-    setIsLoading(true);
+    if (!options?.silent) {
+      setIsLoading(true);
+    }
     setError(null);
     try {
       setDetail(await fetchCoverageYearDetail(listId, year));
     } catch (err) {
       setError(err instanceof Error ? err.message : "Unknown error");
-      setDetail(null);
+      if (!options?.silent) {
+        setDetail(null);
+      }
     } finally {
-      setIsLoading(false);
+      if (!options?.silent) {
+        setIsLoading(false);
+      }
     }
   }, [listId, year]);
 
@@ -119,7 +165,7 @@ export function useCoverageYearDetail(
     detail,
     isLoading,
     error,
-    refresh: loadDetail,
+    refresh: () => loadDetail(),
     setEntryMatch: async (entryId: string, action: CoverageMatchSaveAction) => {
       if (!listId || year === null) return null;
       const payload =
@@ -143,7 +189,8 @@ export function useCoverageYearDetail(
         entryId,
         payload,
       );
-      setDetail(updated);
+      setDetail((previous) => mergeCoverageMatchUpdate(previous, updated));
+      void loadDetail({ silent: true });
       return updated;
     },
   };

--- a/src/tabs/overview/hooks/useOverviewData.ts
+++ b/src/tabs/overview/hooks/useOverviewData.ts
@@ -12,6 +12,7 @@ import {
 import {
   defaultFiltersForView,
   defaultProdToStageFilters,
+  defaultRegistryOverviewFilters,
   overviewFiltersAreActive,
   registryOverviewFiltersAreActive,
   overviewYearRange,
@@ -111,6 +112,26 @@ export function useOverviewData() {
           const query = viewModeToQuery(mode);
           if (query) next.set(OVERVIEW_VIEW_QUERY, query);
           else next.delete(OVERVIEW_VIEW_QUERY);
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  const openRegistryReportsWithSearch = useCallback(
+    (searchQuery: string) => {
+      setPage(1);
+      setShowAll(false);
+      setFilters({
+        ...defaultRegistryOverviewFilters(),
+        searchQuery: searchQuery.trim(),
+      });
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          next.set(OVERVIEW_VIEW_QUERY, "registry");
           return next;
         },
         { replace: true },
@@ -292,6 +313,7 @@ export function useOverviewData() {
     isRefreshing,
     error,
     refresh: () => loadData(true),
+    openRegistryReportsWithSearch,
     filtersAreActive,
     pagination: {
       page,

--- a/src/tabs/overview/lib/coverage-types.ts
+++ b/src/tabs/overview/lib/coverage-types.ts
@@ -11,6 +11,9 @@ export const coverageYearSummarySchema = z.object({
   matchedCount: z.number(),
   ambiguousCount: z.number(),
   coveragePercent: z.number(),
+  hasAnyReportCount: z.number().optional(),
+  prodReadyCount: z.number().optional(),
+  noReportCount: z.number().optional(),
 });
 
 export const coverageListSummarySchema = z.object({
@@ -28,12 +31,24 @@ export const coverageEntryStatusSchema = z.enum([
 
 export const coverageMatchMethodSchema = z.enum(["auto", "manual"]);
 
+export const registryReportPillSchema = z.object({
+  reportId: z.string(),
+  reportYear: z.string().nullable(),
+  companyName: z.string().nullable(),
+  wikidataId: z.string().nullable(),
+  url: z.string(),
+  sourceUrl: z.string().nullable(),
+  matchMethod: z.enum(["wikidata", "name"]),
+  prodReady: z.boolean(),
+});
+
 export const coverageEntrySchema = z.object({
   id: z.string(),
   name: z.string(),
   status: coverageEntryStatusSchema,
   matchMethod: coverageMatchMethodSchema.optional(),
   matchedCompany: coverageMatchedCompanySchema.optional(),
+  registryReports: z.array(registryReportPillSchema).default([]),
 });
 
 export const coverageCompanySearchHitSchema = z.object({
@@ -49,6 +64,9 @@ export const coverageCompanySearchResponseSchema = z.array(
 export const coverageYearDetailSchema = coverageYearSummarySchema.extend({
   listId: z.string(),
   listName: z.string(),
+  hasAnyReportCount: z.number().default(0),
+  prodReadyCount: z.number().default(0),
+  noReportCount: z.number().default(0),
   entries: z.array(coverageEntrySchema),
 });
 
@@ -72,3 +90,15 @@ export type CoverageMatchSaveAction =
   | { type: "match"; companyId: string; companyName: string }
   | { type: "clear" }
   | { type: "markMissing" };
+
+export type RegistryReportPill = z.infer<typeof registryReportPillSchema>;
+
+export type CoverageEntryFilter =
+  | "all"
+  | "matched"
+  | "missing"
+  | "ambiguous"
+  | "hasReports"
+  | "noReports"
+  | "prodReady"
+  | "reportNotProdReady";


### PR DESCRIPTION
## Summary
- Add Reports column with clickable year pills (green = prod-ready, orange = in registry only)
- Add registry stats cards and filters
- Cross-link to Registry Reports view with list names pre-filled
- **Perf fix:** merge fast match-save response immediately; reload registry pills in background

## Test plan
- [x] `npm test` (64 tests)
- [x] `npm run build`
- [ ] After API deploy: confirm pills, stats, filters on Coverage year detail
- [ ] Save manual match — confirm sub-second save, pills update shortly after

## Related
- Requires API PR #49 deployed to stage first