### PR TITLE
[Prod] Patch Version Bump v1.13.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "garbo-validation-tool",
-  "version": "1.13.5-rc.1",
+  "version": "1.13.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "garbo-validation-tool",
-      "version": "1.13.5-rc.1",
+      "version": "1.13.5",
       "dependencies": {
         "@mendable/firecrawl-js": "^4.12.1",
         "@radix-ui/react-dialog": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "garbo-validation-tool",
   "private": true,
-  "version": "1.13.5-rc.1",
+  "version": "1.13.5",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## 📦 Release type

- [x] Patch

## 🧾 Version / artifacts

- **Version being released**: v1.13.5
- **Rollback target version**: v1.13.4

## 📋 What's being released

- Support coverage matches without Wikidata in UI (#260)
- Nullable `wikidataId` on match/search results; editor links by company id when Wikidata is missing

Pairs with API v1.5.5 coverage match search fixes.

## ✅ Validation / smoke check (production)

- [ ] App loads
- [ ] Coverage → Edit match finds companies without Wikidata
- [ ] Manual match persists after refresh
- [ ] Find report flow still works

## ✅ Checklist

- [x] Version updated (`1.13.5`)
- [ ] Changes QA'd in staging
- [x] Rollback target recorded


Made with [Cursor](https://cursor.com)