### PR TITLE
[Prod] Minor Version Bump v1.14.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "garbo-validation-tool",
-  "version": "1.13.7-rc.1",
+  "version": "1.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "garbo-validation-tool",
-      "version": "1.13.7-rc.1",
+      "version": "1.14.0",
       "dependencies": {
         "@mendable/firecrawl-js": "^4.12.1",
         "@radix-ui/react-dialog": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "garbo-validation-tool",
   "private": true,
-  "version": "1.13.7-rc.1",
+  "version": "1.14.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
# 🚀 Production Release PR (Validate)

> **Title format:** `[Prod] Major/Minor/Patch Version Bump vX.X.X`

## 📦 Release type

- [ ] Major
- [x] Minor
- [ ] Patch

## 🔁 Environment promotion

This release promotes changes **to production**.

## 🧾 Version / artifacts

- **Version being released**: v1.14.0
- **Rollback target version**: v1.13.6

## 📋 What's being released

### Crawler auto-search batch pipeline ([#240](https://github.com/Klimatbyran/validate-frontend/pull/240))

- Auto-search modal: search → prefilter → PDF cover extract → LLM select → registry save
- Registry duplicate pre-check fix (bidirectional token matching)
- Downloadable batch run logs with per-candidate breakdown
- Metadata heuristic fallback when PDF text cannot be read

### Coverage lists (Overview tab)

- Coverage list management, year detail, prod/registry gap matching UI
- Find-report dialog and entry match flows

### Company identifiers & report types (Editor)

- Company identifier verification badges
- Report types management UI

### Job status & errors

- Company link approval panels, job action-required section
- Cross-env report pairing and discrepancy improvements

## 🗂 Deployment notes

**Paired release with unearth-api v1.6.0** — deploy validate and API in the same window.

Smoke test: Crawler auto-search batch (5–10 companies), coverage list view, editor company identifiers.

## ✅ Checklist

- [x] Version updated (`1.14.0`)
- [ ] Changes QA'd in staging
- [x] Rollback target recorded (v1.13.6)
- [x] Title follows: `[Prod] Minor Version Bump v1.14.0`
- [ ] unearth-api v1.6.0 deployed in same window

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No runtime or logic changes in the diff—only version metadata for a planned production promotion.
> 
> **Overview**
> **Production release metadata only** — this PR does not change application source in the diff; it finalizes the **v1.14.0** release by updating the semver in **`package.json`** and the root package entry in **`package-lock.json`** from **`1.13.7-rc.1`** to **`1.14.0`**.
> 
> The broader feature set (crawler auto-search batch, coverage lists, editor identifiers, job status UX, etc.) is assumed to already be on the branch; this change is the version tag aligned with paired **unearth-api v1.6.0** deployment per release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 220c629544bb5e8e4c0326fa7173ec030347ac11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->