### PR TITLE
Speed up coverage year view for large index lists

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@radix-ui/react-navigation-menu": "^1.1.4",
         "@radix-ui/react-slot": "^1.0.2",
         "@radix-ui/react-tabs": "^1.0.4",
+        "@tanstack/react-virtual": "^3.14.6",
         "axios": "^1.6.8",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
@@ -2229,6 +2230,33 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.14.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.6.tgz",
+      "integrity": "sha512-4+Uq8m0/gzO4kMCHUEpTtGX1RnONK0C+g88b2ltwPMWUBiaVarBuWKoPJaz7gj1cKCVRAdyu+U8GcKhwCc2beA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.4"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.4.tgz",
+      "integrity": "sha512-nGm5KteqxasUdThLc2izl6dHUqLv0LQj7Nuyo5gYalTPf/U8a9ermvsl7reT+6ioBW1l8WfpP/mcU338nLXpqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
     },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@radix-ui/react-navigation-menu": "^1.1.4",
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-tabs": "^1.0.4",
+    "@tanstack/react-virtual": "^3.14.6",
     "axios": "^1.6.8",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1236,6 +1236,11 @@
       "latestCoverageCell": "{{year}}: {{percent}}% ({{matched}}/{{total}})",
       "entryFilterLabel": "Entry filter",
       "searchPlaceholder": "Search names or matches…",
+      "filteredCount": "{{shown}} of {{total}}",
+      "loadMore": "Load more",
+      "loadingMore": "Loading…",
+      "refreshRegistry": "Refresh report status",
+      "registryRefreshedAt": "Report status updated {{time}}",
       "filters": {
         "all": "All",
         "matched": "Matched",
@@ -1296,7 +1301,10 @@
         "matched": "Matched",
         "missing": "Missing",
         "ambiguous": "Ambiguous",
-        "coverage": "Coverage"
+        "coverage": "Coverage",
+        "inRegistry": "In registry",
+        "inProd": "In prod",
+        "missingReports": "Missing reports"
       }
     },
     "fetchError": "Could not load overview data.",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -1236,6 +1236,11 @@
       "latestCoverageCell": "{{year}}: {{percent}}% ({{matched}}/{{total}})",
       "entryFilterLabel": "Radfilter",
       "searchPlaceholder": "Sök namn eller matchningar…",
+      "filteredCount": "{{shown}} av {{total}}",
+      "loadMore": "Ladda fler",
+      "loadingMore": "Laddar…",
+      "refreshRegistry": "Uppdatera rapportstatus",
+      "registryRefreshedAt": "Rapportstatus uppdaterad {{time}}",
       "filters": {
         "all": "Alla",
         "matched": "Matchade",
@@ -1296,7 +1301,10 @@
         "matched": "Matchade",
         "missing": "Saknas",
         "ambiguous": "Tvetydiga",
-        "coverage": "Täckning"
+        "coverage": "Täckning",
+        "inRegistry": "I register",
+        "inProd": "I prod",
+        "missingReports": "Saknar rapporter"
       }
     },
     "fetchError": "Kunde inte ladda översiktsdata.",

--- a/src/tabs/overview/components/CoverageView.tsx
+++ b/src/tabs/overview/components/CoverageView.tsx
@@ -10,6 +10,7 @@ import {
   useCoverageLists,
   useCoverageYearDetail,
 } from "@/tabs/overview/hooks/useCoverageLists";
+import { fetchCoverageYearNames } from "@/tabs/overview/lib/coverage-api";
 import { CoverageListTable } from "./CoverageListTable";
 import { CoverageYearDetailView } from "./CoverageYearDetail";
 import { CoverageYearFormDialog } from "./CoverageYearFormDialog";
@@ -268,21 +269,44 @@ export function CoverageView({ onViewRegistryReports }: CoverageViewProps) {
                 </Callout>
               ) : yearDetail.detail ? (
                 <CoverageYearDetailView
+                  listId={selectedList.id}
+                  year={selectedYear}
                   detail={yearDetail.detail}
+                  filter={yearDetail.filter}
+                  onFilterChange={yearDetail.setFilter}
+                  search={yearDetail.search}
+                  onSearchChange={yearDetail.setSearch}
+                  hasMore={yearDetail.detail.hasMore ?? false}
+                  isLoadingMore={yearDetail.isLoadingMore}
+                  onLoadMore={() => void yearDetail.loadMore()}
+                  isRefreshingRegistry={yearDetail.isRefreshingRegistry}
+                  onRefreshRegistry={() => void yearDetail.refreshRegistry()}
                   onViewRegistryReports={onViewRegistryReports}
                   onRegistryReportSaved={(entryId, saved) => {
                     yearDetail.addEntryRegistryReport(entryId, saved);
                   }}
-                  onEdit={() =>
-                    setDialog({
-                      kind: "editYear",
-                      listId: selectedList.id,
-                      year: selectedYear,
-                      namesText: yearDetail
-                        .detail!.entries.map((e) => e.name)
-                        .join("\n"),
-                    })
-                  }
+                  onEdit={() => {
+                    void (async () => {
+                      try {
+                        const names = await fetchCoverageYearNames(
+                          selectedList.id,
+                          selectedYear,
+                        );
+                        setDialog({
+                          kind: "editYear",
+                          listId: selectedList.id,
+                          year: selectedYear,
+                          namesText: names.names.join("\n"),
+                        });
+                      } catch (error) {
+                        toast.error(
+                          error instanceof Error
+                            ? error.message
+                            : t("overview.coverage.errorTitle"),
+                        );
+                      }
+                    })();
+                  }}
                   onEditEntry={setMatchEntry}
                 />
               ) : null}

