### PR TITLE
Refine coverage report pill states and registry filters

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1171,16 +1171,15 @@
         "matched": "Matched",
         "missing": "Missing",
         "ambiguous": "Ambiguous",
-        "hasReports": "Has reports",
-        "noReports": "No reports",
-        "prodReady": "Prod ready",
-        "reportNotProdReady": "Reports not prod-ready"
+        "registryInProd": "In prod",
+        "registryOnly": "In registry only",
+        "registryMissing": "Missing reports"
       },
       "reports": {
-        "none": "No reports",
+        "missing": "Missing",
         "viewInRegistry": "View in Registry Reports",
-        "pillProdReady": "Run completed, data in prod",
-        "pillNotProdReady": "Report in registry, not prod-ready"
+        "pillInProd": "In prod — report has been run",
+        "pillInRegistry": "In registry — not run yet"
       },
       "columns": {
         "list": "List",
@@ -1215,10 +1214,7 @@
         "matched": "Matched",
         "missing": "Missing",
         "ambiguous": "Ambiguous",
-        "coverage": "Coverage",
-        "hasReports": "Has reports",
-        "prodReady": "Prod ready",
-        "noReports": "No reports"
+        "coverage": "Coverage"
       }
     },
     "fetchError": "Could not load overview data.",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -1171,16 +1171,15 @@
         "matched": "Matchade",
         "missing": "Saknas",
         "ambiguous": "Tvetydiga",
-        "hasReports": "Har rapporter",
-        "noReports": "Inga rapporter",
-        "prodReady": "Prod-klar",
-        "reportNotProdReady": "Rapporter ej prod-klara"
+        "registryInProd": "I prod",
+        "registryOnly": "Endast i register",
+        "registryMissing": "Saknar rapporter"
       },
       "reports": {
-        "none": "Inga rapporter",
+        "missing": "Saknas",
         "viewInRegistry": "Visa i registerrapporter",
-        "pillProdReady": "Körning klar, data i prod",
-        "pillNotProdReady": "Rapport i register, ej prod-klar"
+        "pillInProd": "I prod — rapporten har körts",
+        "pillInRegistry": "I register — ej körd ännu"
       },
       "columns": {
         "list": "Lista",
@@ -1215,10 +1214,7 @@
         "matched": "Matchade",
         "missing": "Saknas",
         "ambiguous": "Tvetydiga",
-        "coverage": "Täckning",
-        "hasReports": "Har rapporter",
-        "prodReady": "Prod-klar",
-        "noReports": "Inga rapporter"
+        "coverage": "Täckning"
       }
     },
     "fetchError": "Kunde inte ladda översiktsdata.",

