### PR TITLE
Support coverage matches without Wikidata in UI

### DIFF
--- a/src/tabs/overview/components/CoverageEntryMatchDialog.tsx
+++ b/src/tabs/overview/components/CoverageEntryMatchDialog.tsx
@@ -55,7 +55,10 @@ export function CoverageEntryMatchDialog({
           setResults(hits);
           if (!entry?.matchedCompany) return;
           const suggested = hits.find(
-            (hit) => hit.wikidataId === entry.matchedCompany?.wikidataId,
+            (hit) =>
+              hit.id === entry.matchedCompany?.id ||
+              (entry.matchedCompany?.wikidataId &&
+                hit.wikidataId === entry.matchedCompany.wikidataId),
           );
           if (suggested) setSelectedId(suggested.id);
         })
@@ -77,7 +80,12 @@ export function CoverageEntryMatchDialog({
   if (!entry) return null;
 
   const suggestedHit = entry.matchedCompany
-    ? results.find((hit) => hit.wikidataId === entry.matchedCompany?.wikidataId)
+    ? results.find(
+        (hit) =>
+          hit.id === entry.matchedCompany?.id ||
+          (entry.matchedCompany?.wikidataId &&
+            hit.wikidataId === entry.matchedCompany.wikidataId),
+      )
     : null;
 
   return (
@@ -180,7 +188,9 @@ export function CoverageEntryMatchDialog({
               {results.map((hit) => {
                 const isSelected = selectedId === hit.id;
                 const isSuggested =
-                  hit.wikidataId === entry.matchedCompany?.wikidataId;
+                  hit.id === entry.matchedCompany?.id ||
+                  (entry.matchedCompany?.wikidataId &&
+                    hit.wikidataId === entry.matchedCompany.wikidataId);
                 return (
                   <li key={hit.id}>
                     <button
@@ -194,7 +204,7 @@ export function CoverageEntryMatchDialog({
                     >
                       <span className="font-medium">{hit.name}</span>
                       <span className="ml-2 text-xs text-gray-02">
-                        {hit.wikidataId}
+                        {hit.wikidataId || "—"}
                         {isSuggested
                           ? ` · ${t("overview.coverage.suggestedMatch")}`
                           : ""}

--- a/src/tabs/overview/components/CoverageYearDetail.tsx
+++ b/src/tabs/overview/components/CoverageYearDetail.tsx
@@ -346,7 +346,9 @@ function CoverageEntryRow({
       <td className="px-4 py-2 text-gray-02">
         {entry.matchedCompany ? (
           <Link
-            to={editorCompanyPath(entry.matchedCompany.wikidataId)}
+            to={editorCompanyPath(
+              entry.matchedCompany.wikidataId ?? entry.matchedCompany.id,
+            )}
             className="text-blue-03 hover:underline"
           >
             {entry.matchedCompany.name}

--- a/src/tabs/overview/lib/coverage-types.ts
+++ b/src/tabs/overview/lib/coverage-types.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
 
 export const coverageMatchedCompanySchema = z.object({
-  wikidataId: z.string(),
+  id: z.string(),
+  wikidataId: z.string().nullable(),
   name: z.string(),
 });
 
@@ -54,7 +55,7 @@ export const coverageEntrySchema = z.object({
 export const coverageCompanySearchHitSchema = z.object({
   id: z.string(),
   name: z.string(),
-  wikidataId: z.string(),
+  wikidataId: z.string().nullable(),
 });
 
 export const coverageCompanySearchResponseSchema = z.array(


### PR DESCRIPTION
## Summary
- Accept nullable `wikidataId` on coverage match/search API responses
- Link matched companies to the editor using `wikidataId ?? id`
- Compare suggested matches by company id when Wikidata is absent

Pairs with API PR for coverage company match search fixes.

## Test plan
- [ ] Edit match dialog shows companies without Wikidata (displays —)
- [ ] Matched company without Wikidata links to editor
- [ ] Manual match confirm still works


Made with [Cursor](https://cursor.com)