### PR TITLE
Fix coverage UI for async refresh, match save, and find report

### DIFF
--- a/src/tabs/crawler/lib/crawler-utils.ts
+++ b/src/tabs/crawler/lib/crawler-utils.ts
@@ -86,7 +86,7 @@ export const searchCompanyReports = async ({
   country,
   onProgress,
 }: SearchCompanyReportsParams): Promise<CompanyReport[]> => {
-  if (!companies.length) {
+  if (!companies?.length) {
     return [];
   }
 

--- a/src/tabs/overview/components/CoverageYearDetail.tsx
+++ b/src/tabs/overview/components/CoverageYearDetail.tsx
@@ -126,8 +126,13 @@ export function CoverageYearDetailView({
     setFindingReportEntryId(entry.id);
     try {
       const results = await searchCompanyReports({
-        companyNames: [entry.name],
-        reportYear: String(reportYear),
+        companies: [
+          {
+            name: entry.matchedCompany?.name ?? entry.name,
+            reportYear: String(reportYear),
+            wikidataId: entry.matchedCompany?.wikidataId,
+          },
+        ],
       });
       const report = results[0] ?? {
         companyName: entry.name,

--- a/src/tabs/overview/hooks/useCoverageLists.ts
+++ b/src/tabs/overview/hooks/useCoverageLists.ts
@@ -22,6 +22,47 @@ import type {
 } from "../lib/coverage-types";
 import type { SaveReportSuccess } from "@/tabs/crawler/lib/crawler-types";
 
+const REGISTRY_REFRESH_POLL_MS = 2000;
+const REGISTRY_REFRESH_MAX_POLLS = 120;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, ms));
+}
+
+async function waitForRegistryRefresh(
+  listId: string,
+  year: number,
+): Promise<CoverageYearDetail> {
+  for (let attempt = 0; attempt < REGISTRY_REFRESH_MAX_POLLS; attempt += 1) {
+    await sleep(REGISTRY_REFRESH_POLL_MS);
+    const page = await fetchCoverageYearDetail(listId, year, {
+      offset: 0,
+      limit: COVERAGE_PAGE_SIZE,
+      filter: "all",
+      includeRegistry: true,
+    });
+    if (!page.registryRefreshInProgress) {
+      return page;
+    }
+  }
+  throw new Error("Registry refresh timed out");
+}
+
+function applyYearStats(
+  previous: CoverageYearDetail | null,
+  stats: Pick<
+    CoverageYearDetail,
+    | "hasAnyReportCount"
+    | "prodReadyCount"
+    | "noReportCount"
+    | "registryRefreshedAt"
+    | "registryRefreshInProgress"
+  >,
+): CoverageYearDetail | null {
+  if (!previous) return previous;
+  return { ...previous, ...stats };
+}
+
 function entryMatchChanged(
   previous: CoverageEntry,
   updated: CoverageEntry,
@@ -40,6 +81,34 @@ function mergeCoverageMatchUpdate(
 ): CoverageYearDetail {
   if (!previous) return updated;
 
+  const yearFields = {
+    totalNames: updated.totalNames,
+    matchedCount: updated.matchedCount,
+    ambiguousCount: updated.ambiguousCount,
+    coveragePercent: updated.coveragePercent,
+    hasAnyReportCount: updated.hasAnyReportCount,
+    prodReadyCount: updated.prodReadyCount,
+    noReportCount: updated.noReportCount,
+    registryRefreshedAt: updated.registryRefreshedAt,
+  };
+
+  const isPartialEntryUpdate =
+    updated.entries.length > 0 &&
+    updated.entries.length < previous.entries.length;
+
+  if (isPartialEntryUpdate) {
+    const patchById = new Map(
+      updated.entries.map((entry) => [entry.id, entry] as const),
+    );
+    return {
+      ...previous,
+      ...yearFields,
+      entries: previous.entries.map(
+        (entry) => patchById.get(entry.id) ?? entry,
+      ),
+    };
+  }
+
   const previousById = new Map(
     previous.entries.map((entry) => [entry.id, entry] as const),
   );
@@ -57,10 +126,24 @@ function mergeCoverageMatchUpdate(
     };
   });
 
-  if (anyMatchChanged) return updated;
+  if (anyMatchChanged) {
+    return {
+      ...updated,
+      ...yearFields,
+      filteredCount: previous.filteredCount,
+      offset: previous.offset,
+      limit: previous.limit,
+      hasMore: previous.hasMore,
+      entries: previous.entries.map(
+        (entry) =>
+          updated.entries.find((patch) => patch.id === entry.id) ?? entry,
+      ),
+    };
+  }
 
   return {
     ...updated,
+    ...yearFields,
     hasAnyReportCount: previous.hasAnyReportCount,
     prodReadyCount: previous.prodReadyCount,
     noReportCount: previous.noReportCount,
@@ -298,16 +381,28 @@ export function useCoverageYearDetail(
     try {
       const refreshed = await refreshCoverageYearRegistry(listId, year);
       setDetail((previous) =>
-        previous
-          ? {
-              ...previous,
-              hasAnyReportCount: refreshed.hasAnyReportCount,
-              prodReadyCount: refreshed.prodReadyCount,
-              noReportCount: refreshed.noReportCount,
-              registryRefreshedAt: refreshed.registryRefreshedAt,
-            }
-          : previous,
+        applyYearStats(previous, {
+          hasAnyReportCount: refreshed.hasAnyReportCount,
+          prodReadyCount: refreshed.prodReadyCount,
+          noReportCount: refreshed.noReportCount,
+          registryRefreshedAt: refreshed.registryRefreshedAt,
+          registryRefreshInProgress: refreshed.inProgress,
+        }),
       );
+
+      if (refreshed.inProgress) {
+        const completed = await waitForRegistryRefresh(listId, year);
+        setDetail((previous) =>
+          applyYearStats(previous, {
+            hasAnyReportCount: completed.hasAnyReportCount,
+            prodReadyCount: completed.prodReadyCount,
+            noReportCount: completed.noReportCount,
+            registryRefreshedAt: completed.registryRefreshedAt,
+            registryRefreshInProgress: false,
+          }),
+        );
+      }
+
       await loadPage(0, false);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Unknown error");

--- a/src/tabs/overview/hooks/useCoverageLists.ts
+++ b/src/tabs/overview/hooks/useCoverageLists.ts
@@ -285,6 +285,7 @@ export function useCoverageYearDetail(
   const [isRefreshingRegistry, setIsRefreshingRegistry] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const requestRef = useRef(0);
+  const registryRefreshRef = useRef(0);
   const selectionRef = useRef<string | null>(null);
 
   useEffect(() => {
@@ -344,6 +345,8 @@ export function useCoverageYearDetail(
     selectionRef.current = selectionKey;
 
     if (selectionChanged) {
+      registryRefreshRef.current += 1;
+      setIsRefreshingRegistry(false);
       setFilter("all");
       setSearch("");
       setDebouncedSearch("");
@@ -376,10 +379,19 @@ export function useCoverageYearDetail(
 
   const refreshRegistry = useCallback(async () => {
     if (!listId || year === null) return;
+
+    const refreshId = ++registryRefreshRef.current;
+    const selectionKey = `${listId}:${year}`;
+    const isStale = () =>
+      refreshId !== registryRefreshRef.current ||
+      selectionRef.current !== selectionKey;
+
     setIsRefreshingRegistry(true);
     setError(null);
     try {
       const refreshed = await refreshCoverageYearRegistry(listId, year);
+      if (isStale()) return;
+
       setDetail((previous) =>
         applyYearStats(previous, {
           hasAnyReportCount: refreshed.hasAnyReportCount,
@@ -392,6 +404,8 @@ export function useCoverageYearDetail(
 
       if (refreshed.inProgress) {
         const completed = await waitForRegistryRefresh(listId, year);
+        if (isStale()) return;
+
         setDetail((previous) =>
           applyYearStats(previous, {
             hasAnyReportCount: completed.hasAnyReportCount,
@@ -403,11 +417,20 @@ export function useCoverageYearDetail(
         );
       }
 
+      if (isStale()) return;
       await loadPage(0, false);
     } catch (err) {
+      if (isStale()) return;
+
+      setDetail((previous) =>
+        applyYearStats(previous, { registryRefreshInProgress: false }),
+      );
       setError(err instanceof Error ? err.message : "Unknown error");
+      await loadPage(0, false);
     } finally {
-      setIsRefreshingRegistry(false);
+      if (!isStale()) {
+        setIsRefreshingRegistry(false);
+      }
     }
   }, [listId, year, loadPage]);
 

--- a/src/tabs/overview/lib/coverage-types.ts
+++ b/src/tabs/overview/lib/coverage-types.ts
@@ -74,6 +74,7 @@ export const coverageYearDetailSchema = coverageYearSummarySchema.extend({
   limit: z.number().optional(),
   hasMore: z.boolean().optional(),
   registryRefreshedAt: z.string().nullable().optional(),
+  registryRefreshInProgress: z.boolean().optional(),
 });
 
 export const coverageYearRegistryRefreshSchema = z.object({
@@ -82,7 +83,8 @@ export const coverageYearRegistryRefreshSchema = z.object({
   hasAnyReportCount: z.number(),
   prodReadyCount: z.number(),
   noReportCount: z.number(),
-  registryRefreshedAt: z.string(),
+  registryRefreshedAt: z.string().nullable(),
+  inProgress: z.boolean(),
 });
 
 export const coverageYearNamesSchema = z.object({


### PR DESCRIPTION
## Summary
- Poll year detail after refresh-registry until `registryRefreshInProgress` is false.
- Merge partial PATCH match responses into the currently loaded page instead of replacing all entries.
- Fix Find report to send `{ companies: [...] }` (was `companyNames`, causing a crash).
- Guard `searchCompanyReports` when `companies` is undefined.

## Depends on
API PR: https://github.com/UnearthData/api/pull/72

## Test plan
- [ ] Deploy to stage with API PR
- [ ] Save company match on MSCI entry — UI updates the row without losing scroll position
- [ ] Refresh report status — shows in-progress, then updated summary cards
- [ ] Find report on a matched entry — no crash, opens report search modal
- [ ] Paginated browse and filters still work

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches coverage list state merging, async polling, and crawler entry points; wrong merge or stale-handling could show outdated rows or stats, but changes are localized to overview coverage UX.
> 
> **Overview**
> Fixes several coverage year-detail flows that broke or felt wrong with async registry refresh and partial API responses.
> 
> **Registry refresh** now treats refresh as potentially long-running: after calling refresh, the UI tracks `registryRefreshInProgress` / `inProgress`, polls year detail until refresh finishes (with timeout), ignores stale results if the user switches list/year, then reloads the first page so summary cards and rows stay accurate.
> 
> **Saving a company match** no longer replaces the whole loaded entry list when the API returns a partial update. `mergeCoverageMatchUpdate` patches only the returned rows into the current page and keeps pagination fields (`filteredCount`, `offset`, `hasMore`) so scroll position and “load more” state are preserved.
> 
> **Find report** calls `searchCompanyReports` with the correct `{ companies: [...] }` shape (matched name + `wikidataId`) instead of the invalid `companyNames` argument that caused a crash. **`searchCompanyReports`** also no-ops safely when `companies` is undefined.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf5388de632b5bd3fb3c0a8b9d53181b35ba10ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->