### PR TITLE
Treat extractLEI failures as non-blocking in Jobbstatus

### DIFF
--- a/src/lib/workflow-config.ts
+++ b/src/lib/workflow-config.ts
@@ -70,6 +70,9 @@ export const QUEUE_DISPLAY_NAMES: Record<string, string> = {
   diffReportType: "Rapporttyp",
 };
 
+/** Failed jobs on these queues must not fail the overall pipeline step/run. */
+export const NON_BLOCKING_FAILURE_QUEUES = new Set<string>(["extractLEI"]);
+
 /**
  * Pipeline Steps Configuration
  * Defines the logical grouping of workflow stages into pipeline steps

--- a/src/lib/workflow-utils.ts
+++ b/src/lib/workflow-utils.ts
@@ -14,6 +14,7 @@ import type {
 import {
   getQueuesForPipelineStep,
   getAllPipelineSteps,
+  NON_BLOCKING_FAILURE_QUEUES,
 } from "./workflow-config";
 
 /**
@@ -432,6 +433,26 @@ function isJobActivelyProcessing(job: any): boolean {
   return (job.processedOn && !job.finishedOn) || job.status === "active";
 }
 
+function isBlockingFailedQueueEntry(entry: {
+  queueId: string;
+  status: string;
+}): boolean {
+  return (
+    entry.status === "failed" && !NON_BLOCKING_FAILURE_QUEUES.has(entry.queueId)
+  );
+}
+
+function isAcceptableStepOutcome(entry: {
+  queueId: string;
+  status: SwimlaneStatusType;
+}): boolean {
+  if (isPipelineProgressStatus(entry.status)) return true;
+  return (
+    entry.status === "failed" &&
+    NON_BLOCKING_FAILURE_QUEUES.has(entry.queueId)
+  );
+}
+
 /**
  * Calculate the overall status for a pipeline step based on its fields
  */
@@ -548,13 +569,9 @@ export function calculatePipelineStepStatus(
 
     // Check statuses of started jobs only
     const startedStatuses = startedJobs.map((entry) => entry.status);
-    const hasFailed = startedStatuses.some((status) => status === "failed");
-    const allCompleted = startedStatuses.every((status) =>
-      isPipelineProgressStatus(status),
-    );
-    const hasCompleted = startedStatuses.some((status) =>
-      isPipelineProgressStatus(status),
-    );
+    const hasFailed = startedJobs.some(isBlockingFailedQueueEntry);
+    const allCompleted = startedJobs.every(isAcceptableStepOutcome);
+    const hasCompleted = startedJobs.some(isAcceptableStepOutcome);
 
     // If any started job failed, show failed
     if (hasFailed) {
@@ -600,7 +617,7 @@ export function calculatePipelineStepStatus(
     isPipelineProgressStatus(status),
   );
   const hasWaiting = fieldStatuses.some((status) => status === "waiting");
-  const hasFailed = fieldStatuses.some((status) => status === "failed");
+  const hasFailed = jobsWithStatuses.some(isBlockingFailedQueueEntry);
 
   // Check if all jobs are completed (no waiting, no failed, at least one completed)
   if (hasCompleted && !hasWaiting && !hasFailed) {

--- a/src/lib/workflow-utils.ts
+++ b/src/lib/workflow-utils.ts
@@ -448,8 +448,7 @@ function isAcceptableStepOutcome(entry: {
 }): boolean {
   if (isPipelineProgressStatus(entry.status)) return true;
   return (
-    entry.status === "failed" &&
-    NON_BLOCKING_FAILURE_QUEUES.has(entry.queueId)
+    entry.status === "failed" && NON_BLOCKING_FAILURE_QUEUES.has(entry.queueId)
   );
 }
 


### PR DESCRIPTION
## Summary
- Mark `extractLEI` as a non-blocking failure queue in workflow config.
- Data-extraction step status ignores failed extractLEI when other started jobs completed successfully.

## Related PRs
- garbo: LEI validation in pipeline workers
- pipeline-api: non-blocking extractLEI for overall run status

## Test plan
- [ ] Failed extractLEI pill shows red on the individual job
- [ ] Data-extraction step stays green when other jobs completed and save succeeded
- [ ] Completed extractLEI with no LEI found shows green