--- a/src/tabs/overview/components/CoverageYearDetail.tsx
+++ b/src/tabs/overview/components/CoverageYearDetail.tsx
@@ -92,6 +92,7 @@ export function CoverageYearDetailView({
     getScrollElement: () => tableScrollRef.current,
     estimateSize: () => COVERAGE_ROW_HEIGHT_PX,
     overscan: 12,
+    measureElement: (element) => element.getBoundingClientRect().height,
   });
 
   const filterOptions: { value: CoverageEntryFilter; label: string }[] = [
@@ -118,7 +119,10 @@ export function CoverageYearDetailView({
       ? (entries.find((entry) => entry.id === yearPromptEntryId) ?? null)
       : null;
 
-  const handleYearConfirm = async (entry: CoverageEntry, reportYear: number) => {
+  const handleYearConfirm = async (
+    entry: CoverageEntry,
+    reportYear: number,
+  ) => {
     setFindingReportEntryId(entry.id);
     try {
       const results = await searchCompanyReports({
@@ -337,6 +341,8 @@ export function CoverageYearDetailView({
                     <CoverageEntryRow
                       key={entry.id}
                       entry={entry}
+                      rowRef={rowVirtualizer.measureElement}
+                      dataIndex={virtualRow.index}
                       isFindingReport={findingReportEntryId === entry.id}
                       onEditEntry={onEditEntry}
                       onFindReportClick={() => setYearPromptEntryId(entry.id)}
@@ -440,11 +446,15 @@ function CoverageStatCard({
 
 function CoverageEntryRow({
   entry,
+  rowRef,
+  dataIndex,
   isFindingReport,
   onEditEntry,
   onFindReportClick,
 }: {
   entry: CoverageEntry;
+  rowRef: (element: HTMLTableRowElement | null) => void;
+  dataIndex: number;
   isFindingReport: boolean;
   onEditEntry: (entry: CoverageEntry) => void;
   onFindReportClick: () => void;
@@ -468,7 +478,11 @@ function CoverageEntryRow({
   const reports = entry.registryReports ?? [];
 
   return (
-    <tr className="border-t border-gray-03/60">
+    <tr
+      ref={rowRef}
+      data-index={dataIndex}
+      className="border-t border-gray-03/60"
+    >
       <td
         className="px-4 py-2 text-gray-01 align-top truncate"
         title={entry.name}

--- a/src/tabs/overview/components/CoverageYearDetail.tsx
+++ b/src/tabs/overview/components/CoverageYearDetail.tsx
@@ -1,5 +1,6 @@
 import { Link } from "react-router-dom";
-import { useMemo, useState } from "react";
+import { useRef, useState } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import { Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { useI18n } from "@/contexts/I18nContext";
@@ -11,6 +12,7 @@ import { CoverageFindReportDialog } from "./CoverageFindReportDialog";
 import { CoverageFindReportYearPrompt } from "./CoverageFindReportYearPrompt";
 import { searchCompanyReports } from "@/tabs/crawler/lib/crawler-utils";
 import { useRunReportsPipeline } from "@/hooks/useRunReportsPipeline";
+import { fetchCoverageYearNames } from "@/tabs/overview/lib/coverage-api";
 import type {
   CompanyReport,
   SaveReportSuccess,
@@ -21,8 +23,22 @@ import type {
   CoverageYearDetail,
 } from "@/tabs/overview/lib/coverage-types";
 
+const COVERAGE_ROW_HEIGHT_PX = 56;
+const COVERAGE_TABLE_MAX_HEIGHT_PX = 560;
+
 type CoverageYearDetailProps = {
+  listId: string;
+  year: number;
   detail: CoverageYearDetail;
+  filter: CoverageEntryFilter;
+  onFilterChange: (filter: CoverageEntryFilter) => void;
+  search: string;
+  onSearchChange: (search: string) => void;
+  hasMore: boolean;
+  isLoadingMore: boolean;
+  onLoadMore: () => void;
+  isRefreshingRegistry: boolean;
+  onRefreshRegistry: () => void;
   onEdit: () => void;
   onEditEntry: (entry: CoverageEntry) => void;
   onViewRegistryReports?: (names: string[]) => void;
@@ -35,68 +51,48 @@ type FindReportSession = {
   companyReport: CompanyReport;
 };
 
-function entryMatchesFilter(
-  entry: CoverageEntry,
-  filter: CoverageEntryFilter,
-): boolean {
-  const reports = entry.registryReports ?? [];
-
-  switch (filter) {
-    case "all":
-      return true;
-    case "matched":
-    case "missing":
-    case "ambiguous":
-      return entry.status === filter;
-    case "registryInProd":
-      return reports.some((report) => report.prodReady);
-    case "registryOnly":
-      return reports.length > 0 && !reports.some((report) => report.prodReady);
-    case "registryMissing":
-      return reports.length === 0;
-    default:
-      return true;
-  }
-}
-
 export function CoverageYearDetailView({
+  listId,
+  year,
   detail,
+  filter,
+  onFilterChange,
+  search,
+  onSearchChange,
+  hasMore,
+  isLoadingMore,
+  onLoadMore,
+  isRefreshingRegistry,
+  onRefreshRegistry,
   onEdit,
   onEditEntry,
   onViewRegistryReports,
   onRegistryReportSaved,
 }: CoverageYearDetailProps) {
   const { t } = useI18n();
-  const [filter, setFilter] = useState<CoverageEntryFilter>("all");
-  const [search, setSearch] = useState("");
   const [findReportSession, setFindReportSession] =
     useState<FindReportSession | null>(null);
+  const [findingReportEntryId, setFindingReportEntryId] = useState<
+    string | null
+  >(null);
+  const [yearPromptEntryId, setYearPromptEntryId] = useState<string | null>(
+    null,
+  );
+  const [isLoadingRegistryNames, setIsLoadingRegistryNames] = useState(false);
+  const tableScrollRef = useRef<HTMLDivElement>(null);
   const runPipeline = useRunReportsPipeline();
 
   const missingCount =
     detail.totalNames - detail.matchedCount - detail.ambiguousCount;
+  const filteredCount = detail.filteredCount ?? detail.entries.length;
+  const entries = detail.entries;
 
-  const filteredEntries = useMemo(() => {
-    const q = search.trim().toLocaleLowerCase("sv-SE");
-
-    return detail.entries.filter((entry) => {
-      if (!entryMatchesFilter(entry, filter)) return false;
-      if (!q) return true;
-
-      const haystack = [
-        entry.name,
-        entry.matchedCompany?.name ?? "",
-        entry.matchedCompany?.wikidataId ?? "",
-        ...(entry.registryReports ?? []).map(
-          (report) => `${report.reportYear ?? ""} ${report.companyName ?? ""}`,
-        ),
-      ]
-        .join(" ")
-        .toLocaleLowerCase("sv-SE");
-
-      return haystack.includes(q);
-    });
-  }, [detail.entries, filter, search]);
+  const rowVirtualizer = useVirtualizer({
+    count: entries.length,
+    getScrollElement: () => tableScrollRef.current,
+    estimateSize: () => COVERAGE_ROW_HEIGHT_PX,
+    overscan: 12,
+  });
 
   const filterOptions: { value: CoverageEntryFilter; label: string }[] = [
     { value: "all", label: t("overview.coverage.filters.all") },
@@ -117,6 +113,60 @@ export function CoverageYearDetailView({
     },
   ];
 
+  const yearPromptEntry =
+    yearPromptEntryId != null
+      ? (entries.find((entry) => entry.id === yearPromptEntryId) ?? null)
+      : null;
+
+  const handleYearConfirm = async (entry: CoverageEntry, reportYear: number) => {
+    setFindingReportEntryId(entry.id);
+    try {
+      const results = await searchCompanyReports({
+        companyNames: [entry.name],
+        reportYear: String(reportYear),
+      });
+      const report = results[0] ?? {
+        companyName: entry.name,
+        reportYear: String(reportYear),
+        results: [],
+      };
+      setYearPromptEntryId(null);
+      setFindReportSession({
+        entry,
+        reportYear,
+        companyReport: {
+          ...report,
+          wikidataId: entry.matchedCompany?.wikidataId,
+        },
+      });
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : t("overview.coverage.findReportError"),
+      );
+    } finally {
+      setFindingReportEntryId(null);
+    }
+  };
+
+  const handleViewInRegistry = async () => {
+    if (!onViewRegistryReports) return;
+    setIsLoadingRegistryNames(true);
+    try {
+      const response = await fetchCoverageYearNames(listId, year);
+      onViewRegistryReports(response.names);
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : t("overview.coverage.errorTitle"),
+      );
+    } finally {
+      setIsLoadingRegistryNames(false);
+    }
+  };
+
   return (
     <div className="space-y-4">
       <div className="rounded-lg border border-gray-03 bg-gray-05/50 p-4 space-y-4">
@@ -129,17 +179,30 @@ export function CoverageYearDetailView({
               <Button
                 variant="outline"
                 size="sm"
-                onClick={() =>
-                  onViewRegistryReports(
-                    detail.entries.map((entry) => entry.name),
-                  )
-                }
+                onClick={() => void handleViewInRegistry()}
+                disabled={isLoadingRegistryNames}
               >
-                {t("overview.coverage.reports.viewInRegistry")}
+                {isLoadingRegistryNames ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  t("overview.coverage.reports.viewInRegistry")
+                )}
               </Button>
             ) : null}
             <Button variant="secondary" size="sm" onClick={onEdit}>
               {t("overview.coverage.editYear")}
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => void onRefreshRegistry()}
+              disabled={isRefreshingRegistry}
+            >
+              {isRefreshingRegistry ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                t("overview.coverage.refreshRegistry")
+              )}
             </Button>
           </div>
         </div>
@@ -171,63 +234,173 @@ export function CoverageYearDetailView({
             className="border-blue-03/30 bg-blue-03/10 text-blue-03"
           />
         </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          <CoverageStatCard
+            label={t("overview.coverage.stats.inRegistry")}
+            value={detail.hasAnyReportCount}
+            className="border-gray-03/80 bg-gray-04/30 text-gray-01"
+          />
+          <CoverageStatCard
+            label={t("overview.coverage.stats.inProd")}
+            value={detail.prodReadyCount}
+            className="border-green-03/30 bg-green-03/10 text-green-03"
+          />
+          <CoverageStatCard
+            label={t("overview.coverage.stats.missingReports")}
+            value={detail.noReportCount}
+            className="border-orange-03/30 bg-orange-03/10 text-orange-03"
+          />
+        </div>
+        {detail.registryRefreshedAt ? (
+          <p className="text-xs text-gray-02">
+            {t("overview.coverage.registryRefreshedAt", {
+              time: new Date(detail.registryRefreshedAt).toLocaleString(),
+            })}
+          </p>
+        ) : null}
       </div>
 
       <ViewModePills
         options={filterOptions}
         value={filter}
-        onValueChange={setFilter}
+        onValueChange={onFilterChange}
         ariaLabel={t("overview.coverage.entryFilterLabel")}
       />
 
-      <input
-        className="w-full max-w-md rounded-md border border-gray-03 bg-gray-05 px-3 py-2 text-sm"
-        value={search}
-        onChange={(e) => setSearch(e.target.value)}
-        placeholder={t("overview.coverage.searchPlaceholder")}
-      />
+      <div className="flex flex-wrap items-center gap-3">
+        <input
+          className="w-full max-w-md rounded-md border border-gray-03 bg-gray-05 px-3 py-2 text-sm"
+          value={search}
+          onChange={(e) => onSearchChange(e.target.value)}
+          placeholder={t("overview.coverage.searchPlaceholder")}
+        />
+        <p className="text-sm text-gray-02 tabular-nums">
+          {t("overview.coverage.filteredCount", {
+            shown: entries.length,
+            total: filteredCount,
+          })}
+        </p>
+      </div>
 
-      <div className="overflow-x-auto rounded-lg border border-gray-03">
-        <table className="min-w-full text-sm">
-          <thead className="bg-gray-05/80 text-left text-gray-02">
+      <div
+        ref={tableScrollRef}
+        className="overflow-auto rounded-lg border border-gray-03"
+        style={{ maxHeight: COVERAGE_TABLE_MAX_HEIGHT_PX }}
+      >
+        <table className="min-w-full text-sm table-fixed">
+          <thead className="sticky top-0 z-10 bg-gray-05/95 text-left text-gray-02 backdrop-blur-sm">
             <tr>
-              <th className="px-4 py-2 font-medium">
+              <th className="w-[24%] px-4 py-2 font-medium">
                 {t("overview.coverage.columns.listName")}
               </th>
-              <th className="px-4 py-2 font-medium">
+              <th className="w-[14%] px-4 py-2 font-medium">
                 {t("overview.coverage.columns.status")}
               </th>
-              <th className="px-4 py-2 font-medium">
+              <th className="w-[22%] px-4 py-2 font-medium">
                 {t("overview.coverage.columns.dbMatch")}
               </th>
-              <th className="px-4 py-2 font-medium">
+              <th className="w-[18%] px-4 py-2 font-medium">
                 {t("overview.coverage.columns.reports")}
               </th>
-              <th className="px-4 py-2 font-medium min-w-[12rem]">
+              <th className="w-[22%] px-4 py-2 font-medium min-w-[12rem]">
                 {t("overview.coverage.columns.actions")}
               </th>
             </tr>
           </thead>
           <tbody>
-            {filteredEntries.map((entry) => (
-              <CoverageEntryRow
-                key={entry.id}
-                entry={entry}
-                reportYear={detail.year}
-                onEditEntry={onEditEntry}
-                onFindReportReady={setFindReportSession}
-              />
-            ))}
-            {filteredEntries.length === 0 ? (
+            {entries.length === 0 ? (
               <tr>
                 <td colSpan={5} className="px-4 py-8 text-center text-gray-02">
                   {t("overview.coverage.noEntries")}
                 </td>
               </tr>
-            ) : null}
+            ) : (
+              <>
+                {rowVirtualizer.getVirtualItems().length > 0 ? (
+                  <tr aria-hidden="true">
+                    <td
+                      colSpan={5}
+                      style={{
+                        height: rowVirtualizer.getVirtualItems()[0]?.start ?? 0,
+                        padding: 0,
+                        border: 0,
+                      }}
+                    />
+                  </tr>
+                ) : null}
+                {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+                  const entry = entries[virtualRow.index];
+                  if (!entry) return null;
+
+                  return (
+                    <CoverageEntryRow
+                      key={entry.id}
+                      entry={entry}
+                      isFindingReport={findingReportEntryId === entry.id}
+                      onEditEntry={onEditEntry}
+                      onFindReportClick={() => setYearPromptEntryId(entry.id)}
+                    />
+                  );
+                })}
+                {rowVirtualizer.getVirtualItems().length > 0 ? (
+                  <tr aria-hidden="true">
+                    <td
+                      colSpan={5}
+                      style={{
+                        height:
+                          rowVirtualizer.getTotalSize() -
+                          (rowVirtualizer.getVirtualItems().at(-1)?.end ?? 0),
+                        padding: 0,
+                        border: 0,
+                      }}
+                    />
+                  </tr>
+                ) : null}
+              </>
+            )}
           </tbody>
         </table>
       </div>
+
+      {hasMore ? (
+        <div className="flex justify-center">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => void onLoadMore()}
+            disabled={isLoadingMore}
+          >
+            {isLoadingMore ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" />
+                <span className="ml-2">
+                  {t("overview.coverage.loadingMore")}
+                </span>
+              </>
+            ) : (
+              t("overview.coverage.loadMore")
+            )}
+          </Button>
+        </div>
+      ) : null}
+
+      {yearPromptEntry ? (
+        <CoverageFindReportYearPrompt
+          open
+          onOpenChange={(open) => {
+            if (!findingReportEntryId) {
+              setYearPromptEntryId(open ? yearPromptEntry.id : null);
+            }
+          }}
+          companyName={yearPromptEntry.name}
+          defaultYear={year}
+          isSearching={findingReportEntryId === yearPromptEntry.id}
+          onConfirm={(reportYear) =>
+            void handleYearConfirm(yearPromptEntry, reportYear)
+          }
+        />
+      ) : null}
 
       {findReportSession ? (
         <CoverageFindReportDialog
@@ -267,54 +440,16 @@ function CoverageStatCard({
 
 function CoverageEntryRow({
   entry,
-  reportYear,
+  isFindingReport,
   onEditEntry,
-  onFindReportReady,
+  onFindReportClick,
 }: {
   entry: CoverageEntry;
-  reportYear: number;
+  isFindingReport: boolean;
   onEditEntry: (entry: CoverageEntry) => void;
-  onFindReportReady: (session: FindReportSession) => void;
+  onFindReportClick: () => void;
 }) {
   const { t } = useI18n();
-  const [isFindingReport, setIsFindingReport] = useState(false);
-  const [yearPromptOpen, setYearPromptOpen] = useState(false);
-
-  const handleFindReportClick = () => {
-    setYearPromptOpen(true);
-  };
-
-  const handleYearConfirm = async (year: number) => {
-    setIsFindingReport(true);
-    try {
-      const results = await searchCompanyReports({
-        companyNames: [entry.name],
-        reportYear: String(year),
-      });
-      const report = results[0] ?? {
-        companyName: entry.name,
-        reportYear: String(year),
-        results: [],
-      };
-      setYearPromptOpen(false);
-      onFindReportReady({
-        entry,
-        reportYear: year,
-        companyReport: {
-          ...report,
-          wikidataId: entry.matchedCompany?.wikidataId,
-        },
-      });
-    } catch (error) {
-      toast.error(
-        error instanceof Error
-          ? error.message
-          : t("overview.coverage.findReportError"),
-      );
-    } finally {
-      setIsFindingReport(false);
-    }
-  };
 
   const statusLabel =
     entry.status === "matched"
@@ -334,8 +469,13 @@ function CoverageEntryRow({
 
   return (
     <tr className="border-t border-gray-03/60">
-      <td className="px-4 py-2 text-gray-01">{entry.name}</td>
-      <td className={`px-4 py-2 font-medium ${statusClass}`}>
+      <td
+        className="px-4 py-2 text-gray-01 align-top truncate"
+        title={entry.name}
+      >
+        {entry.name}
+      </td>
+      <td className={`px-4 py-2 font-medium align-top ${statusClass}`}>
         <span>{statusLabel}</span>
         {entry.matchMethod === "manual" ? (
           <span className="ml-2 text-[10px] uppercase tracking-wide text-blue-03">
@@ -343,7 +483,7 @@ function CoverageEntryRow({
           </span>
         ) : null}
       </td>
-      <td className="px-4 py-2 text-gray-02">
+      <td className="px-4 py-2 text-gray-02 align-top truncate">
         {entry.matchedCompany ? (
           <Link
             to={editorCompanyPath(
@@ -357,7 +497,7 @@ function CoverageEntryRow({
           "—"
         )}
       </td>
-      <td className="px-4 py-2">
+      <td className="px-4 py-2 align-top">
         {reports.length > 0 ? (
           <div className="flex flex-wrap gap-1.5">
             {reports.map((report) => (
@@ -370,7 +510,7 @@ function CoverageEntryRow({
           </span>
         )}
       </td>
-      <td className="px-4 py-2">
+      <td className="px-4 py-2 align-top">
         <div className="flex flex-wrap gap-2">
           <Button
             variant="secondary"
@@ -390,21 +530,11 @@ function CoverageEntryRow({
               <Loader2 className="h-4 w-4 animate-spin" />
             </Button>
           ) : (
-            <Button variant="outline" size="sm" onClick={handleFindReportClick}>
+            <Button variant="outline" size="sm" onClick={onFindReportClick}>
               {t("overview.coverage.findReport")}
             </Button>
           )}
         </div>
-        <CoverageFindReportYearPrompt
-          open={yearPromptOpen}
-          onOpenChange={(open) => {
-            if (!isFindingReport) setYearPromptOpen(open);
-          }}
-          companyName={entry.name}
-          defaultYear={reportYear}
-          isSearching={isFindingReport}
-          onConfirm={(year) => void handleYearConfirm(year)}
-        />
       </td>
     </tr>
   );

--- a/src/tabs/overview/hooks/useCoverageLists.ts
+++ b/src/tabs/overview/hooks/useCoverageLists.ts
@@ -1,17 +1,20 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   addCoverageListYear,
+  COVERAGE_PAGE_SIZE,
   createCoverageList,
   deleteCoverageList,
   deleteCoverageListYear,
   fetchCoverageLists,
   fetchCoverageYearDetail,
+  refreshCoverageYearRegistry,
   renameCoverageList,
   replaceCoverageYearNames,
   setCoverageEntryMatch,
 } from "../lib/coverage-api";
 import type {
   CoverageEntry,
+  CoverageEntryFilter,
   CoverageListSummary,
   CoverageYearDetail,
   CoverageMatchSaveAction,
@@ -191,44 +194,117 @@ export function useCoverageYearDetail(
   year: number | null,
 ) {
   const [detail, setDetail] = useState<CoverageYearDetail | null>(null);
+  const [filter, setFilter] = useState<CoverageEntryFilter>("all");
+  const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
   const [isLoading, setIsLoading] = useState(false);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [isRefreshingRegistry, setIsRefreshingRegistry] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const requestRef = useRef(0);
 
-  const loadDetail = useCallback(
-    async (options?: { silent?: boolean }) => {
+  useEffect(() => {
+    const timer = window.setTimeout(() => setDebouncedSearch(search), 300);
+    return () => window.clearTimeout(timer);
+  }, [search]);
+
+  const loadPage = useCallback(
+    async (offset: number, append: boolean) => {
       if (!listId || year === null) {
         setDetail(null);
         return;
       }
-      if (!options?.silent) {
-        setIsLoading(true);
-      }
+
+      const requestId = ++requestRef.current;
       setError(null);
+
       try {
-        setDetail(await fetchCoverageYearDetail(listId, year));
+        const page = await fetchCoverageYearDetail(listId, year, {
+          offset,
+          limit: COVERAGE_PAGE_SIZE,
+          filter,
+          q: debouncedSearch,
+          includeRegistry: true,
+        });
+
+        if (requestId !== requestRef.current) return;
+
+        setDetail((previous) => {
+          if (!append || !previous) return page;
+          return {
+            ...page,
+            entries: [...previous.entries, ...page.entries],
+          };
+        });
       } catch (err) {
+        if (requestId !== requestRef.current) return;
         setError(err instanceof Error ? err.message : "Unknown error");
-        if (!options?.silent) {
+        if (!append) {
           setDetail(null);
-        }
-      } finally {
-        if (!options?.silent) {
-          setIsLoading(false);
         }
       }
     },
-    [listId, year],
+    [listId, year, filter, debouncedSearch],
   );
 
   useEffect(() => {
-    void loadDetail();
-  }, [loadDetail]);
+    if (!listId || year === null) {
+      setDetail(null);
+      return;
+    }
+
+    setIsLoading(true);
+    void loadPage(0, false).finally(() => setIsLoading(false));
+  }, [listId, year, filter, debouncedSearch, loadPage]);
+
+  const loadMore = useCallback(async () => {
+    if (!detail?.hasMore || isLoadingMore || isLoading) return;
+    setIsLoadingMore(true);
+    try {
+      await loadPage(detail.entries.length, true);
+    } finally {
+      setIsLoadingMore(false);
+    }
+  }, [detail, isLoading, isLoadingMore, loadPage]);
+
+  const refreshRegistry = useCallback(async () => {
+    if (!listId || year === null) return;
+    setIsRefreshingRegistry(true);
+    setError(null);
+    try {
+      const refreshed = await refreshCoverageYearRegistry(listId, year);
+      setDetail((previous) =>
+        previous
+          ? {
+              ...previous,
+              hasAnyReportCount: refreshed.hasAnyReportCount,
+              prodReadyCount: refreshed.prodReadyCount,
+              noReportCount: refreshed.noReportCount,
+              registryRefreshedAt: refreshed.registryRefreshedAt,
+            }
+          : previous,
+      );
+      await loadPage(0, false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setIsRefreshingRegistry(false);
+    }
+  }, [listId, year, loadPage]);
 
   return {
     detail,
+    filter,
+    setFilter,
+    search,
+    setSearch,
     isLoading,
+    isLoadingMore,
+    isRefreshingRegistry,
     error,
-    refresh: () => loadDetail(),
+    loadMore,
+    refreshRegistry,
+    refresh: () => loadPage(0, false),
     addEntryRegistryReport: (entryId: string, saved: SaveReportSuccess) => {
       setDetail((previous) =>
         previous
@@ -260,7 +336,7 @@ export function useCoverageYearDetail(
         payload,
       );
       setDetail((previous) => mergeCoverageMatchUpdate(previous, updated));
-      void loadDetail({ silent: true });
+      void loadPage(0, false);
       return updated;
     },
   };

--- a/src/tabs/overview/hooks/useCoverageLists.ts
+++ b/src/tabs/overview/hooks/useCoverageLists.ts
@@ -202,6 +202,7 @@ export function useCoverageYearDetail(
   const [isRefreshingRegistry, setIsRefreshingRegistry] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const requestRef = useRef(0);
+  const selectionRef = useRef<string | null>(null);
 
   useEffect(() => {
     const timer = window.setTimeout(() => setDebouncedSearch(search), 300);
@@ -209,7 +210,11 @@ export function useCoverageYearDetail(
   }, [search]);
 
   const loadPage = useCallback(
-    async (offset: number, append: boolean) => {
+    async (
+      offset: number,
+      append: boolean,
+      queryOverride?: { filter?: CoverageEntryFilter; q?: string },
+    ) => {
       if (!listId || year === null) {
         setDetail(null);
         return;
@@ -222,8 +227,8 @@ export function useCoverageYearDetail(
         const page = await fetchCoverageYearDetail(listId, year, {
           offset,
           limit: COVERAGE_PAGE_SIZE,
-          filter,
-          q: debouncedSearch,
+          filter: queryOverride?.filter ?? filter,
+          q: queryOverride?.q ?? debouncedSearch,
           includeRegistry: true,
         });
 
@@ -239,9 +244,6 @@ export function useCoverageYearDetail(
       } catch (err) {
         if (requestId !== requestRef.current) return;
         setError(err instanceof Error ? err.message : "Unknown error");
-        if (!append) {
-          setDetail(null);
-        }
       }
     },
     [listId, year, filter, debouncedSearch],
@@ -250,22 +252,44 @@ export function useCoverageYearDetail(
   useEffect(() => {
     if (!listId || year === null) {
       setDetail(null);
+      selectionRef.current = null;
       return;
     }
 
+    const selectionKey = `${listId}:${year}`;
+    const selectionChanged = selectionRef.current !== selectionKey;
+    selectionRef.current = selectionKey;
+
+    if (selectionChanged) {
+      setFilter("all");
+      setSearch("");
+      setDebouncedSearch("");
+    }
+
     setIsLoading(true);
-    void loadPage(0, false).finally(() => setIsLoading(false));
+    void loadPage(
+      0,
+      false,
+      selectionChanged ? { filter: "all", q: "" } : undefined,
+    ).finally(() => setIsLoading(false));
   }, [listId, year, filter, debouncedSearch, loadPage]);
 
   const loadMore = useCallback(async () => {
-    if (!detail?.hasMore || isLoadingMore || isLoading) return;
+    if (
+      !detail?.hasMore ||
+      isLoadingMore ||
+      isLoading ||
+      isRefreshingRegistry
+    ) {
+      return;
+    }
     setIsLoadingMore(true);
     try {
       await loadPage(detail.entries.length, true);
     } finally {
       setIsLoadingMore(false);
     }
-  }, [detail, isLoading, isLoadingMore, loadPage]);
+  }, [detail, isLoading, isLoadingMore, isRefreshingRegistry, loadPage]);
 
   const refreshRegistry = useCallback(async () => {
     if (!listId || year === null) return;

--- a/src/tabs/overview/lib/coverage-api.ts
+++ b/src/tabs/overview/lib/coverage-api.ts
@@ -4,11 +4,18 @@ import {
   coverageListCollectionSchema,
   coverageListSummarySchema,
   coverageYearDetailSchema,
+  coverageYearNamesSchema,
+  coverageYearRegistryRefreshSchema,
   coverageCompanySearchResponseSchema,
   type CoverageListSummary,
   type CoverageYearDetail,
+  type CoverageYearNames,
+  type CoverageYearRegistryRefresh,
   type CoverageCompanySearchHit,
+  type CoverageEntryFilter,
 } from "./coverage-types";
+
+export const COVERAGE_PAGE_SIZE = 100;
 
 function coverageUrl(path: string): string {
   const base = getUnearthApiBaseUrl();
@@ -54,14 +61,64 @@ export async function fetchCoverageList(
   );
 }
 
+export type CoverageYearDetailQuery = {
+  offset?: number;
+  limit?: number;
+  filter?: CoverageEntryFilter;
+  q?: string;
+  includeRegistry?: boolean;
+};
+
 export async function fetchCoverageYearDetail(
   listId: string,
   year: number,
+  query: CoverageYearDetailQuery = {},
 ): Promise<CoverageYearDetail> {
-  const url = coverageUrl(`${listId}/years/${year}`);
+  const params = new URLSearchParams();
+  if (query.offset !== undefined) {
+    params.set("offset", String(query.offset));
+  }
+  if (query.limit !== undefined) {
+    params.set("limit", String(query.limit));
+  }
+  if (query.filter && query.filter !== "all") {
+    params.set("filter", query.filter);
+  }
+  if (query.q?.trim()) {
+    params.set("q", query.q.trim());
+  }
+  if (query.includeRegistry === false) {
+    params.set("includeRegistry", "false");
+  }
+  const queryString = params.toString();
+  const url = coverageUrl(
+    `${listId}/years/${year}${queryString ? `?${queryString}` : ""}`,
+  );
   const response = await garboAuthFetch(url, { cache: "no-store" });
   return parseJson(response, url, (data) =>
     coverageYearDetailSchema.parse(data),
+  );
+}
+
+export async function fetchCoverageYearNames(
+  listId: string,
+  year: number,
+): Promise<CoverageYearNames> {
+  const url = coverageUrl(`${listId}/years/${year}/names`);
+  const response = await garboAuthFetch(url, { cache: "no-store" });
+  return parseJson(response, url, (data) =>
+    coverageYearNamesSchema.parse(data),
+  );
+}
+
+export async function refreshCoverageYearRegistry(
+  listId: string,
+  year: number,
+): Promise<CoverageYearRegistryRefresh> {
+  const url = coverageUrl(`${listId}/years/${year}/refresh-registry`);
+  const response = await garboAuthFetch(url, { method: "POST" });
+  return parseJson(response, url, (data) =>
+    coverageYearRegistryRefreshSchema.parse(data),
   );
 }
 

--- a/src/tabs/overview/lib/coverage-types.ts
+++ b/src/tabs/overview/lib/coverage-types.ts
@@ -69,6 +69,26 @@ export const coverageYearDetailSchema = coverageYearSummarySchema.extend({
   prodReadyCount: z.number().default(0),
   noReportCount: z.number().default(0),
   entries: z.array(coverageEntrySchema),
+  filteredCount: z.number().optional(),
+  offset: z.number().optional(),
+  limit: z.number().optional(),
+  hasMore: z.boolean().optional(),
+  registryRefreshedAt: z.string().nullable().optional(),
+});
+
+export const coverageYearRegistryRefreshSchema = z.object({
+  listId: z.string(),
+  year: z.number(),
+  hasAnyReportCount: z.number(),
+  prodReadyCount: z.number(),
+  noReportCount: z.number(),
+  registryRefreshedAt: z.string(),
+});
+
+export const coverageYearNamesSchema = z.object({
+  listId: z.string(),
+  year: z.number(),
+  names: z.array(z.string()),
 });
 
 export const coverageListCollectionSchema = z.object({
@@ -83,6 +103,10 @@ export type CoverageListSummary = z.infer<typeof coverageListSummarySchema>;
 export type CoverageEntryStatus = z.infer<typeof coverageEntryStatusSchema>;
 export type CoverageEntry = z.infer<typeof coverageEntrySchema>;
 export type CoverageYearDetail = z.infer<typeof coverageYearDetailSchema>;
+export type CoverageYearNames = z.infer<typeof coverageYearNamesSchema>;
+export type CoverageYearRegistryRefresh = z.infer<
+  typeof coverageYearRegistryRefreshSchema
+>;
 export type CoverageCompanySearchHit = z.infer<
   typeof coverageCompanySearchHitSchema
 >;


### PR DESCRIPTION
## Summary
- Virtualize the coverage entry table and load rows in pages of 100 via the paginated API.
- Move filter and search to server-side requests (debounced) with Load more pagination.
- Add registry summary cards (in registry / in prod / missing reports) and a Refresh report status button.
- Use lightweight names endpoint for Edit year and View in registry actions.

## Test plan
- [ ] Deploy alongside API PR (requires registry cache migration + backfill)
- [ ] Open MSCI coverage year — fast initial load, smooth scroll
- [ ] Filter pills and search return correct subsets
- [ ] Load more appends next page
- [ ] Refresh report status updates summary cards and filters
- [ ] Edit year / view in registry still work with full name list


Made with [Cursor](https://cursor.com)