### PR TITLE
[Prod] Minor Version Bump v1.16.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "garbo-validation-tool",
-  "version": "1.15.2-rc.1",
+  "version": "1.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "garbo-validation-tool",
-      "version": "1.15.2-rc.1",
+      "version": "1.16.0",
       "dependencies": {
         "@mendable/firecrawl-js": "^4.12.1",
         "@radix-ui/react-dialog": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "garbo-validation-tool",
   "private": true,
-  "version": "1.15.2-rc.1",
+  "version": "1.16.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
# Production Release PR (Validate)

## Release type

- [x] Minor

## Version / artifacts

- **Version being released:** v1.16.0
- **Image:** `ghcr.io/klimatbyran/validate-frontend:1.16.0`
- **Rollback target:** v1.15.1

## What's being released

Everything merged since **v1.15.1** (staging validated on `1.15.2-rc.x`):

### Prevent duplicate companies / pipeline company context ([#279](https://github.com/Klimatbyran/validate-frontend/pull/279))

- Send `companyId`, `wikidataId`, and `companyName` when enqueueing parsePdf from upload, crawler, coverage, and registry
- Shared `pipeline-company-context` helper + tests
- Company link UX: clearer autoApprove scope, restrict create-new when Wikidata owner exists, improved overview labels
- Fix prod-to-stage pipeline company id display in overview runs

## Deployment notes

- Deploy together with **pipeline-api v0.5.0** and **Garbo** dedup release ([#1380](https://github.com/Klimatbyran/garbo/pull/1380) + [#1381](https://github.com/Klimatbyran/garbo/pull/1381))
- Validate-only frontend; no config changes required

## Smoke test (production)

- [ ] Upload two reports for same company (e.g. Nestlé) — expect one company row after pipeline completes
- [ ] Crawler/registry/coverage enqueue passes company context when selected
- [ ] Company link approval UI shows correct candidates; create-new blocked when Wikidata owner exists
- [ ] Overview run rows show correct company id/name

## Checklist

- [x] Version updated (`1.16.0`)
- [ ] QA verified in staging (`1.15.2-rc.x`)
- [x] Rollback target recorded (v1.15.1)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only metadata change with no runtime logic in the diff; operational risk is mainly coordinated deployment with pipeline-api and Garbo, not this bump itself.
> 
> **Overview**
> **Production release tag only:** bumps `garbo-validation-tool` from `1.15.2-rc.1` to **`1.16.0`** in `package.json` and the root entry in `package-lock.json` (no application code in this diff).
> 
> This PR is the **minor production release** artifact for image `ghcr.io/klimatbyran/validate-frontend:1.16.0`, with rollback to **v1.15.1**. Per the release notes, the shipped behavior since v1.15.1 includes pipeline **company context** on `parsePdf` enqueue (#279)—deploy alongside **pipeline-api v0.5.0** and the Garbo dedup releases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c3c20403b693affdbb2e62d443edfd38f78b444. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->