### PR TITLE
Preserve registry pills on PATCH match response

### DIFF
--- a/src/tabs/overview/hooks/useCoverageLists.ts
+++ b/src/tabs/overview/hooks/useCoverageLists.ts
@@ -103,9 +103,17 @@ function mergeCoverageMatchUpdate(
     return {
       ...previous,
       ...yearFields,
-      entries: previous.entries.map(
-        (entry) => patchById.get(entry.id) ?? entry,
-      ),
+      entries: previous.entries.map((entry) => {
+        const patch = patchById.get(entry.id);
+        if (!patch) return entry;
+        return {
+          ...patch,
+          registryReports:
+            patch.registryReports.length > 0
+              ? patch.registryReports
+              : entry.registryReports,
+        };
+      }),
     };
   }
 

--- a/src/tabs/overview/hooks/useCoverageLists.ts
+++ b/src/tabs/overview/hooks/useCoverageLists.ts
@@ -111,7 +111,9 @@ function mergeCoverageMatchUpdate(
           registryReports:
             patch.registryReports.length > 0
               ? patch.registryReports
-              : entry.registryReports,
+              : entryMatchChanged(entry, patch)
+                ? []
+                : entry.registryReports,
         };
       }),
     };


### PR DESCRIPTION
## Summary
- When PATCH match returns a lightweight single-entry response with empty `registryReports`, keep existing pills from the loaded page row.

## Depends on
API PR: https://github.com/UnearthData/api/pull/74

## Test plan
- [ ] Deploy with API PR #74
- [ ] Save match on MSCI entry — row updates, registry pills remain visible

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small client-side merge tweak in coverage overview state; no auth or persistence changes.
> 
> **Overview**
> When a coverage **match save** returns a **partial page update** (fewer entries than the loaded list), merging no longer blindly replaces each row with the PATCH payload.
> 
> For patched rows, **`registryReports`** now uses the response when it includes pills; if the API sends an empty list but the match fields did not change, the UI **keeps the existing registry pills** from the loaded row. If the match actually changed (`entryMatchChanged`), empty `registryReports` still **clears** pills as expected.
> 
> This pairs with the API’s lightweight single-entry PATCH responses that omit registry data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22aeda7c31c330a21d50a974e6b080cb38644d01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->