### PR TITLE
Collapse duplicate report shells and fix note resolution regression

### DIFF
--- a/src/tabs/editor/lib/reporting-period-public-read.ts
+++ b/src/tabs/editor/lib/reporting-period-public-read.ts
@@ -3,6 +3,26 @@ import { getPeriodDataYear, getPeriodReportYear } from "./reporting-period-ui";
 
 type PeriodForPublicPick = GarboReportingPeriodSummary & { id: string };
 
+/**
+ * Minimal shape the pick algorithm actually reads - no period `id` required,
+ * so it also works for callers (e.g. the Errors tab) whose ReportingPeriod
+ * type omits period ids. `publicPeriodIdsForCompany` below needs `id` and
+ * keeps the stricter `PeriodForPublicPick` type.
+ */
+export interface MinimalPeriodForPick {
+  year?: string | null;
+  startDate?: string;
+  endDate?: string;
+  companyReportId?: string | null;
+  reportURL?: string | null;
+  reportS3Url?: string | null;
+  companyReport?: {
+    id?: string | null;
+    reportYear?: string | null;
+    reportPublicationDate?: string | null;
+  } | null;
+}
+
 function parseCompanyReportYear(
   reportYear: string | null | undefined,
 ): number | null {
@@ -11,21 +31,21 @@ function parseCompanyReportYear(
   return Number(trimmed);
 }
 
-function reportYearForPick(period: PeriodForPublicPick): number | null {
+function reportYearForPick(period: MinimalPeriodForPick): number | null {
   const fromShell = parseCompanyReportYear(period.companyReport?.reportYear);
   if (fromShell !== null) return fromShell;
   const fallback = getPeriodReportYear(period);
   return fallback ? parseCompanyReportYear(fallback) : null;
 }
 
-function publicationTime(period: PeriodForPublicPick): number {
+function publicationTime(period: MinimalPeriodForPick): number {
   const raw = period.companyReport?.reportPublicationDate;
   if (!raw) return 0;
   const ms = Date.parse(raw);
   return Number.isFinite(ms) ? ms : 0;
 }
 
-function companyReportIdForPick(period: PeriodForPublicPick): string {
+function companyReportIdForPick(period: MinimalPeriodForPick): string {
   return (
     period.companyReport?.id?.trim() || period.companyReportId?.trim() || ""
   );
@@ -33,8 +53,8 @@ function companyReportIdForPick(period: PeriodForPublicPick): string {
 
 /** Negative = prefer `a` over `b` (higher CompanyReport.reportYear wins). */
 function preferPeriodFromNewerReport(
-  a: PeriodForPublicPick,
-  b: PeriodForPublicPick,
+  a: MinimalPeriodForPick,
+  b: MinimalPeriodForPick,
 ): number {
   const yearA = reportYearForPick(a);
   const yearB = reportYearForPick(b);
@@ -56,7 +76,7 @@ function preferPeriodFromNewerReport(
  * Mirrors public API `pickOnePeriodPerDataYear`: one period per data year,
  * preferring the row linked to the newest CompanyReport.reportYear.
  */
-export function pickOnePeriodPerDataYear<T extends PeriodForPublicPick>(
+export function pickOnePeriodPerDataYear<T extends MinimalPeriodForPick>(
   periods: T[],
 ): T[] {
   const byDataYear = new Map<string, T>();

--- a/src/tabs/errors/lib/datapoint-notes.ts
+++ b/src/tabs/errors/lib/datapoint-notes.ts
@@ -176,7 +176,7 @@ export async function resolveStageDatapoint(
   target: DatapointNoteTarget,
   source: ErrorBrowserStageSource = "stage",
 ): Promise<ResolvedStageDatapoint | null> {
-  if (!row.wikidataId || !row.companyReportId) return null;
+  if (!row.wikidataId) return null;
 
   const res = await garboAuthFetch(
     errorBrowserStageUnearthUrl(
@@ -230,6 +230,10 @@ export async function resolveStageDatapoint(
 
   // Reporting period exists but this specific value was never extracted
   // (a `missing` row) - creatable on save, see DatapointCreateContext.
+  // Needs a companyReportId to re-identify the period on save - an unlinked
+  // period (no CompanyReport shell) can't be targeted that way.
+  if (!row.companyReportId) return null;
+
   return {
     datapointId: null,
     note: null,

--- a/src/tabs/errors/lib/reporting-period-comparison.test.ts
+++ b/src/tabs/errors/lib/reporting-period-comparison.test.ts
@@ -67,7 +67,12 @@ describe("pickReportingPeriodsForFilters", () => {
 });
 
 describe("buildReportingPeriodComparisonSlots", () => {
-  it("emits one slot per report shell for the same data year", () => {
+  it("collapses duplicate shells for the same data year to the public-pick winner", () => {
+    // Same scenario as production: a company re-processed into a second
+    // CompanyReport shell that also covers data year 2024. Only the period
+    // the public API would serve (higher CompanyReport.reportYear) should
+    // produce a slot - the losing duplicate must not show up as a separate
+    // "missing" comparison row.
     const stagePeriods = [
       period({
         startDate: "2024-01-01",
@@ -92,30 +97,12 @@ describe("buildReportingPeriodComparisonSlots", () => {
       null,
     );
 
-    expect(slots).toHaveLength(2);
-    expect(slots.map((slot) => slot.shellKey).sort()).toEqual([
-      "catalog:2023:data:2024",
-      "catalog:2024:data:2024",
-    ]);
+    expect(slots).toHaveLength(1);
+    expect(slots[0]?.shellKey).toBe("catalog:2024:data:2024");
+    expect(slots[0]?.stagePeriod?.companyReportId).toBe("shell-a");
   });
 
-  it("pairs stage and prod shells by stable identity, not env-local companyReportId", () => {
-    const stageOnly = period({
-      startDate: "2024-01-01",
-      endDate: "2024-12-31",
-      year: "2024",
-      companyReportId: "stage-only",
-      reportSha256: "abc123",
-      companyReport: { id: "stage-only", reportYear: "2024" },
-    });
-    const prodOnly = period({
-      startDate: "2024-01-01",
-      endDate: "2024-12-31",
-      year: "2024",
-      companyReportId: "prod-only",
-      reportSha256: "def456",
-      companyReport: { id: "prod-only", reportYear: "2023" },
-    });
+  it("pairs stage and prod periods by stable identity, not env-local companyReportId", () => {
     const sharedStage = period({
       startDate: "2024-01-01",
       endDate: "2024-12-31",
@@ -134,25 +121,39 @@ describe("buildReportingPeriodComparisonSlots", () => {
     });
 
     const slots = buildReportingPeriodComparisonSlots(
-      [stageOnly, sharedStage],
-      [prodOnly, sharedProd],
+      [sharedStage],
+      [sharedProd],
       2024,
       null,
     );
 
-    expect(slots).toHaveLength(3);
+    expect(slots).toHaveLength(1);
+    expect(slots[0]?.shellKey).toBe("sha256:shared-hash");
+    expect(slots[0]?.stagePeriod?.companyReportId).toBe("stage-shared");
+    expect(slots[0]?.prodPeriod?.companyReportId).toBe("prod-shared");
+  });
 
-    const sharedSlot = slots.find(
-      (slot) => slot.shellKey === "sha256:shared-hash",
-    );
-    expect(sharedSlot?.stagePeriod?.companyReportId).toBe("stage-shared");
-    expect(sharedSlot?.prodPeriod?.companyReportId).toBe("prod-shared");
+  it("produces a stage-only slot when prod has no period for that shell", () => {
+    const stageOnly = period({
+      startDate: "2024-01-01",
+      endDate: "2024-12-31",
+      year: "2024",
+      companyReportId: "stage-only",
+      reportSha256: "abc123",
+      companyReport: { id: "stage-only", reportYear: "2024" },
+    });
 
-    const stageOnlySlot = slots.find(
-      (slot) => slot.shellKey === "sha256:abc123",
+    const slots = buildReportingPeriodComparisonSlots(
+      [stageOnly],
+      [],
+      2024,
+      null,
     );
-    expect(stageOnlySlot?.stagePeriod).toBeTruthy();
-    expect(stageOnlySlot?.prodPeriod).toBeNull();
+
+    expect(slots).toHaveLength(1);
+    expect(slots[0]?.shellKey).toBe("sha256:abc123");
+    expect(slots[0]?.stagePeriod).toBeTruthy();
+    expect(slots[0]?.prodPeriod).toBeNull();
   });
 
   it("maps unlinked periods to null companyReportId", () => {

--- a/src/tabs/errors/lib/reporting-period-comparison.ts
+++ b/src/tabs/errors/lib/reporting-period-comparison.ts
@@ -1,4 +1,5 @@
 import { getPeriodDataYear } from "@/tabs/editor/lib/reporting-period-ui";
+import { pickOnePeriodPerDataYear } from "@/tabs/editor/lib/reporting-period-public-read";
 import type { ReportingPeriod } from "../types";
 import {
   getCrossEnvPeriodShellKey,
@@ -34,7 +35,14 @@ function periodMatchesReportYearFilter(
   return getPeriodReportYearFromApi(period) === reportYear;
 }
 
-/** All reporting periods matching data year and optional PDF report year. */
+/**
+ * All reporting periods matching data year and optional PDF report year,
+ * collapsed to one per data year - a company can have two CompanyReport
+ * shells covering the same data year (e.g. a re-processed duplicate); this
+ * picks the same one the public API would serve (`pickOnePeriodPerDataYear`),
+ * so stage/prod comparisons never show a value as missing when it's really
+ * just stranded on a losing duplicate shell.
+ */
 export function pickReportingPeriodsForFilters(
   reportingPeriods: ReportingPeriod[] | undefined,
   dataYear: number,
@@ -42,11 +50,12 @@ export function pickReportingPeriodsForFilters(
 ): ReportingPeriod[] {
   if (!reportingPeriods?.length) return [];
   const reportYearFilter = reportYear ?? null;
-  return reportingPeriods.filter(
+  const matched = reportingPeriods.filter(
     (period) =>
       periodMatchesDataYear(period, dataYear) &&
       periodMatchesReportYearFilter(period, reportYearFilter),
   );
+  return pickOnePeriodPerDataYear(matched);
 }
 
 /** One period per CompanyReport shell, unioned across stage and prod. */

--- a/src/tabs/errors/types.ts
+++ b/src/tabs/errors/types.ts
@@ -155,6 +155,7 @@ export interface ReportingPeriod {
   companyReport?: {
     id?: string;
     reportYear?: string | null;
+    reportPublicationDate?: string | null;
     registryReportId?: string | null;
     report?: {
       url?: string | null;


### PR DESCRIPTION
## Summary
Two follow-up fixes to the Errors tab, both stranded on this branch after #282 merged before these commits landed on it:

- **Collapse duplicate report shells to the public-API winner**: a company can have two `CompanyReport` shells covering the same data year (e.g. a re-processed duplicate upload). The Errors tab reads from the staff "full periods" endpoint on both stage and prod (no per-year dedup), so `pickReportingPeriodsForFilters`/`buildReportingPeriodComparisonSlots` treated each shell as a separate comparison row — a real extracted value on the "winning" shell could show as missing if the losing duplicate got compared instead. Now reuses the existing `pickOnePeriodPerDataYear` (already used by the Editor tab to show which duplicate the public API picks) so stage and prod each resolve to the same period the public API would actually serve.
- **Fix `resolveStageDatapoint` blocking notes on unlinked periods**: a bug flagged by an automated review pass. The `!row.companyReportId` guard I'd added ran before the period lookup; for unlinked periods (no `CompanyReport` shell) both `row.companyReportId` and the stage period's `companyReportId` are `null`, and that match used to succeed (`null === null`), resolving an existing datapoint normally. The guard blocked that path entirely, always producing the generic "not found" error even when a datapoint already existed. Moved the requirement down to only where it's actually needed (building `createContext` for a placeholder).

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean
- [x] `npx vitest run src/tabs/errors src/tabs/editor` — 55/55 passing (updated two tests in `reporting-period-comparison.test.ts` that encoded the old per-shell-not-per-year behavior)
- [ ] Manually verify: a company with two report shells for the same data year shows the public-API-winning shell's value in the Browser/Overview/Summary tabs, not a stranded/losing duplicate
- [ ] Manually verify: opening the reason dialog on an unlinked-period row with an existing datapoint/note works again (no longer hits the generic "couldn't find" error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Errors tab comparison logic and datapoint note resolution paths where wrong period or blocked notes would mislead reviewers; behavior is covered by updated unit tests but still affects staging review workflows.
> 
> **Overview**
> The Errors tab **stage/prod reporting-period comparisons** now **dedupe multiple `CompanyReport` shells for the same data year** by reusing `pickOnePeriodPerDataYear` (same rule as the public API: newer `reportYear`, then publication date). That stops a “winning” extracted value from looking **missing** when a losing duplicate shell was compared instead.
> 
> **`pickOnePeriodPerDataYear`** is generalized with a **`MinimalPeriodForPick`** type so the Errors tab can use it without period `id`s; **`reportPublicationDate`** was added on the Errors `ReportingPeriod` type to support the pick tie-breakers.
> 
> **`resolveStageDatapoint`** no longer bails out when `row.companyReportId` is missing up front, so **unlinked periods** (`null === null` period match) can load/save notes on **existing** datapoints again; **`companyReportId` is only required** when creating a placeholder row via `createContext`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e90be86edc82aeeab540e27435cb4caff1df702e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->