### PR TITLE
[Prod] Minor Version Bump v1.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "garbo-validation-tool",
-  "version": "1.14.4-rc.1",
+  "version": "1.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "garbo-validation-tool",
-      "version": "1.14.4-rc.1",
+      "version": "1.15.0",
       "dependencies": {
         "@mendable/firecrawl-js": "^4.12.1",
         "@radix-ui/react-dialog": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "garbo-validation-tool",
   "private": true,
-  "version": "1.14.4-rc.1",
+  "version": "1.15.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
# Production Release PR (Validate)

## Release Type

- [x] Minor version bump

### Rollback Version

v1.14.3

## What's Being Released

### Coverage overview improvements ([#274](https://github.com/Klimatbyran/validate-frontend/pull/274))

- **Run report** action on coverage list rows (shared registry pipeline + year picker)
- Tier-colored coverage percentages in list table, year pills, and stat cards
- Bordered `outline` button variant for row actions (Edit match / Find report / Run report)
- Bugbot fixes: disable Run when years are unparseable, stable year picker selection, consistent registry year matching

## Deployment Notes

Validate-only frontend release. No paired API deploy required.

Smoke test: Overview → Coverage → open MSCI year → verify colored coverage %, bordered row actions, Run report opens modal for entries with registry pills.

## Checklist

- [x] Version updated (`1.15.0`)
- [ ] QA verified in staging
- [x] Rollback target recorded (v1.14.3)
- [x] Title follows: `[Prod] Minor Version Bump v1.15.0`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only version strings in package manifests change; no runtime code or dependency updates in this diff.
> 
> **Overview**
> Bumps the **garbo-validation-tool** release metadata from `1.14.4-rc.1` to **`1.15.0`** in `package.json` and the root entry in `package-lock.json`.
> 
> This is a **production minor release** packaging step; the diff contains **no application source changes**—only version fields for the validate frontend cut labeled v1.15.0 (rollback target noted in the PR: v1.14.3).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 804debd3cdd881274a0042c38aadc41b4708c6e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->