### PR TITLE
[Prod] Patch Version Bump v1.14.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "garbo-validation-tool",
-  "version": "1.14.3-rc.1",
+  "version": "1.14.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "garbo-validation-tool",
-      "version": "1.14.3-rc.1",
+      "version": "1.14.3",
       "dependencies": {
         "@mendable/firecrawl-js": "^4.12.1",
         "@radix-ui/react-dialog": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "garbo-validation-tool",
   "private": true,
-  "version": "1.14.3-rc.1",
+  "version": "1.14.3",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
# Production Release PR (Validate)

## Release Type

- [x] Patch version bump

### Rollback Version

v1.14.2

## What''s Being Released

- Preserve registry pills on PATCH match response (#272)
- Clear stale pills when match company changes

## Deployment Notes

**Paired release with unearth-api v1.6.4.** Deploy API and Validate together.

Smoke test: Overview → Coverage → MSCI — save company match without timeout; row updates correctly.

## Checklist

- [x] Version updated (`1.14.3`)
- [ ] QA verified in staging
- [x] Rollback version recorded (v1.14.2)
- [x] Title follows: `[Prod] Patch Version Bump v1.14.3`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No application code changes—only version metadata for a patch production cut.
> 
> **Overview**
> Production patch release: bumps **garbo-validation-tool** from `1.14.3-rc.1` to **`1.14.3`** in `package.json` and `package-lock.json` only.
> 
> This tags the Validate frontend for prod alongside **unearth-api v1.6.4**; the functional fixes (registry pills on PATCH match, clearing stale pills when the matched company changes) are already on the branch and are called out in the release notes rather than in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 193f63f07a5abad2f319e311ad27a5f2c5838dc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->