### PR TITLE
[Prod] Patch Version Bump v1.13.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "garbo-validation-tool",
-  "version": "1.13.4-rc.2",
+  "version": "1.13.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "garbo-validation-tool",
-      "version": "1.13.4-rc.2",
+      "version": "1.13.4",
       "dependencies": {
         "@mendable/firecrawl-js": "^4.12.1",
         "@radix-ui/react-dialog": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "garbo-validation-tool",
   "private": true,
-  "version": "1.13.4-rc.2",
+  "version": "1.13.4",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## 📦 Release type

- [ ] Major
- [ ] Minor
- [x] Patch

## 🔁 Environment promotion

Promotes staging RC to production (`1.13.4`).

## 🧾 Version / artifacts

- **Version being released**: v1.13.4
- **Rollback target version**: v1.13.3

## 📋 What's being released

- Coverage registry report pills with prod-ready filters and stats (#257)
- **Find report** action on coverage list rows with year prompt, PDF previews, save/run (#258)
- Optimistic coverage row updates after registry save (no full list refetch)
- Crawler search omits country when not provided (pairs with API v1.5.4)

## 🗂 Deployment notes

- Deploy **after** API v1.5.4 and Garbo v6.0.5 (coverage stats + find-report search depend on API)

## ✅ Validation / smoke check (production)

- [ ] App loads
- [ ] Coverage list year detail loads with report pills
- [ ] Find report flow: year prompt → search → save to registry
- [ ] No obvious console/network errors

## ✅ Checklist

- [x] Version updated (`1.13.4`)
- [ ] Changes QA'd in staging
- [x] Rollback target recorded
- [x] Title follows required format


Made with [Cursor](https://cursor.com)