### PR TITLE
[Prod] Minor Version Bump v1.17.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "garbo-validation-tool",
-  "version": "1.16.1-rc.9",
+  "version": "1.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "garbo-validation-tool",
-      "version": "1.16.1-rc.9",
+      "version": "1.17.0",
       "dependencies": {
         "@mendable/firecrawl-js": "^4.12.1",
         "@radix-ui/react-dialog": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "garbo-validation-tool",
   "private": true,
-  "version": "1.16.1-rc.9",
+  "version": "1.17.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
# Production Release PR (Validate)

## Release type

- [x] Minor

## Environment promotion

This release promotes changes **to production** (staging validated on `1.16.1-rc.9`).

## Version / artifacts

- **Version being released**: v1.17.0
- **Image:** `ghcr.io/klimatbyran/validate-frontend:1.17.0`
- **Rollback target version**: v1.16.0

## What's being released

Everything merged since **v1.16.0**:

### Errors Browser ([#277](https://github.com/Klimatbyran/validate-frontend/pull/277), [#281](https://github.com/Klimatbyran/validate-frontend/pull/281), [#282](https://github.com/Klimatbyran/validate-frontend/pull/282), [#285](https://github.com/Klimatbyran/validate-frontend/pull/285))
- Per-datapoint error reason notes
- Link report year in error browser rows to source report
- Exclude report-absent/report-extra from accuracy metrics; duplicate shell collapse fixes

### Company link partial match ([#283](https://github.com/Klimatbyran/validate-frontend/pull/283), [#284](https://github.com/Klimatbyran/validate-frontend/pull/284))
- Partial-match approval UI with display name support
- Create-new option on partial match with warning

### LEI validation non-blocking ([#286](https://github.com/Klimatbyran/validate-frontend/pull/286))
- Treat `extractLEI` failures as non-blocking in Jobbstatus step aggregation

### Coverage list editing ([#287](https://github.com/Klimatbyran/validate-frontend/pull/287))
- Edit coverage list and year labels/names in Overview

### Coverage registry report actions ([#288](https://github.com/Klimatbyran/validate-frontend/pull/288))
- Find report (manual URL + optional crawl), replace URL, remove report from registry pills
- Re-upload registry PDFs on URL replace/save via `cache-pdf`
- Pipeline runs use `report.url` (same as Registry tab)

## Deployment notes

- Deploy together with **Garbo v6.1.0**, **API v1.7.0**, and **pipeline-api v0.6.0**
- Validate-only frontend deploy; no config changes required

## Validation / smoke check (production)

- [ ] App loads
- [ ] Errors Browser: add note, link to report, accuracy filters behave
- [ ] Company link partial match approval + create-new flow
- [ ] Coverage: edit list/year, find/replace/remove registry reports, run report from pill
- [ ] Jobbstatus: invalid LEI does not block run completion

## Checklist

- [x] Version updated (`1.17.0`)
- [ ] Changes QA'd in staging (`1.16.1-rc.x`)
- [x] Rollback target recorded (v1.16.0)
- [x] Title follows: `[Prod] Minor Version Bump v1.17.0`
