### PR TITLE
[Prod] Patch Version Bump v1.14.1

### DIFF
--- a/k8s/overlays/production/kustomization.yaml
+++ b/k8s/overlays/production/kustomization.yaml
@@ -9,4 +9,4 @@ patches:
   - path: deployment-patch.yaml
 images:
   - name: ghcr.io/klimatbyran/validate-frontend
-    newTag: "1.14.0" # {"$imagepolicy": "flux-system:validate-frontend:tag"}
+    newTag: "1.14.1" # {"$imagepolicy": "flux-system:validate-frontend:tag"}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "garbo-validation-tool",
-  "version": "1.14.1-rc.2",
+  "version": "1.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "garbo-validation-tool",
-      "version": "1.14.1-rc.2",
+      "version": "1.14.1",
       "dependencies": {
         "@mendable/firecrawl-js": "^4.12.1",
         "@radix-ui/react-dialog": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "garbo-validation-tool",
   "private": true,
-  "version": "1.14.1-rc.2",
+  "version": "1.14.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
# Production Release PR (Validate)

## Release Type

- [x] Patch version bump

### Rollback Version

v1.14.0

## What''s Being Released

- Coverage list UI improvements for large index lists (#268)
  - Paginated year detail, registry filters, refresh report status
  - Find-report and entry match flows
- Upload tab enhancements (included in release train)

## Deployment Notes

**Paired release with Garbo v6.0.8 and unearth-api v1.6.2.**

Deploy after Garbo migration and API backfill. Smoke test: Overview → Coverage → open MSCI 2026, confirm pagination works.

## Checklist

- [x] Version updated (`1.14.1`)
- [x] QA verified in staging
- [x] Rollback version recorded (v1.14.0)
- [x] Title follows: `[Prod] Patch Version Bump v1.14.1`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only change with no runtime or dependency updates in the diff; rollback target is v1.14.0 per release notes.
> 
> **Overview**
> **Production release metadata only:** bumps `garbo-validation-tool` from `1.14.2-rc.0` to **`1.14.1`** in `package.json` and the root entry in `package-lock.json`.
> 
> There are **no application or dependency changes** in this diff—the release packages already-merged work (e.g. coverage list UI and upload tab improvements described in the PR notes), paired with Garbo v6.0.8 and unearth-api v1.6.2.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b207f52c716829aeb139954102d99d732ce5c737. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->