--- a/src/tabs/overview/components/CoverageYearDetail.tsx
+++ b/src/tabs/overview/components/CoverageYearDetail.tsx
@@ -67,8 +67,7 @@ export function CoverageYearDetailView({
         entry.matchedCompany?.name ?? "",
         entry.matchedCompany?.wikidataId ?? "",
         ...(entry.registryReports ?? []).map(
-          (report) =>
-            `${report.reportYear ?? ""} ${report.companyName ?? ""}`,
+          (report) => `${report.reportYear ?? ""} ${report.companyName ?? ""}`,
         ),
       ]
         .join(" ")
@@ -110,7 +109,9 @@ export function CoverageYearDetailView({
                 variant="outline"
                 size="sm"
                 onClick={() =>
-                  onViewRegistryReports(detail.entries.map((entry) => entry.name))
+                  onViewRegistryReports(
+                    detail.entries.map((entry) => entry.name),
+                  )
                 }
               >
                 {t("overview.coverage.reports.viewInRegistry")}

--- a/src/tabs/overview/components/CoverageYearDetail.tsx
+++ b/src/tabs/overview/components/CoverageYearDetail.tsx
@@ -31,14 +31,12 @@ function entryMatchesFilter(
     case "missing":
     case "ambiguous":
       return entry.status === filter;
-    case "hasReports":
-      return reports.length > 0;
-    case "noReports":
-      return reports.length === 0;
-    case "prodReady":
+    case "registryInProd":
       return reports.some((report) => report.prodReady);
-    case "reportNotProdReady":
+    case "registryOnly":
       return reports.length > 0 && !reports.some((report) => report.prodReady);
+    case "registryMissing":
+      return reports.length === 0;
     default:
       return true;
   }
@@ -85,12 +83,17 @@ export function CoverageYearDetailView({
     { value: "matched", label: t("overview.coverage.filters.matched") },
     { value: "missing", label: t("overview.coverage.filters.missing") },
     { value: "ambiguous", label: t("overview.coverage.filters.ambiguous") },
-    { value: "hasReports", label: t("overview.coverage.filters.hasReports") },
-    { value: "noReports", label: t("overview.coverage.filters.noReports") },
-    { value: "prodReady", label: t("overview.coverage.filters.prodReady") },
     {
-      value: "reportNotProdReady",
-      label: t("overview.coverage.filters.reportNotProdReady"),
+      value: "registryInProd",
+      label: t("overview.coverage.filters.registryInProd"),
+    },
+    {
+      value: "registryOnly",
+      label: t("overview.coverage.filters.registryOnly"),
+    },
+    {
+      value: "registryMissing",
+      label: t("overview.coverage.filters.registryMissing"),
     },
   ];
 
@@ -119,7 +122,7 @@ export function CoverageYearDetailView({
           </div>
         </div>
 
-        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-8 gap-3">
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
           <CoverageStatCard
             label={t("overview.coverage.stats.total")}
             value={detail.totalNames}
@@ -144,21 +147,6 @@ export function CoverageYearDetailView({
             label={t("overview.coverage.stats.coverage")}
             value={`${detail.coveragePercent}%`}
             className="border-blue-03/30 bg-blue-03/10 text-blue-03"
-          />
-          <CoverageStatCard
-            label={t("overview.coverage.stats.hasReports")}
-            value={detail.hasAnyReportCount}
-            className="border-gray-03/80 bg-gray-04/30 text-gray-01"
-          />
-          <CoverageStatCard
-            label={t("overview.coverage.stats.prodReady")}
-            value={detail.prodReadyCount}
-            className="border-green-03/30 bg-green-03/10 text-green-03"
-          />
-          <CoverageStatCard
-            label={t("overview.coverage.stats.noReports")}
-            value={detail.noReportCount}
-            className="border-orange-03/30 bg-orange-03/10 text-orange-03"
           />
         </div>
       </div>
@@ -293,8 +281,8 @@ function CoverageEntryRow({
             ))}
           </div>
         ) : (
-          <span className="text-gray-02">
-            {t("overview.coverage.reports.none")}
+          <span className="font-medium text-gray-02">
+            {t("overview.coverage.reports.missing")}
           </span>
         )}
       </td>

--- a/src/tabs/overview/components/ReportYearPill.tsx
+++ b/src/tabs/overview/components/ReportYearPill.tsx
@@ -11,7 +11,7 @@ export function ReportYearPill({ report }: ReportYearPillProps) {
   const label = report.reportYear ?? "?";
   const className = report.prodReady
     ? "border-green-03/40 bg-green-03/20 text-green-03 hover:bg-green-03/30"
-    : "border-orange-03/40 bg-orange-03/20 text-orange-03 hover:bg-orange-03/30";
+    : "border-yellow-500/40 bg-yellow-500/20 text-yellow-400 hover:bg-yellow-500/30";
 
   return (
     <a
@@ -20,8 +20,8 @@ export function ReportYearPill({ report }: ReportYearPillProps) {
       rel="noopener noreferrer"
       title={
         report.prodReady
-          ? t("overview.coverage.reports.pillProdReady")
-          : t("overview.coverage.reports.pillNotProdReady")
+          ? t("overview.coverage.reports.pillInProd")
+          : t("overview.coverage.reports.pillInRegistry")
       }
       className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium transition-colors ${className}`}
     >

--- a/src/tabs/overview/hooks/useCoverageLists.ts
+++ b/src/tabs/overview/hooks/useCoverageLists.ts
@@ -134,28 +134,31 @@ export function useCoverageYearDetail(
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const loadDetail = useCallback(async (options?: { silent?: boolean }) => {
-    if (!listId || year === null) {
-      setDetail(null);
-      return;
-    }
-    if (!options?.silent) {
-      setIsLoading(true);
-    }
-    setError(null);
-    try {
-      setDetail(await fetchCoverageYearDetail(listId, year));
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Unknown error");
-      if (!options?.silent) {
+  const loadDetail = useCallback(
+    async (options?: { silent?: boolean }) => {
+      if (!listId || year === null) {
         setDetail(null);
+        return;
       }
-    } finally {
       if (!options?.silent) {
-        setIsLoading(false);
+        setIsLoading(true);
       }
-    }
-  }, [listId, year]);
+      setError(null);
+      try {
+        setDetail(await fetchCoverageYearDetail(listId, year));
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Unknown error");
+        if (!options?.silent) {
+          setDetail(null);
+        }
+      } finally {
+        if (!options?.silent) {
+          setIsLoading(false);
+        }
+      }
+    },
+    [listId, year],
+  );
 
   useEffect(() => {
     void loadDetail();

--- a/src/tabs/overview/lib/coverage-types.ts
+++ b/src/tabs/overview/lib/coverage-types.ts
@@ -98,7 +98,6 @@ export type CoverageEntryFilter =
   | "matched"
   | "missing"
   | "ambiguous"
-  | "hasReports"
-  | "noReports"
-  | "prodReady"
-  | "reportNotProdReady";
+  | "registryInProd"
+  | "registryOnly"
+  | "registryMissing";


### PR DESCRIPTION
## Summary
- Report year pills: green = in prod, yellow = in registry only, "Missing" when no registry reports
- Replace hasReports/prodReady/noReports stat cards and filters with registryInProd / registryOnly / registryMissing
- Updated EN/SV copy for pill tooltips and filters

Pairs with API PR for simplified prod-ready semantics.

## Test plan
- [ ] Open Coverage year detail — pills show green/yellow/missing as expected
- [ ] Filter by "In prod", "In registry only", "Missing reports" — rows filter correctly
- [ ] Stat cards show only match/coverage stats (no separate registry count cards)
- [ ] Deploy after API pill-states PR is live


Made with [Cursor](https://cursor.com)