### PR TITLE
[Prod] Minor Version Bump v1.15.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "garbo-validation-tool",
-  "version": "1.15.1-rc.1",
+  "version": "1.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "garbo-validation-tool",
-      "version": "1.15.1-rc.1",
+      "version": "1.15.1",
       "dependencies": {
         "@mendable/firecrawl-js": "^4.12.1",
         "@radix-ui/react-dialog": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "garbo-validation-tool",
   "private": true,
-  "version": "1.15.1-rc.1",
+  "version": "1.15.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
# Production Release PR (Validate)

## Release type

- [x] Minor version bump

### Rollback version

v1.15.0

## Environment promotion

Promotes **staging → production** (`1.15.1-rc.1` tested on validate-stage).

**Requires paired API v1.6.6** (identifier endpoints + LEI clear fix).

## Version / artifacts

- **Version being released:** v1.15.1
- **Image:** `ghcr.io/klimatbyran/validate-frontend:1.15.1`
- **Rollback target:** v1.15.0

## What's being released

Everything merged since **v1.15.0** (`804debd`):

### Company identifier editor ([#276](https://github.com/Klimatbyran/validate-frontend/pull/276))

- **Identifiers section** on company detail — edit Wikidata, LEI, org number, and ISIN in dedicated rows
- **Add / edit / verify** flows via `POST /api/companies/:id/identifiers`
- **Clear LEI, org number, and ISIN** via empty save → `DELETE /identifiers/:type`
- Internal company ID stays read-only
- **Core company save no longer sends `wikidataId` or `lei`** — identifiers managed separately
- i18n strings for identifier types, add flow, clear/save toasts

### Supporting changes (same PR series)

- `CompanyIdentifiersEditor` replaces read-only `CompanyIdentifiersList`
- `companies-api.ts`: `upsertCompanyIdentifier`, `deleteCompanyIdentifier`
- `company-identifiers.ts`: build editable rows, legacy column fallback, `canClearIdentifierType`
- Tests: `CompanyDetailTab.test.tsx`, `company-identifiers.test.ts`
- CI: Prettier fix; format check skips deleted files (`--diff-filter=ACMR`)
- npm audit fix for high-severity dependency (`4d3e23c`)

## Deployment notes

- Validate-only frontend release, but **depends on API v1.6.6** for identifier upsert/delete
- Deploy API first (or simultaneously) to avoid 404 on identifier routes
- No config changes required

## Smoke test (production)

- [ ] Editor → company detail → Identifiers section loads
- [ ] Edit and save Wikidata / LEI with verify metadata
- [ ] Add ORG_NUMBER or ISIN
- [ ] Clear LEI (empty field + save) → null in DB after refresh
- [ ] Core company save (name/tags) still works and does not send lei/wikidataId
- [ ] Invalid Wikidata IDs rejected client-side

## Checklist

- [x] Version updated (`1.15.1`)
- [x] QA verified in staging (`1.15.1-rc.1`)
- [x] Rollback target recorded (v1.15.0)
- [x] Title follows: `[Prod] Minor Version Bump v1.15.1`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only version metadata changes in package files; no runtime code or dependency updates in this diff.
> 
> **Overview**
> Promotes the **garbo-validation-tool** release from **`1.15.1-rc.1`** to **`1.15.1`** in `package.json` and the root entry in `package-lock.json`.
> 
> This is a **version-only** change for the production promotion of staging-validated **v1.15.1** (image `ghcr.io/klimatbyran/validate-frontend:1.15.1`). No application source, config, or dependency lock entries are modified beyond aligning the package version fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e1075b45913e22a1e9b53e72cf4ae612e186cce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->