### PR TITLE
Exclude report-absent/report-extra from accuracy metrics and default filters

### DIFF
--- a/src/tabs/errors/components/BrowserView.tsx
+++ b/src/tabs/errors/components/BrowserView.tsx
@@ -15,7 +15,7 @@ import {
   resolveStageDatapoint,
   saveDatapointNote,
 } from "../lib";
-import type { DatapointErrorStatus } from "../lib";
+import type { DatapointErrorStatus, DatapointCreateContext } from "../lib";
 import { CompanyTableRow } from "./CompanyTableRow";
 import { PerformanceMetricsTable } from "./PerformanceMetricsTable";
 import { DiscrepancyFilterPills } from "./DiscrepancyFilterPills";
@@ -51,8 +51,6 @@ export function BrowserView({
   const [searchQuery, setSearchQuery] = React.useState("");
   const [visibleTypes, setVisibleTypes] = React.useState<Set<DiscrepancyType>>(
     new Set([
-      "report-absent",
-      "report-extra",
       "hallucination",
       "missing",
       "rounding",
@@ -69,6 +67,8 @@ export function BrowserView({
   const [reasonDialogDatapointId, setReasonDialogDatapointId] = React.useState<
     string | null
   >(null);
+  const [reasonDialogCreateContext, setReasonDialogCreateContext] =
+    React.useState<DatapointCreateContext | null>(null);
   const [reasonDialogExistingReason, setReasonDialogExistingReason] =
     React.useState("");
   const [reasonDialogExistingStatus, setReasonDialogExistingStatus] =
@@ -93,6 +93,7 @@ export function BrowserView({
   const handleOpenReasonDialog = async (row: CompanyRow) => {
     setReasonDialogRow(row);
     setReasonDialogDatapointId(null);
+    setReasonDialogCreateContext(null);
     setReasonDialogExistingReason("");
     setReasonDialogExistingStatus(null);
     if (!noteTarget) return;
@@ -109,7 +110,10 @@ export function BrowserView({
         setReasonDialogRow(null);
         return;
       }
+      // Value not extracted on stage yet (e.g. a `missing` row) - the dialog
+      // still opens, empty, and the placeholder row is created on save.
       setReasonDialogDatapointId(resolved.datapointId);
+      setReasonDialogCreateContext(resolved.createContext ?? null);
       const existingReason = resolved.note?.errorReason ?? "";
       setReasonDialogExistingReason(existingReason);
       setReasonDialogExistingStatus(resolved.note?.status ?? null);
@@ -136,13 +140,17 @@ export function BrowserView({
   };
 
   const handleSaveReason = async (input: ErrorReasonSaveInput) => {
-    if (!reasonDialogRow || !noteTarget || !reasonDialogDatapointId) return;
+    if (!reasonDialogRow || !noteTarget) return;
+    if (!reasonDialogDatapointId && !reasonDialogCreateContext) return;
     setSavingReason(true);
     try {
       await saveDatapointNote(
         {
           datapointType: noteTarget.datapointType,
-          datapointId: reasonDialogDatapointId,
+          datapointId: reasonDialogDatapointId ?? undefined,
+          createContext: reasonDialogDatapointId
+            ? undefined
+            : (reasonDialogCreateContext ?? undefined),
           errorReason: input.errorReason,
           status: input.status,
           previousValue: input.previousValue,
@@ -222,8 +230,6 @@ export function BrowserView({
   const showDefaultTypes = () => {
     setVisibleTypes(
       new Set([
-        "report-absent",
-        "report-extra",
         "hallucination",
         "missing",
         "rounding",

--- a/src/tabs/errors/components/SummaryView.tsx
+++ b/src/tabs/errors/components/SummaryView.tsx
@@ -40,13 +40,13 @@ function calcRates(dp: DataPointMetric) {
   const rounding = dp.breakdown.rounding;
   const bothNull = dp.breakdown.bothNull;
   const withAnyData = dp.withAnyData;
+  // Excludes reportAbsent/reportExtra: those are coverage gaps (report year missing
+  // on one side), not extraction outcomes, and must never dilute accuracy.
   const totalSlots =
     dp.breakdown.identical +
     dp.breakdown.rounding +
     dp.breakdown.hallucination +
     dp.breakdown.missing +
-    dp.breakdown.reportAbsent +
-    dp.breakdown.reportExtra +
     dp.breakdown.unitError +
     dp.breakdown.smallError +
     dp.breakdown.error +

--- a/src/tabs/errors/lib/datapoint-notes.ts
+++ b/src/tabs/errors/lib/datapoint-notes.ts
@@ -123,9 +123,28 @@ interface StageCompanyDetails {
   reportingPeriods?: StageReportingPeriod[];
 }
 
+/**
+ * Identifies where to create a placeholder datapoint row when the reviewer is
+ * noting an error on a value the pipeline never extracted (a `missing` row).
+ * The reporting period must already exist on stage - this only fills in the
+ * leaf Scope1/Scope2/etc. row so a note has something to attach to.
+ */
+export interface DatapointCreateContext {
+  wikidataId: string;
+  companyReportId: string;
+  dataYear: string;
+  /** Required when datapointType is "category". */
+  category?: number;
+  /** Required when datapointType is "statedTotalEmissions". */
+  statedTotalLocation?: StatedTotalLocation;
+}
+
 export interface ResolvedStageDatapoint {
-  datapointId: string;
+  /** Null when the value doesn't exist on stage yet - see createContext. */
+  datapointId: string | null;
   note: ExistingDatapointNote | null;
+  /** Present when datapointId is null and the row can be created on save. */
+  createContext?: DatapointCreateContext;
 }
 
 function resolveStatedTotalDatapoint(
@@ -157,7 +176,7 @@ export async function resolveStageDatapoint(
   target: DatapointNoteTarget,
   source: ErrorBrowserStageSource = "stage",
 ): Promise<ResolvedStageDatapoint | null> {
-  if (!row.wikidataId) return null;
+  if (!row.wikidataId || !row.companyReportId) return null;
 
   const res = await garboAuthFetch(
     errorBrowserStageUnearthUrl(
@@ -174,35 +193,57 @@ export async function resolveStageDatapoint(
     (p) =>
       p.companyReportId === row.companyReportId && p.year === String(dataYear),
   );
-  const emissions = period?.emissions;
-  if (!emissions) return null;
+  // No reporting period at all on stage - the report itself hasn't run there
+  // yet (report-absent), nothing to attach a note to.
+  if (!period) return null;
 
-  const datapoint: StageDatapointPayload | null | undefined = (() => {
-    switch (target.datapointType) {
-      case "scope1":
-        return emissions.scope1;
-      case "scope2":
-        return emissions.scope2;
-      case "scope1And2":
-        return emissions.scope1And2;
-      case "biogenicEmissions":
-        return emissions.biogenicEmissions;
-      case "statedTotalEmissions":
-        return resolveStatedTotalDatapoint(
-          emissions,
-          target.statedTotalLocation,
-        );
-      case "category":
-        return emissions.scope3?.categories?.find(
-          (c) => c.category === target.category,
-        );
-      default:
-        return null;
-    }
-  })();
+  const emissions = period.emissions;
+  const datapoint: StageDatapointPayload | null | undefined = emissions
+    ? (() => {
+        switch (target.datapointType) {
+          case "scope1":
+            return emissions.scope1;
+          case "scope2":
+            return emissions.scope2;
+          case "scope1And2":
+            return emissions.scope1And2;
+          case "biogenicEmissions":
+            return emissions.biogenicEmissions;
+          case "statedTotalEmissions":
+            return resolveStatedTotalDatapoint(
+              emissions,
+              target.statedTotalLocation,
+            );
+          case "category":
+            return emissions.scope3?.categories?.find(
+              (c) => c.category === target.category,
+            );
+          default:
+            return null;
+        }
+      })()
+    : null;
 
-  if (!datapoint) return null;
-  return { datapointId: datapoint.id, note: datapoint.note ?? null };
+  if (datapoint) {
+    return { datapointId: datapoint.id, note: datapoint.note ?? null };
+  }
+
+  // Reporting period exists but this specific value was never extracted
+  // (a `missing` row) - creatable on save, see DatapointCreateContext.
+  return {
+    datapointId: null,
+    note: null,
+    createContext: {
+      wikidataId: row.wikidataId,
+      companyReportId: row.companyReportId,
+      dataYear: String(dataYear),
+      category: target.datapointType === "category" ? target.category : undefined,
+      statedTotalLocation:
+        target.datapointType === "statedTotalEmissions"
+          ? target.statedTotalLocation
+          : undefined,
+    },
+  };
 }
 
 /** Matches Prisma's DatapointErrorStatus enum. */
@@ -210,7 +251,9 @@ export type DatapointErrorStatus = "OPEN" | "RESOLVED" | "WONT_FIX";
 
 export interface SaveDatapointNoteInput {
   datapointType: DatapointNoteType;
-  datapointId: string;
+  /** Omit when the datapoint doesn't exist yet - pass createContext instead. */
+  datapointId?: string;
+  createContext?: DatapointCreateContext;
   errorReason?: string;
   comment?: string;
   status?: DatapointErrorStatus;

--- a/src/tabs/errors/lib/index.ts
+++ b/src/tabs/errors/lib/index.ts
@@ -62,4 +62,5 @@ export type {
   DatapointErrorStatus,
   ExistingDatapointNote,
   ResolvedStageDatapoint,
+  DatapointCreateContext,
 } from "./datapoint-notes";

--- a/src/tabs/errors/lib/metrics.ts
+++ b/src/tabs/errors/lib/metrics.ts
@@ -1,4 +1,5 @@
 import type { CompanyRow, DataPointMetric } from "../types";
+import { isExtractionComparisonDiscrepancy } from "./discrepancy";
 
 export interface PerformanceMetricRow {
   /** Translation key for the metric name (e.g. errors.metrics.exactMatch). */
@@ -22,7 +23,12 @@ export function computePerformanceMetrics(
   zeroInclusive: PerformanceMetricRow;
 } | null {
   const verifiedOnly = Boolean(opts?.verifiedOnly);
-  const bothExist = comparisonRows.filter((r) => r.inStage && r.inProd);
+  // Only compare rows where the report year exists on both sides - report-absent/
+  // report-extra reflect coverage gaps, not extraction accuracy, and must never
+  // dilute the accuracy percentages.
+  const bothExist = comparisonRows.filter(
+    (r) => r.inStage && r.inProd && isExtractionComparisonDiscrepancy(r.discrepancy),
+  );
   const rows = verifiedOnly
     ? bothExist.filter((r) => r.prodVerified)
     : bothExist;
@@ -165,6 +171,11 @@ export function calculateOverviewAggregates(
     },
   );
 
+  // Denominator for zeroInclusive: only slots where the report year exists on both
+  // sides (totalCompanies also counts reportAbsent/reportExtra, which are coverage
+  // gaps, not extraction outcomes, and must never dilute accuracy).
+  const comparableSlots = totals.totalCompanies - totals.reportAbsent - totals.reportExtra;
+
   return {
     exactMatch:
       totals.withAnyData > 0
@@ -181,9 +192,9 @@ export function calculateOverviewAggregates(
           100
         : 0,
     zeroInclusive:
-      totals.totalCompanies > 0
+      comparableSlots > 0
         ? ((totals.identical + totals.rounding + totals.bothNull) /
-            totals.totalCompanies) *
+            comparableSlots) *
           100
         : 0,
     totals,


### PR DESCRIPTION
## Summary
- Report-absent/report-extra ("Report Not on Stage"/"Report Not on Prod") no longer show by default in the Browser tab filter pills — the pill still exists, just unchecked.
- The Zero-Inclusive accuracy percentage (Browser, Overview, and Summary tabs) now excludes report-absent/report-extra from its denominator — a report year missing on one side is a coverage gap, not an extraction outcome, and shouldn't dilute accuracy. Exact-match and precision-tolerant rates already excluded these correctly.
- `resolveStageDatapoint` now distinguishes "no reporting period at all on stage" (stays blocked — that's report-absent, out of scope here) from "period exists, this one value was never extracted" (a `missing` row) — the latter now opens the reason dialog instead of failing with a generic "couldn't find this value" error. Saving sends a `createContext` instead of a `datapointId` in that case.
- Pairs with [UnearthData/api#support-missing-value-datapoint-notes] which adds the corresponding placeholder-datapoint creation on the backend. No schema/migration changes in this repo.

## Test plan
- [ ] Typecheck/lint clean (`npx tsc --noEmit`, `npx eslint`) — done locally
- [ ] Existing errors-tab test suite passes (`npx vitest run src/tabs/errors`) — done locally, 25/25 passing
- [ ] Manually verify in the Browser tab: report-absent/report-extra rows are hidden by default, filter pill still toggles them
- [ ] Manually verify Zero-Inclusive % changes (goes up) once report-absent/extra are excluded, on a company/year known to have coverage gaps
- [ ] Manually verify opening the reason dialog on a `missing` row (after the paired api PR is deployed) no longer errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how headline accuracy percentages are computed and extends datapoint note saves with a new create path; behavior depends on the paired API for placeholder creation.
> 
> **Overview**
> **Accuracy metrics** no longer treat report-absent/report-extra as extraction outcomes. Zero-inclusive rates (Browser performance table, Overview aggregates, Summary per–data-point table) drop those coverage gaps from the denominator so accuracy is not diluted when a report year exists on only one side. Browser metrics also limit row sets to discrepancies where both stage and prod have the period (`isExtractionComparisonDiscrepancy`).
> 
> **Browser filters** hide report-absent and report-extra rows by default; pills and “show all” still expose them.
> 
> **Error reason dialog** can attach notes when stage has the reporting period but never extracted the value (`missing`). `resolveStageDatapoint` returns `datapointId: null` plus `DatapointCreateContext` instead of failing; save posts `createContext` when there is no id (paired backend API). True report-absent (no period on stage) stays blocked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b82fbab1235dc4caaf9c3d799446489401095a9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->