### PR TITLE
Send company context on run-reports and clarify dedup UX

### DIFF
--- a/src/hooks/useRunReportsPipeline.ts
+++ b/src/hooks/useRunReportsPipeline.ts
@@ -13,6 +13,11 @@ import {
   UploadApiError,
   createJobsFromUrls,
 } from "@/tabs/upload/lib/upload-api";
+import type { RunReportListItem } from "@/lib/run-reports-types";
+import {
+  urlContextsFromRunItems,
+  type PipelineUrlContext,
+} from "@/lib/pipeline-company-context";
 import type { UploadBatchOptionsProps } from "@/tabs/upload/components/UploadBatchOptions";
 import type { UploadTagsOptionsProps } from "@/tabs/upload/components/UploadTagsOptions";
 import type { UploadWorkerRunOptionsProps } from "@/tabs/upload/components/UploadWorkerRunOptions";
@@ -23,10 +28,18 @@ export type RunReportsPipelineRunOptions = {
   workers: UploadWorkerRunOptionsProps;
 };
 
+export type RunReportsPipelineRunForUrlsOptions = {
+  onSuccess?: () => void;
+  /** Per-URL Garbo company identity (wikidata, name, id). */
+  urlContexts?: PipelineUrlContext[];
+  /** Shorthand: build urlContexts from run-report rows. */
+  runItems?: RunReportListItem[];
+};
+
 export type RunReportsPipelineHandle = {
   runForUrls: (
     urls: string[],
-    options?: { onSuccess?: () => void },
+    options?: RunReportsPipelineRunForUrlsOptions,
   ) => Promise<void>;
   isRunningReports: boolean;
   autoApprove: boolean;
@@ -106,7 +119,7 @@ export function useRunReportsPipeline(config?: RunReportsPipelineConfig) {
   const runForUrls = useCallback(
     async (
       urls: string[],
-      options?: { onSuccess?: () => void },
+      options?: RunReportsPipelineRunForUrlsOptions,
     ): Promise<void> => {
       if (!urls.length) {
         toast.error(t("registry.noReportUrls"));
@@ -144,6 +157,12 @@ export function useRunReportsPipeline(config?: RunReportsPipelineConfig) {
 
       setIsRunningReports(true);
       try {
+        const urlContexts =
+          options?.urlContexts ??
+          (options?.runItems
+            ? urlContextsFromRunItems(options.runItems)
+            : undefined);
+
         const result = await createJobsFromUrls({
           urls,
           autoApprove,
@@ -152,6 +171,7 @@ export function useRunReportsPipeline(config?: RunReportsPipelineConfig) {
           runOnly,
           tags,
           parsePdfEndpoint: config?.parsePdfEndpoint,
+          urlContexts,
         });
 
         const envelope =

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -312,7 +312,9 @@
         "emissions": "Emissions",
         "economy": "Economy",
         "allYears": "All years",
-        "thisReport": "This report"
+        "thisReport": "This report",
+        "companyIdLabel": "Company",
+        "reportShellLabel": "Report shell"
       },
       "searchPlaceholder": "Search by company name or Wikidata ID...",
       "searchAndFilters": "Search & Filters",
@@ -579,6 +581,7 @@
     "orClickToSelect": "or click to select files",
     "pastePdfLinks": "Paste PDF links (one per line)",
     "autoApprove": "Auto-approve",
+    "autoApproveHint": "Auto-approves the Wikidata match only. It does not merge or deduplicate companies — existing companies are linked by Wikidata, LEI, or exact name when known.",
     "addLinks": "Add links",
     "uploadedFiles": "Uploaded files ({{count}})",
     "addedLinks": "Added links ({{count}})",
@@ -1734,6 +1737,7 @@
     "companyId": "Company ID",
     "createNew": "Create new company",
     "createNewDescription": "Use when none of the candidates are the correct company.",
+    "createNewExactNameWarning": "An existing company already matches this name exactly. Creating a new company will likely produce a duplicate.",
     "approved": "Company linked",
     "pendingApproval": "Select company",
     "approveTitle": "Confirm company link",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -312,7 +312,9 @@
         "emissions": "Utsläpp",
         "economy": "Ekonomi",
         "allYears": "Alla år",
-        "thisReport": "Denna rapport"
+        "thisReport": "Denna rapport",
+        "companyIdLabel": "Bolag",
+        "reportShellLabel": "Rapportskal"
       },
       "searchPlaceholder": "Sök på företagsnamn eller Wikidata-ID...",
       "searchAndFilters": "Sök & filter",
@@ -579,6 +581,7 @@
     "orClickToSelect": "eller klicka för att välja filer",
     "pastePdfLinks": "Klistra in PDF-länkar (en per rad)",
     "autoApprove": "Auto-godkänn",
+    "autoApproveHint": "Auto-godkänner endast Wikidata-matchningen. Det slår inte ihop eller deduplicerar bolag — befintliga bolag kopplas via Wikidata, LEI eller exakt namn när det är känt.",
     "addLinks": "Lägg till länkar",
     "uploadedFiles": "Uppladdade filer ({{count}})",
     "addedLinks": "Tillagda länkar ({{count}})",
@@ -1734,6 +1737,7 @@
     "companyId": "Bolags-ID",
     "createNew": "Skapa nytt bolag",
     "createNewDescription": "Använd när inget av förslagen är rätt bolag.",
+    "createNewExactNameWarning": "Ett befintligt bolag matchar redan detta namn exakt. Att skapa ett nytt bolag ger sannolikt en dubblett.",
     "approved": "Bolag kopplat",
     "pendingApproval": "Välj bolag",
     "approveTitle": "Bekräfta bolagskoppling",

--- a/src/lib/pipeline-company-context.test.ts
+++ b/src/lib/pipeline-company-context.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+  pipelineContextFromRunItem,
+  urlContextsFromRunItems,
+} from "@/lib/pipeline-company-context";
+
+describe("pipeline-company-context", () => {
+  it("builds url context from run item fields", () => {
+    expect(
+      pipelineContextFromRunItem({
+        url: "https://example.com/r.pdf",
+        companyId: "11111111-1111-4111-8111-111111111111",
+        companyName: "Meta",
+        wikidataId: "Q380",
+      }),
+    ).toEqual({
+      url: "https://example.com/r.pdf",
+      companyId: "11111111-1111-4111-8111-111111111111",
+      companyName: "Meta",
+      wikidataId: "Q380",
+    });
+  });
+
+  it("returns undefined when no identifiers are present", () => {
+    expect(
+      urlContextsFromRunItems([
+        {
+          url: "https://example.com/r.pdf",
+          companyName: null,
+          wikidataId: null,
+        },
+      ]),
+    ).toBeUndefined();
+  });
+
+  it("filters items without identity fields", () => {
+    expect(
+      urlContextsFromRunItems([
+        { url: "https://a.test/r.pdf", wikidataId: "Q1" },
+        { url: "https://b.test/r.pdf" },
+      ]),
+    ).toEqual([{ url: "https://a.test/r.pdf", wikidataId: "Q1" }]);
+  });
+});

--- a/src/lib/pipeline-company-context.ts
+++ b/src/lib/pipeline-company-context.ts
@@ -1,0 +1,49 @@
+import type { RunReportListItem } from "@/lib/run-reports-types";
+
+export type PipelineCompanyContext = {
+  companyId?: string;
+  companyName?: string;
+  wikidataId?: string;
+};
+
+export type PipelineUrlContext = PipelineCompanyContext & {
+  url: string;
+};
+
+export function pipelineContextFromRunItem(
+  item: RunReportListItem,
+): PipelineUrlContext | null {
+  const url = item.url?.trim();
+  if (!url) return null;
+
+  const companyId = item.companyId?.trim();
+  const companyName = item.companyName?.trim();
+  const wikidataId = item.wikidataId?.trim();
+
+  if (!companyId && !companyName && !wikidataId) {
+    return { url };
+  }
+
+  return {
+    url,
+    ...(companyId ? { companyId } : {}),
+    ...(companyName ? { companyName } : {}),
+    ...(wikidataId ? { wikidataId } : {}),
+  };
+}
+
+export function urlContextsFromRunItems(
+  items: RunReportListItem[],
+): PipelineUrlContext[] | undefined {
+  const contexts = items
+    .map(pipelineContextFromRunItem)
+    .filter((ctx): ctx is PipelineUrlContext => ctx != null)
+    .filter(
+      (ctx) =>
+        Boolean(ctx.companyId) ||
+        Boolean(ctx.companyName) ||
+        Boolean(ctx.wikidataId),
+    );
+
+  return contexts.length > 0 ? contexts : undefined;
+}

--- a/src/lib/run-reports-types.ts
+++ b/src/lib/run-reports-types.ts
@@ -5,6 +5,8 @@
 export type RunReportListItem = {
   id?: string;
   url: string;
+  /** Garbo Company.id when the caller already knows the canonical company. */
+  companyId?: string | null;
   companyName?: string | null;
   wikidataId?: string | null;
   reportYear?: string | null;

--- a/src/tabs/crawler/CrawlerTab.tsx
+++ b/src/tabs/crawler/CrawlerTab.tsx
@@ -120,7 +120,14 @@ export function CrawlerTab() {
     const urls = selectedReports
       .map((r) => r.url?.trim())
       .filter((url): url is string => Boolean(url));
-    void runForUrls(urls, { onSuccess: () => setIsRunReportsOpen(false) });
+    void runForUrls(urls, {
+      runItems: selectedReports.map((r) => ({
+        url: r.url,
+        companyName: r.companyName,
+        wikidataId: r.wikidataId ?? null,
+      })),
+      onSuccess: () => setIsRunReportsOpen(false),
+    });
   }, [runForUrls, selectedReports]);
 
   const viewModeOptions = [

--- a/src/tabs/editor/components/single-company/SingleCompanyOverviewTable.tsx
+++ b/src/tabs/editor/components/single-company/SingleCompanyOverviewTable.tsx
@@ -167,14 +167,21 @@ export function SingleCompanyOverviewTable({
                   <td className="px-4 py-3 font-medium">
                     <div className="flex flex-col">
                       <span>{c.name}</span>
-                      <span className="text-xs text-gray-02">
-                        {c.wikidataId ?? c.id.split("-")[0]}
+                      <span className="text-xs text-gray-02 break-all">
+                        {t("editor.singleCompanyView.table.companyIdLabel")}:{" "}
+                        {c.id}
                       </span>
+                      {c.wikidataId ? (
+                        <span className="text-xs text-gray-02">
+                          Wikidata: {c.wikidataId}
+                        </span>
+                      ) : null}
                       {row.companyReportId ? (
                         <span
-                          className={`${editorSecondaryIdTextClass} mt-0.5`}
+                          className={`${editorSecondaryIdTextClass} mt-0.5 break-all`}
                         >
-                          {row.companyReportId}
+                          {t("editor.singleCompanyView.table.reportShellLabel")}
+                          : {row.companyReportId}
                         </span>
                       ) : null}
                     </div>

--- a/src/tabs/jobbstatus/components/CompanyLinkApprovalDisplay.tsx
+++ b/src/tabs/jobbstatus/components/CompanyLinkApprovalDisplay.tsx
@@ -24,6 +24,13 @@ export function CompanyLinkApprovalDisplay({
   const isApproved = data.status === "approved";
   const isPending = data.status === "pending_approval";
   const isWikidataRelink = data.metadata?.source === "wikidata-relink";
+  const allowCreateNew =
+    data.allowCreateNew !== false && !data.wikidataNode?.trim();
+
+  const normalizedExtracted = data.extractedName.trim().toLowerCase();
+  const hasExactNameCandidate = data.candidates.some(
+    (candidate) => candidate.name.trim().toLowerCase() === normalizedExtracted,
+  );
 
   const handleApprove = () => {
     if (createNew) {
@@ -130,7 +137,7 @@ export function CompanyLinkApprovalDisplay({
               </label>
             ))}
 
-            {data.allowCreateNew !== false ? (
+            {allowCreateNew ? (
               <label
                 className={cn(
                   "flex items-start gap-3 rounded-lg border p-3 cursor-pointer transition-colors",
@@ -154,6 +161,11 @@ export function CompanyLinkApprovalDisplay({
                   <div className="text-xs text-gray-02">
                     {t("companyLink.createNewDescription")}
                   </div>
+                  {createNew && hasExactNameCandidate ? (
+                    <Callout variant="warning" className="mt-2 text-xs">
+                      {t("companyLink.createNewExactNameWarning")}
+                    </Callout>
+                  ) : null}
                 </div>
               </label>
             ) : null}

--- a/src/tabs/overview/OverviewTab.tsx
+++ b/src/tabs/overview/OverviewTab.tsx
@@ -67,6 +67,7 @@ export function OverviewTab() {
         .filter((row) => row.reportUrl)
         .map((row) => ({
           url: row.reportUrl!,
+          companyId: row.companyId,
           companyName: row.companyName,
           wikidataId: row.wikidataId,
           reportYear: row.reportYear,
@@ -77,6 +78,7 @@ export function OverviewTab() {
       .map((row) => ({
         id: row.registryEntry?.id,
         url: row.runUrl!,
+        companyId: row.companyId,
         companyName: row.companyName,
         wikidataId: row.wikidataId,
         reportYear: row.reportYear,
@@ -114,6 +116,7 @@ export function OverviewTab() {
   const handleRunReports = useCallback(() => {
     const urls = runItems.map((item) => item.url);
     void activePipeline.runForUrls(urls, {
+      runItems,
       onSuccess: () => {
         setIsRunReportsOpen(false);
         clearSelection();

--- a/src/tabs/overview/OverviewTab.tsx
+++ b/src/tabs/overview/OverviewTab.tsx
@@ -67,7 +67,7 @@ export function OverviewTab() {
         .filter((row) => row.reportUrl)
         .map((row) => ({
           url: row.reportUrl!,
-          companyId: row.companyId,
+          companyId: row.stageCompanyId ?? undefined,
           companyName: row.companyName,
           wikidataId: row.wikidataId,
           reportYear: row.reportYear,

--- a/src/tabs/overview/components/CoverageFindReportDialog.tsx
+++ b/src/tabs/overview/components/CoverageFindReportDialog.tsx
@@ -153,6 +153,20 @@ export function CoverageFindReportDialog({
     const url = selectedReport?.url?.trim();
     if (!url) return;
     void runForUrls([url], {
+      runItems: [
+        {
+          url,
+          companyId: entry.matchedCompany?.id ?? null,
+          companyName:
+            selectedReport?.companyName ??
+            entry.matchedCompany?.name ??
+            entry.name,
+          wikidataId:
+            selectedReport?.wikidataId ??
+            entry.matchedCompany?.wikidataId ??
+            null,
+        },
+      ],
       onSuccess: () => {
         if (selectedReport) {
           onSaved?.({

--- a/src/tabs/overview/components/CoverageYearDetail.tsx
+++ b/src/tabs/overview/components/CoverageYearDetail.tsx
@@ -201,7 +201,10 @@ export function CoverageYearDetailView({
   const handleRunReportModalRun = () => {
     const url = runReportSession?.runItem.url?.trim();
     if (!url) return;
-    void runForUrls([url], { onSuccess: () => setIsRunModalOpen(false) });
+    void runForUrls([url], {
+      runItems: runReportSession ? [runReportSession.runItem] : undefined,
+      onSuccess: () => setIsRunModalOpen(false),
+    });
   };
 
   const handleYearConfirm = async (

--- a/src/tabs/overview/lib/coverage-registry-report-run.test.ts
+++ b/src/tabs/overview/lib/coverage-registry-report-run.test.ts
@@ -89,6 +89,7 @@ describe("coverage-registry-report-run", () => {
     expect(toRunReportListItem(entry, report)).toEqual({
       id: "r2",
       url: "https://example.com/2025.pdf",
+      companyId: "c1",
       companyName: "ABB Ltd",
       wikidataId: "Q52825",
       reportYear: "2025",

--- a/src/tabs/overview/lib/coverage-registry-report-run.ts
+++ b/src/tabs/overview/lib/coverage-registry-report-run.ts
@@ -40,6 +40,7 @@ export function toRunReportListItem(
   return {
     id: report.reportId,
     url: report.url,
+    companyId: entry.matchedCompany?.id ?? null,
     companyName: report.companyName ?? entry.matchedCompany?.name ?? entry.name,
     wikidataId: report.wikidataId ?? entry.matchedCompany?.wikidataId ?? null,
     reportYear: report.reportYear,

--- a/src/tabs/registry/RegistryTab.tsx
+++ b/src/tabs/registry/RegistryTab.tsx
@@ -197,7 +197,14 @@ function RegistryTabContent() {
     const urls = selectedReports
       .map((entry) => entry.url?.trim())
       .filter((url): url is string => Boolean(url));
-    void runForUrls(urls, { onSuccess: () => setIsRunReportsOpen(false) });
+    void runForUrls(urls, {
+      runItems: selectedReports.map((entry) => ({
+        url: entry.url,
+        companyName: entry.companyName,
+        wikidataId: entry.wikidataId ?? null,
+      })),
+      onSuccess: () => setIsRunReportsOpen(false),
+    });
   }, [runForUrls, selectedReports]);
 
   const handleAddEntry = async (entry: RegistryNewEntry) => {

--- a/src/tabs/upload/components/AutoApproveToggle.tsx
+++ b/src/tabs/upload/components/AutoApproveToggle.tsx
@@ -5,38 +5,48 @@ export function AutoApproveToggle({
   value,
   onChange,
   className,
+  showScopeHint = false,
 }: {
   value: boolean;
   onChange: (value: boolean) => void;
   className?: string;
+  /** When true, explains that auto-approve only skips Wikidata staff review. */
+  showScopeHint?: boolean;
 }) {
   const { t } = useI18n();
   const label = t("upload.autoApprove");
   return (
-    <div className={cn("flex items-center space-x-2", className)}>
-      <span className="text-sm text-gray-02">{label}</span>
-      <button
-        type="button"
-        role="switch"
-        aria-checked={value}
-        aria-label={label}
-        onClick={() => onChange(!value)}
-        className={cn(
-          "relative inline-flex h-6 w-11 items-center rounded-full",
-          "transition-colors focus-visible:outline-none",
-          "focus-visible:ring-2 focus-visible:ring-ring",
-          "focus-visible:ring-offset-2",
-          value ? "bg-green-03" : "bg-gray-03",
-        )}
-      >
-        <span
+    <div className={cn("space-y-1", className)}>
+      <div className="flex items-center space-x-2">
+        <span className="text-sm text-gray-02">{label}</span>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={value}
+          aria-label={label}
+          onClick={() => onChange(!value)}
           className={cn(
-            "inline-block h-4 w-4 transform rounded-full",
-            "bg-white transition-transform",
-            value ? "translate-x-6" : "translate-x-1",
+            "relative inline-flex h-6 w-11 items-center rounded-full",
+            "transition-colors focus-visible:outline-none",
+            "focus-visible:ring-2 focus-visible:ring-ring",
+            "focus-visible:ring-offset-2",
+            value ? "bg-green-03" : "bg-gray-03",
           )}
-        />
-      </button>
+        >
+          <span
+            className={cn(
+              "inline-block h-4 w-4 transform rounded-full",
+              "bg-white transition-transform",
+              value ? "translate-x-6" : "translate-x-1",
+            )}
+          />
+        </button>
+      </div>
+      {showScopeHint ? (
+        <p className="text-xs text-gray-02 max-w-md">
+          {t("upload.autoApproveHint")}
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/src/tabs/upload/components/FileUploadZone.tsx
+++ b/src/tabs/upload/components/FileUploadZone.tsx
@@ -32,7 +32,11 @@ export function FileUploadZone({
   return (
     <>
       <div className="flex items-center justify-end mb-2">
-        <AutoApproveToggle value={autoApprove} onChange={onAutoApproveChange} />
+        <AutoApproveToggle
+          value={autoApprove}
+          onChange={onAutoApproveChange}
+          showScopeHint
+        />
       </div>
       <FileDropZone
         isDragging={isDragging}

--- a/src/tabs/upload/components/UploadWorkerRunOptions.tsx
+++ b/src/tabs/upload/components/UploadWorkerRunOptions.tsx
@@ -99,32 +99,37 @@ export function UploadWorkerRunOptions({
       {/* Bottom toggles */}
       <div className="space-y-2 pt-2 border-t border-gray-03/50">
         {typeof autoApprove === "boolean" && onAutoApproveChange && (
-          <div className="flex items-center justify-between">
-            <label
-              htmlFor="auto-approve"
-              className="text-sm text-gray-01 cursor-pointer"
-            >
-              {t("upload.autoApprove")}
-            </label>
-            <button
-              id="auto-approve"
-              type="button"
-              role="switch"
-              aria-checked={autoApprove}
-              onClick={() => onAutoApproveChange(!autoApprove)}
-              className={cn(
-                "relative inline-flex h-6 w-11 items-center rounded-full",
-                "transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-                autoApprove ? "bg-green-03" : "bg-gray-03",
-              )}
-            >
-              <span
+          <div className="space-y-1">
+            <div className="flex items-center justify-between">
+              <label
+                htmlFor="auto-approve"
+                className="text-sm text-gray-01 cursor-pointer"
+              >
+                {t("upload.autoApprove")}
+              </label>
+              <button
+                id="auto-approve"
+                type="button"
+                role="switch"
+                aria-checked={autoApprove}
+                onClick={() => onAutoApproveChange(!autoApprove)}
                 className={cn(
-                  "inline-block h-4 w-4 transform rounded-full bg-white transition-transform",
-                  autoApprove ? "translate-x-6" : "translate-x-1",
+                  "relative inline-flex h-6 w-11 items-center rounded-full",
+                  "transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+                  autoApprove ? "bg-green-03" : "bg-gray-03",
                 )}
-              />
-            </button>
+              >
+                <span
+                  className={cn(
+                    "inline-block h-4 w-4 transform rounded-full bg-white transition-transform",
+                    autoApprove ? "translate-x-6" : "translate-x-1",
+                  )}
+                />
+              </button>
+            </div>
+            <p className="text-xs text-gray-02">
+              {t("upload.autoApproveHint")}
+            </p>
           </div>
         )}
 

--- a/src/tabs/upload/components/UrlUploadForm.tsx
+++ b/src/tabs/upload/components/UrlUploadForm.tsx
@@ -29,6 +29,7 @@ export function UrlUploadForm({
           <AutoApproveToggle
             value={autoApprove}
             onChange={onAutoApproveChange}
+            showScopeHint
           />
         </div>
         <textarea

--- a/src/tabs/upload/lib/upload-api.ts
+++ b/src/tabs/upload/lib/upload-api.ts
@@ -1,5 +1,9 @@
 import { authenticatedFetch } from "@/lib/api-helpers";
 import type { RunOnlyWorkerId } from "@/lib/run-only-workers";
+import type {
+  PipelineCompanyContext,
+  PipelineUrlContext,
+} from "@/lib/pipeline-company-context";
 import { PARSE_PDF_API_ENDPOINT, PARSE_PDF_UPLOAD_ENDPOINT } from "./utils";
 
 export class UploadApiError extends Error {
@@ -94,6 +98,8 @@ export interface CreateJobsFromUrlsOptions {
   tags?: string[];
   cachePdf?: boolean;
   parsePdfEndpoint?: string;
+  pipelineCompany?: PipelineCompanyContext;
+  urlContexts?: PipelineUrlContext[];
 }
 
 export async function uploadPdfsToParsePdf({
@@ -138,6 +144,8 @@ export async function createJobsFromUrls({
   tags,
   cachePdf = true,
   parsePdfEndpoint = PARSE_PDF_API_ENDPOINT,
+  pipelineCompany,
+  urlContexts,
 }: CreateJobsFromUrlsOptions): Promise<CreateJobsFromUrlsResult> {
   const body = {
     autoApprove: Boolean(autoApprove),
@@ -147,6 +155,8 @@ export async function createJobsFromUrls({
     ...(runOnly && runOnly.length > 0 ? { runOnly } : {}),
     ...(tags && tags.length > 0 ? { tags } : {}),
     ...(cachePdf ? { cachePdf: true } : {}),
+    ...(pipelineCompany ? { pipelineCompany } : {}),
+    ...(urlContexts && urlContexts.length > 0 ? { urlContexts } : {}),
     urls,
   };
 


### PR DESCRIPTION
## Summary
- Pass companyId/wikidataId/companyName via urlContexts when running reports from Crawler, Registry, Coverage, and Overview
- Clarify autoApprove scope (Wikidata only, not company dedup)
- Warn when creating new company despite exact-name match; show company id vs report shell in editor overview

## Test plan
- [ ] Run report from Coverage/Registry for linked company — network request includes urlContexts
- [ ] Deploy with garbo + pipeline-api duplicate-prevention PRs
- [ ] Stage: Meta report with known wikidata resolves without duplicate company

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect how pipeline jobs are enqueued and company linking is presented; incorrect `urlContexts` could mis-associate reports, but scope is UI + request payload with tests on context building.
> 
> **Overview**
> When users **run reports** from Crawler, Registry, Coverage, or Overview, the app now sends **per-URL company identity** (`companyId`, `wikidataId`, `companyName`) in the parse-PDF request via new `urlContexts` / `runItems` options on the shared run-reports pipeline—built from `pipeline-company-context` helpers and optional `companyId` on `RunReportListItem`.
> 
> **UX clarifications** reduce mistaken duplicate companies: **auto-approve** hints state it only skips Wikidata staff review (not company merge/dedup); **company link** approval hides “create new” when Wikidata is already set and warns on exact-name matches; the **single-company overview** table labels full company id vs report shell id explicitly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb96b8a42c47fcd9ad4e91e4a75b6747919e9bf0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->