### PR TITLE
Fix precheck company name action UI for delayed jobs

### DIFF
--- a/src/lib/workflow-utils.test.ts
+++ b/src/lib/workflow-utils.test.ts
@@ -93,6 +93,16 @@ describe("getJobStatus precheck company name", () => {
 
     expect(status).toBe("waiting");
   });
+
+  it("returns needs_approval when delayed precheck only has placeholder Unknown", () => {
+    const status = getJobStatus({
+      queueId: "precheck",
+      status: "delayed",
+      data: { companyName: "Unknown" },
+    });
+
+    expect(status).toBe("needs_approval");
+  });
 });
 
 describe("jobNeedsUserInteraction", () => {
@@ -124,7 +134,11 @@ describe("calculatePipelineStepStatus preprocessing", () => {
           queueId: "precheck",
           status: "delayed",
           processedOn: Date.now(),
-          data: { threadId: "thread-1", waitingForCompanyName: true },
+          data: {
+            threadId: "thread-1",
+            companyName: "Unknown",
+            waitingForCompanyName: true,
+          },
         },
       ],
     };

--- a/src/lib/workflow-utils.test.ts
+++ b/src/lib/workflow-utils.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { getJobStatus } from "./workflow-utils";
+import {
+  calculatePipelineStepStatus,
+  getJobStatus,
+  jobNeedsUserInteraction,
+} from "./workflow-utils";
+import type { SwimlaneYearData } from "./types";
 
 describe("getJobStatus wikidata", () => {
   it("returns needs_approval when wikidata approval is pending", () => {
@@ -53,5 +58,79 @@ describe("getJobStatus wikidata", () => {
     });
 
     expect(status).toBe("completed");
+  });
+});
+
+describe("getJobStatus precheck company name", () => {
+  it("returns needs_approval when precheck is delayed waiting for company name", () => {
+    const status = getJobStatus({
+      queueId: "precheck",
+      status: "delayed",
+      data: {
+        waitingForCompanyName: true,
+      },
+    });
+
+    expect(status).toBe("needs_approval");
+  });
+
+  it("returns needs_approval when delayed precheck has no company name", () => {
+    const status = getJobStatus({
+      queueId: "precheck",
+      status: "delayed",
+      data: {},
+    });
+
+    expect(status).toBe("needs_approval");
+  });
+
+  it("returns waiting when delayed precheck already has a company name", () => {
+    const status = getJobStatus({
+      queueId: "precheck",
+      status: "delayed",
+      data: { companyName: "Alfa Laval AB" },
+    });
+
+    expect(status).toBe("waiting");
+  });
+});
+
+describe("jobNeedsUserInteraction", () => {
+  it("detects precheck waiting for manual company name", () => {
+    expect(
+      jobNeedsUserInteraction({
+        queueId: "precheck",
+        status: "delayed",
+        data: { waitingForCompanyName: true },
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("calculatePipelineStepStatus preprocessing", () => {
+  it("shows needs_approval when precheck awaits company name input", () => {
+    const yearData: SwimlaneYearData = {
+      year: 2025,
+      attempts: 1,
+      fields: {},
+      jobs: [
+        {
+          queueId: "doclingParsePDF",
+          status: "completed",
+          finishedOn: Date.now(),
+          data: { threadId: "thread-1" },
+        },
+        {
+          queueId: "precheck",
+          status: "delayed",
+          processedOn: Date.now(),
+          data: { threadId: "thread-1", waitingForCompanyName: true },
+        },
+      ],
+    };
+
+    expect(calculatePipelineStepStatus(yearData, "preprocessing")).toBe(
+      "needs_approval",
+    );
   });
 });

--- a/src/lib/workflow-utils.ts
+++ b/src/lib/workflow-utils.ts
@@ -34,10 +34,18 @@ function isWikidataAutoApprovedUnverified(job: any): boolean {
   return !approval.verifiedByUserId;
 }
 
+/** False for empty names and registry/upload placeholders like "Unknown". */
+export function isResolvableCompanyName(name?: string | null): boolean {
+  if (!name || typeof name !== "string") return false;
+  const trimmed = name.trim();
+  if (!trimmed) return false;
+  return trimmed.toLocaleLowerCase("en-US") !== "unknown";
+}
+
 function companyNameFromJobData(job: any): string | undefined {
   const candidates = [job?.data?.companyName, job?.data?.company];
   for (const value of candidates) {
-    if (typeof value === "string" && value.trim()) return value.trim();
+    if (isResolvableCompanyName(value)) return value!.trim();
   }
   return undefined;
 }

--- a/src/lib/workflow-utils.ts
+++ b/src/lib/workflow-utils.ts
@@ -34,6 +34,38 @@ function isWikidataAutoApprovedUnverified(job: any): boolean {
   return !approval.verifiedByUserId;
 }
 
+function companyNameFromJobData(job: any): string | undefined {
+  const candidates = [job?.data?.companyName, job?.data?.company];
+  for (const value of candidates) {
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return undefined;
+}
+
+/** True when a delayed/waiting job is blocked on staff input (not just queue backoff). */
+export function jobNeedsUserInteraction(job: any): boolean {
+  if (!job) return false;
+
+  const approval = job.data?.approval || (job as any)?.approval;
+  if (approval && typeof approval === "object" && approval.approved === false) {
+    return true;
+  }
+
+  const queueId = job?.queueId ?? job?.queue;
+  if (queueId !== "precheck") return false;
+
+  const rawStatus = job.status;
+  const isWaitingState =
+    rawStatus === "delayed" ||
+    rawStatus === "waiting" ||
+    rawStatus === "waiting-children";
+  if (!isWaitingState) return false;
+
+  if (job.data?.waitingForCompanyName === true) return true;
+
+  return !companyNameFromJobData(job) && !approval;
+}
+
 /**
  * Single source of truth for job status determination
  * Used by all views to ensure consistency
@@ -47,8 +79,8 @@ export function getJobStatus(job: any): SwimlaneStatusType {
   const hasApprovalObject = approval && typeof approval === "object";
   const isPendingApproval = hasApprovalObject && approval.approved === false;
 
-  // If job has pending approval, return needs_approval regardless of other status
-  if (isPendingApproval) {
+  // Staff action required: structured approvals or precheck waiting for company name
+  if (isPendingApproval || jobNeedsUserInteraction(job)) {
     return "needs_approval";
   }
 
@@ -387,6 +419,7 @@ function isPipelineProgressStatus(status: SwimlaneStatusType): boolean {
  */
 function isJobActivelyProcessing(job: any): boolean {
   if (!job) return false;
+  if (job.status === "delayed") return false;
   // Job is actively processing if it has processedOn but no finishedOn, or status is "active"
   return (job.processedOn && !job.finishedOn) || job.status === "active";
 }
@@ -426,17 +459,25 @@ export function calculatePipelineStepStatus(
 
   // Special case for finalize step: show green if saveToAPI (API Lagring) is completed
   // This is the most important step for the user
-  // But check for delayed jobs first - if any job is delayed, show gray
   if (stepId === "finalize") {
-    // Check for delayed jobs first (check raw status, not mapped status)
+    const hasNeedsApproval = jobsWithStatuses.some(
+      (entry) => entry.status === "needs_approval",
+    );
+    if (hasNeedsApproval) {
+      return "needs_approval";
+    }
+
+    // Delayed jobs that are not awaiting staff input show gray
     const hasDelayed = jobsWithStatuses.some(
       (entry) =>
         Array.isArray(entry.attempts) &&
-        entry.attempts.some((j: any) => j && j.status === "delayed"),
+        entry.attempts.some(
+          (j: any) => j && j.status === "delayed" && !jobNeedsUserInteraction(j),
+        ),
     );
 
     if (hasDelayed) {
-      return "waiting"; // Show gray for delayed
+      return "waiting";
     }
 
     const saveToAPIEntry = jobsWithStatuses.find(
@@ -464,15 +505,23 @@ export function calculatePipelineStepStatus(
       return "processing";
     }
 
-    // Check for delayed jobs (check raw status, not mapped status)
+    const hasNeedsApproval = jobsWithStatuses.some(
+      (entry) => entry.status === "needs_approval",
+    );
+    if (hasNeedsApproval) {
+      return "needs_approval";
+    }
+
     const hasDelayed = jobsWithStatuses.some(
       (entry) =>
         Array.isArray(entry.attempts) &&
-        entry.attempts.some((j: any) => j && j.status === "delayed"),
+        entry.attempts.some(
+          (j: any) => j && j.status === "delayed" && !jobNeedsUserInteraction(j),
+        ),
     );
 
     if (hasDelayed) {
-      return "waiting"; // Show gray for delayed
+      return "waiting";
     }
 
     // Filter to only jobs that have been started (ignore waiting jobs that haven't been run)
@@ -517,16 +566,23 @@ export function calculatePipelineStepStatus(
     return "waiting";
   }
 
-  // For other steps, use the original logic but also check for delayed
-  // Check for delayed jobs (check raw status, not mapped status)
+  const hasNeedsApproval = jobsWithStatuses.some(
+    (entry) => entry.status === "needs_approval",
+  );
+  if (hasNeedsApproval) {
+    return "needs_approval";
+  }
+
   const hasDelayed = jobsWithStatuses.some(
     (entry) =>
       Array.isArray(entry.attempts) &&
-      entry.attempts.some((j: any) => j && j.status === "delayed"),
+      entry.attempts.some(
+        (j: any) => j && j.status === "delayed" && !jobNeedsUserInteraction(j),
+      ),
   );
 
   if (hasDelayed) {
-    return "waiting"; // Show gray for delayed
+    return "waiting";
   }
 
   const fieldStatuses = jobsWithStatuses.map((entry) => entry.status);
@@ -543,16 +599,10 @@ export function calculatePipelineStepStatus(
 
   // Priority-based status determination:
   // 1. If there's at least one red (failed) → show red
-  // 2. If there's at least one orange (needs_approval) → show orange (prioritize approval)
-  // 3. If there's at least one gray (waiting) → show gray
-  // 4. Otherwise, if there's any green (completed) → show green
-  const hasNeedsApproval = fieldStatuses.some(
-    (status) => status === "needs_approval",
-  );
+  // 2. If there's at least one gray (waiting) → show gray
+  // 3. Otherwise, if there's any green (completed) → show green
   if (hasFailed) {
     return "failed";
-  } else if (hasNeedsApproval) {
-    return "needs_approval";
   } else if (hasWaiting) {
     return "waiting";
   } else if (hasCompleted) {

--- a/src/lib/workflow-utils.ts
+++ b/src/lib/workflow-utils.ts
@@ -480,7 +480,8 @@ export function calculatePipelineStepStatus(
       (entry) =>
         Array.isArray(entry.attempts) &&
         entry.attempts.some(
-          (j: any) => j && j.status === "delayed" && !jobNeedsUserInteraction(j),
+          (j: any) =>
+            j && j.status === "delayed" && !jobNeedsUserInteraction(j),
         ),
     );
 
@@ -524,7 +525,8 @@ export function calculatePipelineStepStatus(
       (entry) =>
         Array.isArray(entry.attempts) &&
         entry.attempts.some(
-          (j: any) => j && j.status === "delayed" && !jobNeedsUserInteraction(j),
+          (j: any) =>
+            j && j.status === "delayed" && !jobNeedsUserInteraction(j),
         ),
     );
 

--- a/src/tabs/jobbstatus/components/job-details/JobActionRequiredSection.tsx
+++ b/src/tabs/jobbstatus/components/job-details/JobActionRequiredSection.tsx
@@ -5,7 +5,7 @@
 
 import React from "react";
 import type { DetailedJobResponse, QueueJob } from "@/lib/types";
-import { getJobStatus } from "@/lib/workflow-utils";
+import { getJobStatus, isResolvableCompanyName } from "@/lib/workflow-utils";
 import {
   getCompanyLinkApprovalData,
   getWikidataApprovalData,
@@ -33,7 +33,8 @@ function companyNameFromJob(
     job?.data?.company;
   if (!name) return undefined;
   const nameString = typeof name === "string" ? name : String(name);
-  return nameString.trim() || undefined;
+  const trimmed = nameString.trim();
+  return isResolvableCompanyName(trimmed) ? trimmed : undefined;
 }
 
 export function JobActionRequiredSection({
@@ -107,7 +108,7 @@ export function JobActionRequiredSection({
     if (
       isDelayed &&
       hasNoStructuredApproval &&
-      !companyName &&
+      !isResolvableCompanyName(companyName) &&
       !effectiveJob.data?.approval
     ) {
       return true;

--- a/src/tabs/jobbstatus/components/job-details/JobActionRequiredSection.tsx
+++ b/src/tabs/jobbstatus/components/job-details/JobActionRequiredSection.tsx
@@ -1,0 +1,144 @@
+/**
+ * Staff action UI for pipeline jobs — shown above dialog tabs so actions are
+ * visible on both Overview and Technical details.
+ */
+
+import React from "react";
+import type { DetailedJobResponse, QueueJob } from "@/lib/types";
+import { getJobStatus } from "@/lib/workflow-utils";
+import {
+  getCompanyLinkApprovalData,
+  getWikidataApprovalData,
+  hasPendingStructuredApproval,
+} from "../../lib/job-specific-data-parsing";
+import { useJobRerunActions } from "../../hooks/useJobRerunActions";
+import { JobApprovalPanels } from "./JobApprovalPanels";
+
+interface JobActionRequiredSectionProps {
+  job?: QueueJob;
+  detailed: DetailedJobResponse | null;
+  onDetailedChange: React.Dispatch<
+    React.SetStateAction<DetailedJobResponse | null>
+  >;
+}
+
+function companyNameFromJob(
+  effectiveJob?: QueueJob,
+  job?: QueueJob,
+): string | undefined {
+  const name =
+    effectiveJob?.data?.companyName ||
+    job?.data?.companyName ||
+    effectiveJob?.data?.company ||
+    job?.data?.company;
+  if (!name) return undefined;
+  const nameString = typeof name === "string" ? name : String(name);
+  return nameString.trim() || undefined;
+}
+
+export function JobActionRequiredSection({
+  job,
+  detailed,
+  onDetailedChange,
+}: JobActionRequiredSectionProps) {
+  const effectiveJob = React.useMemo(() => {
+    if (!job) return undefined;
+    if (!detailed) return job;
+    return {
+      ...job,
+      status: (detailed as { status?: string }).status ?? job.status,
+      data: {
+        ...(job.data || {}),
+        ...(detailed as { data?: Record<string, unknown> })?.data,
+      },
+      failedReason:
+        (detailed as { failedReason?: string }).failedReason ??
+        (job as { failedReason?: string }).failedReason,
+    } as QueueJob;
+  }, [job, detailed]);
+
+  const {
+    handleWikidataApprove,
+    handleWikidataOverride,
+    handleCompanyLinkApprove,
+    handleCompanyNameOverride,
+  } = useJobRerunActions({
+    job,
+    effectiveJob,
+    detailed,
+    setDetailed: onDetailedChange,
+  });
+
+  const companyLinkApprovalData = getCompanyLinkApprovalData(job, effectiveJob);
+  const wikidataApprovalData = getWikidataApprovalData(job, effectiveJob);
+  const pendingStructuredApproval = hasPendingStructuredApproval(
+    effectiveJob?.data,
+  );
+  const showUnresolvedApprovalHint =
+    pendingStructuredApproval &&
+    !wikidataApprovalData &&
+    !companyLinkApprovalData;
+  const isLoadingApprovalDetails =
+    pendingStructuredApproval && !detailed && Boolean(job?.queueId && job?.id);
+
+  const companyName = companyNameFromJob(effectiveJob, job);
+
+  const showCompanyNameOverride = React.useMemo(() => {
+    if (!effectiveJob || effectiveJob.queueId !== "precheck") return false;
+
+    const status = getJobStatus(effectiveJob);
+    if (status === "completed") return true;
+
+    const waitingForCompanyName =
+      effectiveJob.data?.waitingForCompanyName === true;
+    const isDelayed = effectiveJob.status === "delayed";
+    const hasNoStructuredApproval = !hasPendingStructuredApproval(
+      effectiveJob.data,
+    );
+
+    if (
+      waitingForCompanyName &&
+      (isDelayed || status === "waiting") &&
+      hasNoStructuredApproval
+    ) {
+      return true;
+    }
+
+    if (
+      isDelayed &&
+      hasNoStructuredApproval &&
+      !companyName &&
+      !effectiveJob.data?.approval
+    ) {
+      return true;
+    }
+
+    if (status === "failed") {
+      const failedReason = String(
+        (effectiveJob as { failedReason?: string }).failedReason ?? "",
+      );
+      return (
+        failedReason.includes("Could not identify company name") ||
+        failedReason.includes("companyName provided in job data")
+      );
+    }
+
+    return false;
+  }, [effectiveJob, companyName]);
+
+  return (
+    <JobApprovalPanels
+      companyLinkApprovalData={companyLinkApprovalData}
+      wikidataApprovalData={wikidataApprovalData}
+      showCompanyNameOverride={showCompanyNameOverride}
+      companyName={companyName}
+      missingCompanyNameForOverride={!companyName}
+      showUnresolvedApprovalHint={showUnresolvedApprovalHint}
+      isLoadingApprovalDetails={isLoadingApprovalDetails}
+      onCompanyLinkApprove={handleCompanyLinkApprove}
+      onWikidataApprove={handleWikidataApprove}
+      onWikidataOverride={handleWikidataOverride}
+      onCompanyNameOverride={handleCompanyNameOverride}
+    />
+  );
+}

--- a/src/tabs/jobbstatus/components/job-details/JobDetailsDialog.tsx
+++ b/src/tabs/jobbstatus/components/job-details/JobDetailsDialog.tsx
@@ -31,6 +31,7 @@ import {
 import { Button } from "@/ui/button";
 import { useI18n } from "@/contexts/I18nContext";
 import { JobRedisRetentionHint } from "../JobRedisRetentionHint";
+import { JobActionRequiredSection } from "./JobActionRequiredSection";
 
 interface JobDetailsDialogProps {
   job: QueueJob | null;
@@ -359,6 +360,12 @@ export function JobDetailsDialog({
         activeTab={activeTab}
         setActiveTab={setActiveTab}
         job={effectiveJob ?? job}
+      />
+
+      <JobActionRequiredSection
+        job={job}
+        detailed={detailed}
+        onDetailedChange={setDetailed}
       />
 
       <div className="space-y-6 my-6">

--- a/src/tabs/jobbstatus/components/job-details/JobSpecificDataView.tsx
+++ b/src/tabs/jobbstatus/components/job-details/JobSpecificDataView.tsx
@@ -13,17 +13,13 @@ import { CollapsibleSection } from "@/ui/collapsible-section";
 import { Image, ExternalLink, FileText, RotateCcw } from "lucide-react";
 import { EconomySection } from "../scope/EconomySection";
 import { Button } from "@/ui/button";
-import { getJobStatus } from "@/lib/workflow-utils";
 import {
   parseReturnValueData,
   getScopeData,
   getEconomyData,
   getScope3Data,
   getWikidataApprovalData,
-  getCompanyLinkApprovalData,
-  hasPendingStructuredApproval,
 } from "../../lib/job-specific-data-parsing";
-import { JobApprovalPanels } from "./JobApprovalPanels";
 import { useJobRerunActions } from "../../hooks/useJobRerunActions";
 import { getPipelineUrl } from "@/config/api-env";
 import { useI18n } from "@/contexts/I18nContext";
@@ -141,14 +137,12 @@ export function JobSpecificDataView({
     } as any;
   }, [job, detailed]);
 
-  const {
-    handleWikidataApprove,
-    handleWikidataOverride,
-    handleCompanyLinkApprove,
-    handleCompanyNameOverride,
-    handleRerun,
-    handleRerunAndSave,
-  } = useJobRerunActions({ job, effectiveJob, detailed, setDetailed });
+  const { handleRerun, handleRerunAndSave } = useJobRerunActions({
+    job,
+    effectiveJob,
+    detailed,
+    setDetailed,
+  });
 
   const processedData =
     typeof data === "string" && isJsonString(data) ? JSON.parse(data) : data;
@@ -224,16 +218,6 @@ export function JobSpecificDataView({
   const scope3Data = getScope3Data(processedData, returnValueData);
   const economyData = getEconomyData(returnValueData);
   const wikidataApprovalData = getWikidataApprovalData(job, effectiveJob);
-  const companyLinkApprovalData = getCompanyLinkApprovalData(job, effectiveJob);
-  const pendingStructuredApproval = hasPendingStructuredApproval(
-    effectiveJob?.data,
-  );
-  const showUnresolvedApprovalHint =
-    pendingStructuredApproval &&
-    !wikidataApprovalData &&
-    !companyLinkApprovalData;
-  const isLoadingApprovalDetails =
-    pendingStructuredApproval && !detailed && Boolean(job?.queueId && job?.id);
   const wikidataId: string | undefined = React.useMemo(() => {
     const fromJob = getWikidataInfo(effectiveJob as any)?.node;
     const fromProcessed =
@@ -298,44 +282,6 @@ export function JobSpecificDataView({
     return { reportYearHint, documentReportYear };
   }, [effectiveJob, job, processedData]);
 
-  // Get company name from multiple possible sources
-  const companyName: string | undefined = React.useMemo(() => {
-    const name =
-      effectiveJob?.data?.companyName ||
-      job?.data?.companyName ||
-      processedData?.companyName ||
-      effectiveJob?.data?.company ||
-      job?.data?.company ||
-      processedData?.company;
-    if (!name) return undefined;
-    const nameString = typeof name === "string" ? name : String(name);
-    return nameString.trim() || undefined;
-  }, [effectiveJob, job, processedData]);
-
-  // Show company name override on precheck when completed (correction) or waiting for manual name
-  const showCompanyNameOverride = React.useMemo(() => {
-    if (!effectiveJob || effectiveJob.queueId !== "precheck") return false;
-
-    const status = getJobStatus(effectiveJob);
-    if (status === "completed") return true;
-
-    const waitingForCompanyName =
-      effectiveJob.data?.waitingForCompanyName === true;
-    if (status === "delayed" && waitingForCompanyName) return true;
-
-    if (status === "failed") {
-      const failedReason = String(effectiveJob.failedReason ?? "");
-      return (
-        failedReason.includes("Could not identify company name") ||
-        failedReason.includes("companyName provided in job data")
-      );
-    }
-
-    return false;
-  }, [effectiveJob]);
-
-  const missingCompanyNameForOverride = !companyName;
-
   React.useEffect(() => {
     try {
       console.log("[JobSpecificDataView] scope3 panel context", {
@@ -382,20 +328,6 @@ export function JobSpecificDataView({
 
   return (
     <div className="space-y-3 text-sm">
-      <JobApprovalPanels
-        companyLinkApprovalData={companyLinkApprovalData}
-        wikidataApprovalData={wikidataApprovalData}
-        showCompanyNameOverride={showCompanyNameOverride}
-        companyName={companyName}
-        missingCompanyNameForOverride={missingCompanyNameForOverride}
-        showUnresolvedApprovalHint={showUnresolvedApprovalHint}
-        isLoadingApprovalDetails={isLoadingApprovalDetails}
-        onCompanyLinkApprove={handleCompanyLinkApprove}
-        onWikidataApprove={handleWikidataApprove}
-        onWikidataOverride={handleWikidataOverride}
-        onCompanyNameOverride={handleCompanyNameOverride}
-      />
-
       {/* Report / PDF URLs (source vs cached S3 when both exist) */}
       {(storedPdfUrl || sourceReportUrl) && (
         <div className="mb-4">

--- a/src/tabs/jobbstatus/lib/swimlane-transform.ts
+++ b/src/tabs/jobbstatus/lib/swimlane-transform.ts
@@ -8,7 +8,10 @@ import type {
   SwimlaneCompany,
   SwimlaneYearData,
 } from "@/lib/types";
-import { getJobStatus as getJobStatusFromUtils, isResolvableCompanyName } from "@/lib/workflow-utils";
+import {
+  getJobStatus as getJobStatusFromUtils,
+  isResolvableCompanyName,
+} from "@/lib/workflow-utils";
 
 /**
  * Convert CustomAPICompany array to SwimlaneCompany array
@@ -96,7 +99,7 @@ export function convertCompaniesToSwimlaneFormat(
                 ? rawJobCompany!.trim()
                 : isResolvableCompanyName(companyName)
                   ? companyName
-                  : rawJobCompany ?? companyName;
+                  : (rawJobCompany ?? companyName);
 
               const convertedJob = {
                 ...job,

--- a/src/tabs/jobbstatus/lib/swimlane-transform.ts
+++ b/src/tabs/jobbstatus/lib/swimlane-transform.ts
@@ -8,7 +8,7 @@ import type {
   SwimlaneCompany,
   SwimlaneYearData,
 } from "@/lib/types";
-import { getJobStatus as getJobStatusFromUtils } from "@/lib/workflow-utils";
+import { getJobStatus as getJobStatusFromUtils, isResolvableCompanyName } from "@/lib/workflow-utils";
 
 /**
  * Convert CustomAPICompany array to SwimlaneCompany array
@@ -90,6 +90,14 @@ export function convertCompaniesToSwimlaneFormat(
             attempts: yearProcesses.length,
             fields: {},
             jobs: (process.jobs || []).map((job) => {
+              const rawJobCompany =
+                job.data?.companyName ?? job.data?.company ?? job.company;
+              const displayCompanyName = isResolvableCompanyName(rawJobCompany)
+                ? rawJobCompany!.trim()
+                : isResolvableCompanyName(companyName)
+                  ? companyName
+                  : rawJobCompany ?? companyName;
+
               const convertedJob = {
                 ...job,
                 queueId: job.queue,
@@ -98,8 +106,9 @@ export function convertCompaniesToSwimlaneFormat(
                   (job as any)?.threadId ?? (job as any)?.processId ?? threadId,
                 data: {
                   ...job.data,
-                  company: companyName,
-                  companyName: companyName,
+                  company: displayCompanyName,
+                  companyName: displayCompanyName,
+                  waitingForCompanyName: job.data?.waitingForCompanyName,
                   year: year,
                   threadId:
                     (job as any)?.threadId ??


### PR DESCRIPTION
## Summary
- Fix company name entry form not appearing when precheck is `delayed` waiting for manual input (`getJobStatus` maps delayed → waiting, so the old check never matched).
- Add fallback detection for delayed precheck with no company name and no structured approval.
- Move action-required panels above dialog tabs so they are visible on both Overview and Technical details.

## Test plan
- [ ] Open a precheck job with `status: delayed`, `waitingForCompanyName: true`, no `approval` — confirm **Action required** shows company name input on both tabs.
- [ ] Enter company name and apply — precheck reruns and continues.


Made with [Cursor](https://cursor.com)