### PR TITLE
[Prod] Patch Version Bump v1.14.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "garbo-validation-tool",
-  "version": "1.14.2-rc.1",
+  "version": "1.14.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "garbo-validation-tool",
-      "version": "1.14.2-rc.1",
+      "version": "1.14.2",
       "dependencies": {
         "@mendable/firecrawl-js": "^4.12.1",
         "@radix-ui/react-dialog": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "garbo-validation-tool",
   "private": true,
-  "version": "1.14.2-rc.1",
+  "version": "1.14.2",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
# Production Release PR (Validate)

## Release Type

- [x] Patch version bump

### Rollback Version

v1.14.1

## What''s Being Released

- Fix coverage UI for async refresh, match save, and find report (#270)
  - Poll registry refresh until background job completes
  - Merge partial PATCH match responses into loaded page
  - Fix find-report API payload crash
  - Guard stale refresh polling on navigation/timeout

## Deployment Notes

**Paired release with unearth-api v1.6.3.** Deploy API and Validate together.

Smoke test: Overview → Coverage → MSCI year — save match, refresh report status, find report, company search.

## Checklist

- [x] Version updated (`1.14.2`)
- [ ] QA verified in staging
- [x] Rollback version recorded (v1.14.1)
- [x] Title follows: `[Prod] Patch Version Bump v1.14.2`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No application or dependency changes—only release metadata version strings updated from RC to stable.
> 
> **Overview**
> Promotes **garbo-validation-tool** from `1.14.2-rc.1` to **`1.14.2`** in `package.json` and `package-lock.json` for the production patch release.
> 
> This PR is a **version-only** cut; the coverage UI fixes described in the release notes (async refresh polling, match save merge, find-report payload, refresh polling guards) are assumed to already be on the release branch and are not part of this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 285a7462ce86db84e2d39029f329a64997c81be7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->